### PR TITLE
feat: enable CORS with configurable origins via CORS_ALLOWED_ORIGINS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -128,8 +129,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -184,7 +187,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -470,6 +472,12 @@ dependencies = [
  "quote",
  "syn 2.0.116",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "der"
@@ -2838,6 +2846,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 1.0.69",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "utoipa",
@@ -3131,6 +3140,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3178,22 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3240,6 +3277,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,6 +3375,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,13 @@ sqlx = { version = "0.7", features = [
 bigdecimal = { version = "0.4", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-bigdecimal = { version = "0.3", features = ["serde"] }
 home = "=0.5.11"
 reqwest = { version = "0.11", features = ["json"] }
 redis = { version = "0.24", features = ["tokio-comp", "connection-manager"] }
 ipnet = "2.9"
 utoipa = { version = "4", features = ["chrono", "uuid"] }
 utoipa-swagger-ui = { version = "6", features = ["axum"] }
+tower-http = { version = "0.5", features = ["cors"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ pub struct Config {
     pub database_url: String,
     pub stellar_horizon_url: String,
     pub redis_url: String,
+    /// Comma-separated list of allowed CORS origins (e.g. "http://localhost:3000,https://app.example.com")
+    pub cors_allowed_origins: Option<String>,
 }
 
 impl Config {
@@ -21,6 +23,7 @@ impl Config {
             database_url: env::var("DATABASE_URL")?,
             stellar_horizon_url: env::var("STELLAR_HORIZON_URL")?,
             redis_url: env::var("REDIS_URL")?,
+            cors_allowed_origins: env::var("CORS_ALLOWED_ORIGINS").ok(),
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ mod stellar;
 mod services;
 
 use axum::{Router, extract::State, routing::{get, post}, middleware as axum_middleware};
+use http::header::HeaderValue;
 use sqlx::migrate::Migrator; // for Migrator
+use tower_http::cors::{CorsLayer, AllowOrigin};
 use std::net::SocketAddr; // for SocketAddr
 use std::path::Path; // for Path
 use tokio::net::TcpListener; // for TcpListener
@@ -88,8 +90,20 @@ async fn main() -> anyhow::Result<()> {
     let idempotency_service = IdempotencyService::new(&config.redis_url)?;
     tracing::info!("Redis idempotency service initialized");
 
+    // Build CORS layer from configurable origins
+    let cors_layer = match &config.cors_allowed_origins {
+        Some(origins) => {
+            let origins: Vec<HeaderValue> = origins
+                .split(',')
+                .filter_map(|s| s.trim().parse().ok())
+                .collect();
+            CorsLayer::new().allow_origin(AllowOrigin::list(origins))
+        }
+        None => CorsLayer::permissive(), // Allow any origin when not configured (dev default)
+    };
+
     // Build router with state
-    let app_state = AppState { 
+    let app_state = AppState {
         db: pool,
         horizon_client,
     };
@@ -111,6 +125,7 @@ async fn main() -> anyhow::Result<()> {
         .route("/health", get(handlers::health))
         .merge(webhook_routes)
         .merge(dlq_routes)
+        .layer(cors_layer)
         .with_state(app_state);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.server_port));


### PR DESCRIPTION
## Enable CORS (Cross-Origin Resource Sharing)

### Summary
Allow frontend clients from other origins to communicate with the API by adding a configurable CORS layer.
Closes #7 
### Motivation
Browsers block cross-origin requests by default. CORS is needed so frontend apps (e.g. on a different host or port) can call this API safely.

### Changes
- Add `tower-http` with the `cors` feature
- Introduce `CORS_ALLOWED_ORIGINS` env var for allowed origins
- Create `CorsLayer` in `main.rs` and attach it to the Axum router
- Resolve duplicate `bigdecimal` entry in `Cargo.toml`

### Configuration
Set origins in `.env`: