### PR TITLE
feat: enhance /health endpoint with JSON response and DB health check

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,6 +1,42 @@
 use crate::AppState;
-use axum::{extract::State, response::IntoResponse};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
 
-pub async fn health(State(_state): State<AppState>) -> impl IntoResponse {
-    "OK"
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HealthStatus {
+    status: String,
+    version: String,
+    db: String,
+}
+
+pub async fn health(State(state): State<AppState>) -> impl IntoResponse {
+    // Check database connectivity with SELECT 1 query
+    let db_status = match sqlx::query("SELECT 1").execute(&state.db).await {
+        Ok(_) => "connected",
+        Err(_) => "disconnected",
+    };
+
+    let health_response = HealthStatus {
+        status: if db_status == "connected" {
+            "healthy".to_string()
+        } else {
+            "unhealthy".to_string()
+        },
+        version: "0.1.0".to_string(),
+        db: db_status.to_string(),
+    };
+
+    // Return 503 if database is down, 200 otherwise
+    let status_code = if db_status == "connected" {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    (status_code, Json(health_response))
 }


### PR DESCRIPTION
This PR upgrades the /health endpoint from a simple text response to a structured JSON status report to better support Kubernetes liveness/readiness probes and external monitoring. Closes #5