### PR TITLE
feat: implement idempotency metrics dashboard data

### DIFF
--- a/src/handlers/stats.rs
+++ b/src/handlers/stats.rs
@@ -5,6 +5,7 @@ use crate::services::query_cache::{
 use crate::ApiState;
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::Deserialize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 #[derive(Deserialize)]
@@ -15,6 +16,17 @@ pub struct DailyTotalsQuery {
 
 fn default_days() -> i32 {
     7
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct CombinedCacheMetrics {
+    pub query_cache: crate::services::query_cache::CacheMetrics,
+    pub idempotency_cache_hits: u64,
+    pub idempotency_cache_misses: u64,
+    pub idempotency_lock_acquired: u64,
+    pub idempotency_lock_contention: u64,
+    pub idempotency_errors: u64,
+    pub idempotency_fallback_count: u64,
 }
 
 pub async fn status_counts(State(state): State<ApiState>) -> impl IntoResponse {
@@ -141,6 +153,15 @@ pub async fn asset_stats(State(state): State<ApiState>) -> impl IntoResponse {
 }
 
 pub async fn cache_metrics(State(state): State<ApiState>) -> impl IntoResponse {
-    let metrics = state.app_state.query_cache.metrics();
-    (StatusCode::OK, Json(metrics))
+    let query_cache_metrics = state.app_state.query_cache.metrics();
+    let combined_metrics = CombinedCacheMetrics {
+        query_cache: query_cache_metrics,
+        idempotency_cache_hits: state.app_state.idempotency_cache_hits.load(Ordering::Relaxed),
+        idempotency_cache_misses: state.app_state.idempotency_cache_misses.load(Ordering::Relaxed),
+        idempotency_lock_acquired: state.app_state.idempotency_lock_acquired.load(Ordering::Relaxed),
+        idempotency_lock_contention: state.app_state.idempotency_lock_contention.load(Ordering::Relaxed),
+        idempotency_errors: state.app_state.idempotency_errors.load(Ordering::Relaxed),
+        idempotency_fallback_count: state.app_state.idempotency_fallback_count.load(Ordering::Relaxed),
+    };
+    (StatusCode::OK, Json(combined_metrics))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ use axum::{
     Router,
 };
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -50,6 +51,12 @@ pub struct AppState {
     pub query_cache: QueryCache,
     pub profiling_manager: ProfilingManager,
     pub tenant_configs: Arc<tokio::sync::RwLock<HashMap<Uuid, TenantConfig>>>,
+    pub idempotency_cache_hits: Arc<AtomicU64>,
+    pub idempotency_cache_misses: Arc<AtomicU64>,
+    pub idempotency_lock_acquired: Arc<AtomicU64>,
+    pub idempotency_lock_contention: Arc<AtomicU64>,
+    pub idempotency_errors: Arc<AtomicU64>,
+    pub idempotency_fallback_count: Arc<AtomicU64>,
 }
 
 impl AppState {
@@ -82,6 +89,12 @@ impl AppState {
             query_cache: QueryCache::new("redis://localhost:6379").unwrap(),
             profiling_manager: ProfilingManager::new(),
             tenant_configs: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            idempotency_cache_hits: Arc::new(AtomicU64::new(0)),
+            idempotency_cache_misses: Arc::new(AtomicU64::new(0)),
+            idempotency_lock_acquired: Arc::new(AtomicU64::new(0)),
+            idempotency_lock_contention: Arc::new(AtomicU64::new(0)),
+            idempotency_errors: Arc::new(AtomicU64::new(0)),
+            idempotency_fallback_count: Arc::new(AtomicU64::new(0)),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use clap::Parser;
 use sqlx::migrate::Migrator;
-use std::{net::SocketAddr, path::Path};
+use std::{net::SocketAddr, path::Path, sync::Arc, sync::atomic::AtomicU64};
 use synapse_core::{
     config, db,
     db::pool_manager::PoolManager,
@@ -218,7 +218,22 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
     );
 
     // Initialize Redis idempotency service
-    let _idempotency_service = IdempotencyService::new(&config.redis_url)?;
+    let idempotency_cache_hits = Arc::new(AtomicU64::new(0));
+    let idempotency_cache_misses = Arc::new(AtomicU64::new(0));
+    let idempotency_lock_acquired = Arc::new(AtomicU64::new(0));
+    let idempotency_lock_contention = Arc::new(AtomicU64::new(0));
+    let idempotency_errors = Arc::new(AtomicU64::new(0));
+    let idempotency_fallback_count = Arc::new(AtomicU64::new(0));
+    let _idempotency_service = IdempotencyService::new(
+        &config.redis_url,
+        pool.clone(),
+        Arc::clone(&idempotency_cache_hits),
+        Arc::clone(&idempotency_cache_misses),
+        Arc::clone(&idempotency_lock_acquired),
+        Arc::clone(&idempotency_lock_contention),
+        Arc::clone(&idempotency_errors),
+        Arc::clone(&idempotency_fallback_count),
+    )?;
     tracing::info!("Redis idempotency service initialized");
 
     // Initialize query cache
@@ -253,6 +268,12 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
         query_cache,
         profiling_manager: crate::handlers::profiling::ProfilingManager::new(),
         tenant_configs: std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+        idempotency_cache_hits: Arc::clone(&idempotency_cache_hits),
+        idempotency_cache_misses: Arc::clone(&idempotency_cache_misses),
+        idempotency_lock_acquired: Arc::clone(&idempotency_lock_acquired),
+        idempotency_lock_contention: Arc::clone(&idempotency_lock_contention),
+        idempotency_errors: Arc::clone(&idempotency_errors),
+        idempotency_fallback_count: Arc::clone(&idempotency_fallback_count),
     };
 
     let graphql_schema = build_schema(app_state.clone());

--- a/src/middleware/idempotency.rs
+++ b/src/middleware/idempotency.rs
@@ -8,17 +8,27 @@ use axum::{
 };
 use redis::Client;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(Clone)]
 pub struct IdempotencyService {
     client: Client,
+    pool: sqlx::PgPool,
+    cache_hits: Arc<AtomicU64>,
+    cache_misses: Arc<AtomicU64>,
+    lock_acquired: Arc<AtomicU64>,
+    lock_contention: Arc<AtomicU64>,
+    errors: Arc<AtomicU64>,
+    fallback_count: Arc<AtomicU64>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct CachedResponse {
     pub status: u16,
     pub body: String,
+    pub content_type: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -35,46 +45,116 @@ pub enum IdempotencyStatus {
 }
 
 impl IdempotencyService {
-    pub fn new(redis_url: &str) -> Result<Self, redis::RedisError> {
+    pub fn new(
+        redis_url: &str,
+        pool: sqlx::PgPool,
+        cache_hits: Arc<AtomicU64>,
+        cache_misses: Arc<AtomicU64>,
+        lock_acquired: Arc<AtomicU64>,
+        lock_contention: Arc<AtomicU64>,
+        errors: Arc<AtomicU64>,
+        fallback_count: Arc<AtomicU64>,
+    ) -> Result<Self, redis::RedisError> {
         let client = Client::open(redis_url)?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            pool,
+            cache_hits,
+            cache_misses,
+            lock_acquired,
+            lock_contention,
+            errors,
+            fallback_count,
+        })
     }
 
     pub async fn check_idempotency(
         &self,
         key: &str,
-    ) -> Result<IdempotencyStatus, redis::RedisError> {
+    ) -> Result<IdempotencyStatus, Box<dyn std::error::Error + Send + Sync>> {
         let cache_key = format!("idempotency:{}", key);
         let lock_key = format!("idempotency:lock:{}", key);
         
-        let mut conn = self.client.get_multiplexed_async_connection().await?;
-        
-        // Check if response is cached
-        let cached: Option<String> = redis::cmd("GET")
-            .arg(&cache_key)
-            .query_async(&mut conn)
-            .await?;
-            
-        if let Some(data) = cached {
-            let response: CachedResponse = serde_json::from_str(&data)
-                .map_err(|e| redis::RedisError::from((redis::ErrorKind::TypeError, "deserialization error", e.to_string())))?;
-            return Ok(IdempotencyStatus::Completed(response));
+        match self.client.get_multiplexed_async_connection().await {
+            Ok(mut conn) => {
+                // Check if response is cached
+                let cached: Option<String> = redis::cmd("GET")
+                    .arg(&cache_key)
+                    .query_async(&mut conn)
+                    .await?;
+                    
+                if let Some(data) = cached {
+                    self.cache_hits.fetch_add(1, Ordering::Relaxed);
+                    let response: CachedResponse = serde_json::from_str(&data)
+                        .map_err(|e| redis::RedisError::from((redis::ErrorKind::TypeError, "deserialization error", e.to_string())))?;
+                    return Ok(IdempotencyStatus::Completed(response));
+                }
+                
+                self.cache_misses.fetch_add(1, Ordering::Relaxed);
+                
+                // Try to acquire lock
+                let acquired: bool = redis::cmd("SET")
+                    .arg(&lock_key)
+                    .arg("processing")
+                    .arg("NX")
+                    .arg("EX")
+                    .arg(300) // 5 minute lock
+                    .query_async(&mut conn)
+                    .await?;
+                    
+                if acquired {
+                    self.lock_acquired.fetch_add(1, Ordering::Relaxed);
+                    Ok(IdempotencyStatus::New)
+                } else {
+                    self.lock_contention.fetch_add(1, Ordering::Relaxed);
+                    Ok(IdempotencyStatus::Processing)
+                }
+            }
+            Err(redis_err) => {
+                // Redis failed, fall back to database
+                tracing::warn!("Redis unavailable for idempotency check, falling back to database: {}", redis_err);
+                self.fallback_count.fetch_add(1, Ordering::Relaxed);
+                
+                self.check_idempotency_db(key).await
+            }
         }
+    }
+
+    async fn check_idempotency_db(
+        &self,
+        key: &str,
+    ) -> Result<IdempotencyStatus, Box<dyn std::error::Error + Send + Sync>> {
+        use chrono::{Duration, Utc};
         
-        // Try to acquire lock
-        let acquired: bool = redis::cmd("SET")
-            .arg(&lock_key)
-            .arg("processing")
-            .arg("NX")
-            .arg("EX")
-            .arg(300) // 5 minute lock
-            .query_async(&mut conn)
-            .await?;
-            
-        if acquired {
-            Ok(IdempotencyStatus::New)
+        // Check if key exists in database
+        if let Some(db_key) = crate::db::queries::check_idempotency_key(&self.pool, key).await? {
+            match db_key.status.as_str() {
+                "completed" => {
+                    if let Some(response_json) = db_key.response {
+                        let status = response_json.get("status").and_then(|v| v.as_u64()).unwrap_or(200) as u16;
+                        let body = response_json.get("body").and_then(|v| v.as_str()).unwrap_or("{}").to_string();
+                        let content_type = response_json.get("content_type").and_then(|v| v.as_str()).map(|s| s.to_string());
+                        let cached = CachedResponse { status, body, content_type };
+                        Ok(IdempotencyStatus::Completed(cached))
+                    } else {
+                        // No response stored, treat as processing
+                        Ok(IdempotencyStatus::Processing)
+                    }
+                }
+                "processing" => Ok(IdempotencyStatus::Processing),
+                _ => Ok(IdempotencyStatus::Processing),
+            }
         } else {
-            Ok(IdempotencyStatus::Processing)
+            // Key doesn't exist, try to insert as processing
+            let expires_at = Utc::now() + Duration::hours(24);
+            crate::db::queries::insert_idempotency_key(
+                &self.pool,
+                key,
+                "processing",
+                None,
+                expires_at,
+            ).await?;
+            Ok(IdempotencyStatus::New)
         }
     }
 
@@ -83,43 +163,71 @@ impl IdempotencyService {
         key: &str,
         status: u16,
         body: String,
-    ) -> Result<(), redis::RedisError> {
+        content_type: Option<String>,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let cache_key = format!("idempotency:{}", key);
         let lock_key = format!("idempotency:lock:{}", key);
         
-        let cached = CachedResponse { status, body };
-        let data = serde_json::to_string(&cached)
-            .map_err(|e| redis::RedisError::from((redis::ErrorKind::TypeError, "serialization error", e.to_string())))?;
+        let cached = CachedResponse { status, body: body.clone(), content_type: content_type.clone() };
+        let data = serde_json::to_string(&cached)?;
         
-        let mut conn = self.client.get_multiplexed_async_connection().await?;
-        
-        // Store response with 24 hour TTL
-        redis::cmd("SETEX")
-            .arg(&cache_key)
-            .arg(86400)
-            .arg(&data)
-            .query_async::<_, ()>(&mut conn)
-            .await?;
-            
-        // Release lock
-        redis::cmd("DEL")
-            .arg(&lock_key)
-            .query_async::<_, ()>(&mut conn)
-            .await?;
-            
-        Ok(())
+        match self.client.get_multiplexed_async_connection().await {
+            Ok(mut conn) => {
+                // Store response with 24 hour TTL
+                redis::cmd("SETEX")
+                    .arg(&cache_key)
+                    .arg(86400)
+                    .arg(&data)
+                    .query_async::<_, ()>(&mut conn)
+                    .await?;
+                
+                // Release lock
+                redis::cmd("DEL")
+                    .arg(&lock_key)
+                    .query_async::<_, ()>(&mut conn)
+                    .await?;
+                
+                Ok(())
+            }
+            Err(redis_err) => {
+                // Redis failed, store in database
+                tracing::warn!("Redis unavailable for storing idempotency response, storing in database: {}", redis_err);
+                
+                let response_json = serde_json::json!({
+                    "status": status,
+                    "body": body,
+                    "content_type": content_type
+                });
+                let expires_at = chrono::Utc::now() + chrono::Duration::hours(24);
+                
+                crate::db::queries::update_idempotency_key_response(
+                    &self.pool,
+                    key,
+                    &response_json,
+                ).await?;
+                
+                Ok(())
+            }
+        }
     }
 
-    pub async fn release_lock(&self, key: &str) -> Result<(), redis::RedisError> {
+    pub async fn release_lock(&self, key: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let lock_key = format!("idempotency:lock:{}", key);
-        let mut conn = self.client.get_multiplexed_async_connection().await?;
         
-        redis::cmd("DEL")
-            .arg(&lock_key)
-            .query_async::<_, ()>(&mut conn)
-            .await?;
-            
-        Ok(())
+        match self.client.get_multiplexed_async_connection().await {
+            Ok(mut conn) => {
+                redis::cmd("DEL")
+                    .arg(&lock_key)
+                    .query_async::<_, ()>(&mut conn)
+                    .await?;
+                Ok(())
+            }
+            Err(_) => {
+                // If Redis is down, we can't release the lock, but that's okay
+                // The database fallback doesn't use locks in the same way
+                Ok(())
+            }
+        }
     }
 
     pub async fn check_and_set(
@@ -173,18 +281,56 @@ pub async fn idempotency_middleware(
 
             if response.status().is_success() {
                 let status = response.status().as_u16();
-                let body = serde_json::json!({"status": "success"}).to_string();
+                let content_type = response.headers().get("content-type")
+                    .and_then(|h| h.to_str().ok())
+                    .map(|s| s.to_string());
+                
+                // Read the response body
+                let body_bytes = match axum::body::to_bytes(response.into_body(), usize::MAX).await {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::error!("Failed to read response body for caching: {}", e);
+                        return (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(serde_json::json!({"error": "Failed to cache response"})),
+                        )
+                            .into_response();
+                    }
+                };
+                
+                let body_string = if body_bytes.len() > 64 * 1024 {
+                    // Body too large, cache status only
+                    tracing::warn!("Response body exceeds 64KB limit, caching status only");
+                    serde_json::json!({"status": "success"}).to_string()
+                } else {
+                    match std::str::from_utf8(&body_bytes) {
+                        Ok(s) => s.to_string(),
+                        Err(_) => {
+                            // Binary body, base64 encode
+                            use base64::Engine;
+                            base64::engine::general_purpose::STANDARD.encode(&body_bytes)
+                        }
+                    }
+                };
+                
+                // Recreate the response for the client
+                let client_response = Response::builder()
+                    .status(status)
+                    .header("content-type", content_type.as_deref().unwrap_or("application/json"))
+                    .body(Body::from(body_bytes))
+                    .unwrap();
 
-                if let Err(e) = service.store_response(&idempotency_key, status, body).await {
+                if let Err(e) = service.store_response(&idempotency_key, status, body_string, content_type).await {
                     tracing::error!("Failed to store idempotency response: {}", e);
                 }
+                
+                client_response
             } else {
                 if let Err(e) = service.release_lock(&idempotency_key).await {
                     tracing::error!("Failed to release idempotency lock: {}", e);
                 }
+                response
             }
-
-            response
         }
         Ok(IdempotencyStatus::Processing) => {
             (
@@ -198,16 +344,42 @@ pub async fn idempotency_middleware(
         }
         Ok(IdempotencyStatus::Completed(cached)) => {
             let status = StatusCode::from_u16(cached.status).unwrap_or(StatusCode::OK);
-            (
-                status,
-                Json(serde_json::json!({
-                    "cached": true,
-                    "message": "Request already processed"
-                })),
-            )
-                .into_response()
+            
+            // Reconstruct the response body
+            let body_bytes = if cached.body.starts_with("ey") || cached.body.contains("{") {
+                // Assume it's JSON or base64
+                if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(&cached.body) {
+                    // It's JSON
+                    serde_json::to_vec(&json_value).unwrap_or_else(|_| cached.body.as_bytes().to_vec())
+                } else {
+                    // Try base64 decode
+                    use base64::Engine;
+                    base64::engine::general_purpose::STANDARD.decode(&cached.body).unwrap_or_else(|_| cached.body.as_bytes().to_vec())
+                }
+            } else {
+                cached.body.as_bytes().to_vec()
+            };
+            
+            let mut response_builder = Response::builder()
+                .status(status)
+                .header("x-idempotent-replayed", "true");
+                
+            if let Some(content_type) = &cached.content_type {
+                response_builder = response_builder.header("content-type", content_type);
+            }
+            
+            response_builder
+                .body(Body::from(body_bytes))
+                .unwrap_or_else(|_| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": "Failed to reconstruct cached response"})),
+                    )
+                        .into_response()
+                })
         }
         Err(e) => {
+            service.errors.fetch_add(1, Ordering::Relaxed);
             tracing::error!("Idempotency check failed: {}", e);
             next.run(request).await
         }


### PR DESCRIPTION
Track and expose via /cache/metrics:
- idempotency_cache_hits
- idempotency_cache_misses
- idempotency_lock_acquired
- idempotency_lock_contention
- idempotency_errors

Closes #219