### PR TITLE
feat: rate limiting, CORS, secrets rotation, k6 load tests

### DIFF
--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -1,6 +1,129 @@
 # Load Test Results
 
-This document contains baseline performance metrics and bottleneck analysis for the Synapse Core API.
+This document covers the load testing infrastructure for Synapse Core and how to run the three k6 test scenarios.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- The `load-test` profile services must be healthy before running scripts
+
+## Test Scripts
+
+| Script | Purpose | Target throughput | Duration |
+|---|---|---|---|
+| `tests/load/callback_load.js` | Sustained callback ingestion | 1000 req/s constant | 5 minutes |
+| `tests/load/search_load.js` | Concurrent search queries | 50 VUs ramping | ~5 minutes |
+| `tests/load/mixed_load.js` | Realistic mix (60% callbacks, 25% reads, 15% searches) | 100→500 req/s ramping | ~5.5 minutes |
+
+## Success Criteria (all scripts)
+
+- p95 latency **< 200ms**
+- Error rate **< 0.1%**
+
+## Running Load Tests
+
+### Start infrastructure
+
+```bash
+docker compose -f docker-compose.load.yml up -d postgres redis app
+# Wait for the app to be healthy
+sleep 15
+```
+
+### Run individual scripts
+
+```bash
+# Callback ingestion (1000 req/s for 5 minutes)
+docker compose -f docker-compose.load.yml --profile load-test run --rm k6 \
+  run /scripts/callback_load.js
+
+# Search queries (50 concurrent VUs)
+docker compose -f docker-compose.load.yml --profile load-test run --rm k6 \
+  run /scripts/search_load.js
+
+# Mixed realistic traffic
+docker compose -f docker-compose.load.yml --profile load-test run --rm k6 \
+  run /scripts/mixed_load.js
+```
+
+### Run all scripts sequentially
+
+```bash
+for script in callback_load search_load mixed_load; do
+  docker compose -f docker-compose.load.yml --profile load-test run --rm k6 \
+    run /scripts/${script}.js
+done
+```
+
+### Override base URL or API key
+
+```bash
+docker compose -f docker-compose.load.yml --profile load-test run --rm \
+  -e BASE_URL=http://app:3000 \
+  -e API_KEY=my-tenant-key \
+  k6 run /scripts/callback_load.js
+```
+
+## HTML Reports
+
+Each script writes an HTML summary to `docs/` (mounted as `/results` inside the k6 container):
+
+- `docs/callback_load_summary.html`
+- `docs/search_load_summary.html`
+- `docs/mixed_load_summary.html`
+
+Open any of these in a browser after the run to review pass/fail against thresholds.
+
+## Monitoring During Tests
+
+```bash
+# Container resource usage
+docker stats synapse-load-app synapse-load-postgres synapse-load-redis
+
+# PostgreSQL active connections
+docker exec synapse-load-postgres psql -U synapse \
+  -c "SELECT count(*) FROM pg_stat_activity;"
+
+# Redis memory
+docker exec synapse-load-redis redis-cli INFO memory
+
+# App logs
+docker logs -f synapse-load-app
+```
+
+## Teardown
+
+```bash
+docker compose -f docker-compose.load.yml down -v
+```
+
+## Test Environment
+
+- **Database**: PostgreSQL 14 (max_connections=200, shared_buffers=256MB)
+- **Redis**: 7-alpine (maxmemory=512mb, persistence disabled)
+- **App**: Rust/Axum (2 CPU cores, 1GB RAM limit)
+
+## Results
+
+> Fill in after running tests against your environment.
+
+```
+callback_load:
+  http_req_duration: avg=XXXms p(95)=XXXms p(99)=XXXms
+  http_req_failed:   X.XX%
+  http_reqs:         XXXXX
+
+search_load:
+  http_req_duration: avg=XXXms p(95)=XXXms p(99)=XXXms
+  http_req_failed:   X.XX%
+  http_reqs:         XXXXX
+
+mixed_load:
+  http_req_duration: avg=XXXms p(95)=XXXms p(99)=XXXms
+  http_req_failed:   X.XX%
+  http_reqs:         XXXXX
+```
+
 
 ## Test Environment
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,8 @@ pub struct Config {
     pub backup_dir: String,
     pub backup_encryption_key: Option<String>,
     pub otlp_endpoint: Option<String>,
+    // CORS
+    pub cors_allowed_origins: Vec<String>,
     // Back-pressure
     pub max_pending_queue: u64,
     // DB pool sizing
@@ -100,6 +102,13 @@ impl Config {
             backup_dir: env::var("BACKUP_DIR").unwrap_or_else(|_| "./backups".to_string()),
             backup_encryption_key: env::var("BACKUP_ENCRYPTION_KEY").ok(),
             otlp_endpoint: env::var("OTLP_ENDPOINT").ok(),
+            cors_allowed_origins: env::var("CORS_ALLOWED_ORIGINS")
+                .unwrap_or_default()
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(String::from)
+                .collect(),
             max_pending_queue: env::var("MAX_PENDING_QUEUE")
                 .unwrap_or_else(|_| "10000".to_string())
                 .parse()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use crate::graphql::schema::AppSchema;
 use crate::handlers::profiling::ProfilingManager;
 use crate::handlers::ws::TransactionStatusUpdate;
 pub use crate::readiness::ReadinessState;
+use crate::secrets::SecretsStore;
 use crate::services::feature_flags::FeatureFlagService;
 use crate::services::query_cache::QueryCache;
 use crate::stellar::HorizonClient;
@@ -51,6 +52,7 @@ pub struct AppState {
     pub query_cache: QueryCache,
     pub profiling_manager: ProfilingManager,
     pub tenant_configs: Arc<tokio::sync::RwLock<HashMap<Uuid, TenantConfig>>>,
+    pub secrets_store: Option<SecretsStore>,
     /// Current count of pending transactions, updated every 5s by background task.
     pub pending_queue_depth: Arc<AtomicU64>,
     /// Current adaptive batch size, updated by the processor pool.
@@ -87,6 +89,7 @@ impl AppState {
             query_cache: QueryCache::new("redis://localhost:6379").unwrap(),
             profiling_manager: ProfilingManager::new(),
             tenant_configs: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            secrets_store: None,
             pending_queue_depth: Arc::new(AtomicU64::new(0)),
             current_batch_size: Arc::new(AtomicU64::new(10)),
         }
@@ -108,29 +111,44 @@ impl std::fmt::Debug for ApiState {
 pub fn create_app(app_state: AppState) -> Router {
     let graphql_schema = crate::graphql::schema::build_schema(app_state.clone());
     let api_state = ApiState {
-        app_state,
+        app_state: app_state.clone(),
         graphql_schema,
     };
 
-    // Callback routes with validation middleware
+    // Callback routes with validation + quota middleware
     let callback_routes = Router::new()
         .route("/callback", post(handlers::webhook::callback))
         .route("/callback/transaction", post(handlers::webhook::callback))
+        .layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            crate::middleware::quota::rate_limit_middleware,
+        ))
         .layer(axum_middleware::from_fn(
             crate::middleware::validate::validate_callback,
         ));
 
-    // Webhook route with validation middleware
+    // Webhook route with validation + quota middleware
     let webhook_routes = Router::new()
         .route("/webhook", post(handlers::webhook::handle_webhook))
+        .layer(axum_middleware::from_fn_with_state(
+            app_state.clone(),
+            crate::middleware::quota::rate_limit_middleware,
+        ))
         .layer(axum_middleware::from_fn(
             crate::middleware::validate::validate_webhook,
         ));
 
-    Router::new()
+    // Admin routes — quota skipped, SecretsStore injected for rotation-aware auth
+    let mut admin_router = Router::new()
         .route("/health", get(handlers::health))
         .route("/ready", get(handlers::ready))
-        .route("/errors", get(handlers::error_catalog))
+        .route("/errors", get(handlers::error_catalog));
+
+    if let Some(store) = &app_state.secrets_store {
+        admin_router = admin_router.layer(axum::Extension(store.clone()));
+    }
+
+    admin_router
         .route("/settlements", get(handlers::settlements::list_settlements))
         .route(
             "/settlements/:id",

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ use synapse_core::{
     middleware,
     middleware::idempotency::IdempotencyService,
     schemas,
+    secrets::SecretsStore,
     services::{FeatureFlagService, LeaderElection, SettlementService, WebhookDispatcher},
     stellar::HorizonClient,
     telemetry,
@@ -23,6 +24,7 @@ use synapse_core::{
 };
 use opentelemetry::trace::TracerProvider as _;
 use tokio::sync::broadcast;
+use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
@@ -204,15 +206,8 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
     tracing::info!("Metrics initialized successfully");
 
     // Initialize rate limiting
-    // let rate_limit_config = Arc::new(RateLimitConfig::new(&config));
-
-    // Load whitelisted IPs from config
-    // if !config.whitelisted_ips.is_empty() {
-    //     rate_limit_config.load_whitelisted_ips(&config.whitelisted_ips).await;
-    // }
-
     tracing::info!(
-        "Rate limiting configured: {} req/sec (default), {} req/sec (whitelisted)",
+        "Rate limiting configured: {} req/min (default), {} req/min (whitelisted)",
         config.default_rate_limit,
         config.whitelist_rate_limit
     );
@@ -255,6 +250,27 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
     let feature_flags = FeatureFlagService::new(pool.clone());
     tracing::info!("Feature flags service initialized");
 
+    // Initialize secrets store and start rotation task (if Vault is configured).
+    let secrets_store = if std::env::var("VAULT_ROLE_ID").is_ok() {
+        match synapse_core::secrets::SecretsManager::new().await {
+            Ok(manager) => {
+                let anchor_secret = manager.get_anchor_secret().await?;
+                let admin_key = manager.get_admin_api_key().await?;
+                let store = SecretsStore::new(anchor_secret, admin_key);
+                manager.start_refresh_task(store.clone());
+                tracing::info!("Secrets rotation enabled: refreshing from Vault every 5 minutes");
+                Some(store)
+            }
+            Err(e) => {
+                tracing::warn!("Vault unavailable, secrets rotation disabled: {e}");
+                None
+            }
+        }
+    } else {
+        tracing::info!("Vault not configured, secrets rotation disabled");
+        None
+    };
+
     let monitor_pool = pool.clone();
     let pending_queue_depth = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let current_batch_size = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(
@@ -272,6 +288,7 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
         query_cache,
         profiling_manager: crate::handlers::profiling::ProfilingManager::new(),
         tenant_configs: std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+        secrets_store,
         pending_queue_depth: pending_queue_depth.clone(),
         current_batch_size: current_batch_size.clone(),
     };
@@ -372,6 +389,29 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
             get(handlers::admin::list_active_instances),
         )
         .with_state(api_state);
+
+    // Configure CORS if allowed origins are specified.
+    let app = if !config.cors_allowed_origins.is_empty() {
+        let origins: Vec<_> = config
+            .cors_allowed_origins
+            .iter()
+            .filter_map(|o| o.parse::<axum::http::HeaderValue>().ok())
+            .collect();
+        tracing::info!(
+            "CORS enabled for origins: {:?}",
+            config.cors_allowed_origins
+        );
+        let cors = CorsLayer::new()
+            .allow_origin(AllowOrigin::list(origins))
+            .allow_methods(AllowMethods::any())
+            .allow_headers(AllowHeaders::any())
+            .allow_credentials(true)
+            .max_age(std::time::Duration::from_secs(3600));
+        app.layer(cors)
+    } else {
+        tracing::info!("CORS disabled (no allowed origins configured)");
+        app
+    };
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.server_port));
     tracing::info!("listening on {}", addr);

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -5,19 +5,39 @@ use axum::{
     response::Response,
 };
 
+use crate::secrets::SecretsStore;
+
+/// Admin auth middleware that accepts all currently-valid API keys (supports secret rotation).
+/// If a `SecretsStore` extension is present on the request, it checks all valid keys
+/// (current + grace-period previous). Falls back to the `ADMIN_API_KEY` env var otherwise.
 pub async fn admin_auth(req: Request<Body>, next: Next<Body>) -> Result<Response, StatusCode> {
     let auth_header = req
         .headers()
         .get("Authorization")
-        .and_then(|h| h.to_str().ok());
+        .and_then(|h| h.to_str().ok())
+        .map(|s| s.trim_start_matches("Bearer ").to_string());
 
+    let provided = match auth_header {
+        Some(v) => v,
+        None => return Err(StatusCode::UNAUTHORIZED),
+    };
+
+    // Try SecretsStore extension first (rotation-aware).
+    if let Some(store) = req.extensions().get::<SecretsStore>() {
+        let valid_keys = store.valid_admin_keys().await;
+        if valid_keys.iter().any(|k| k == &provided) {
+            return Ok(next.run(req).await);
+        }
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    // Fallback: plain env var (no Vault / rotation).
     let admin_api_key =
         std::env::var("ADMIN_API_KEY").unwrap_or_else(|_| "admin-secret-key".to_string());
 
-    match auth_header {
-        Some(auth) if auth == format!("Bearer {}", admin_api_key) || auth == admin_api_key => {
-            Ok(next.run(req).await)
-        }
-        _ => Err(StatusCode::UNAUTHORIZED),
+    if provided == admin_api_key {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
     }
 }

--- a/src/middleware/quota.rs
+++ b/src/middleware/quota.rs
@@ -206,6 +206,63 @@ impl QuotaManager {
             .map_err(redis_cb_err)?;
         Ok(if ttl < 0 { 0 } else { ttl as u64 })
     }
+
+    /// Consume one request against a fixed per-window limit (window_secs TTL).
+    /// Returns `true` if the request is allowed, `false` if the limit is exceeded.
+    pub async fn consume_quota_with_window(
+        &self,
+        key: &str,
+        limit: u32,
+        window_secs: i64,
+    ) -> Result<bool, redis::RedisError> {
+        let usage_key = format!("quota:usage:{}", key);
+        let client = self.redis_client.clone();
+        let usage_key2 = usage_key.clone();
+
+        let current: u32 = self
+            .cb
+            .call(|| async move {
+                let mut conn = client.get_multiplexed_async_connection().await?;
+                let current: u32 = conn.incr(&usage_key2, 1).await?;
+                if current == 1 {
+                    let _: () = conn.expire(&usage_key2, window_secs).await?;
+                }
+                Ok(current)
+            })
+            .await
+            .map_err(redis_cb_err)?;
+
+        Ok(current <= limit)
+    }
+
+    /// Check quota status against an explicit limit (does not consume).
+    pub async fn check_quota_with_limit(
+        &self,
+        key: &str,
+        limit: u32,
+    ) -> Result<QuotaStatus, redis::RedisError> {
+        let usage_key = format!("quota:usage:{}", key);
+        let client = self.redis_client.clone();
+        let usage_key2 = usage_key.clone();
+
+        let current: u32 = self
+            .cb
+            .call(|| async move {
+                let mut conn = client.get_multiplexed_async_connection().await?;
+                Ok::<u32, redis::RedisError>(conn.get(&usage_key2).await.unwrap_or(0))
+            })
+            .await
+            .map_err(redis_cb_err)?;
+
+        let reset_in_seconds = self.get_ttl(&usage_key).await?;
+
+        Ok(QuotaStatus {
+            limit,
+            used: current,
+            remaining: limit.saturating_sub(current),
+            reset_in_seconds,
+        })
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -229,4 +286,139 @@ pub fn extract_quota_key(headers: &axum::http::HeaderMap) -> Option<String> {
                 .and_then(|v| v.to_str().ok())
                 .map(|s| format!("ip:{}", s.split(',').next().unwrap_or(s).trim()))
         })
+}
+
+// ---------------------------------------------------------------------------
+// Axum middleware
+// ---------------------------------------------------------------------------
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderValue, Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use crate::AppState;
+
+const DEFAULT_RATE_LIMIT_PER_MINUTE: u32 = 100;
+
+/// Per-tenant rate limiting middleware.
+///
+/// - Identifies the tenant via `X-API-Key` or `X-Tenant-ID` header.
+/// - Uses `tenants.rate_limit_per_minute` when available; falls back to 100 req/min.
+/// - Unauthenticated requests share a single `anon` bucket capped at 100 req/min.
+/// - Returns `429 Too Many Requests` with `Retry-After`, `X-RateLimit-Limit`,
+///   `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers on exhaustion.
+pub async fn rate_limit_middleware(
+    State(state): State<AppState>,
+    req: Request<Body>,
+    next: Next<Body>,
+) -> Response {
+    // Derive a quota key: prefer API key, then tenant-id header, then "anon".
+    let quota_key = req
+        .headers()
+        .get("x-api-key")
+        .or_else(|| req.headers().get("X-API-Key"))
+        .and_then(|v| v.to_str().ok())
+        .map(|k| k.to_string())
+        .or_else(|| {
+            req.headers()
+                .get("X-Tenant-ID")
+                .and_then(|v| v.to_str().ok())
+                .map(|id| format!("tenant:{id}"))
+        })
+        .unwrap_or_else(|| "anon".to_string());
+
+    // Look up per-tenant limit from the in-memory tenant config cache.
+    let limit_per_minute: u32 = {
+        let configs = state.tenant_configs.read().await;
+        // Try to match by API key (stored as the quota_key itself) or tenant UUID.
+        configs
+            .values()
+            .find(|c| {
+                quota_key == c.tenant_id.to_string()
+                    || quota_key.starts_with("tenant:")
+                        && quota_key.trim_start_matches("tenant:") == c.tenant_id.to_string()
+            })
+            .map(|c| c.rate_limit_per_minute as u32)
+            .unwrap_or(DEFAULT_RATE_LIMIT_PER_MINUTE)
+    };
+
+    // Build a QuotaManager backed by the app's Redis URL.
+    let manager = match QuotaManager::new(&state.redis_url) {
+        Ok(m) => m,
+        Err(_) => {
+            // Redis unavailable — fail open to avoid blocking all traffic.
+            tracing::warn!("rate_limit: Redis unavailable, skipping quota check");
+            return next.run(req).await;
+        }
+    };
+
+    // Override the quota config with the per-tenant per-minute limit.
+    let per_minute_key = format!("ratelimit:{quota_key}");
+    let quota_cfg = Quota {
+        tier: Tier::Free,
+        custom_limit: Some(limit_per_minute),
+        reset_schedule: ResetSchedule::Hourly, // TTL managed manually below
+    };
+    // Best-effort: set config (ignore errors).
+    let _ = manager.set_quota_config(&per_minute_key, &quota_cfg).await;
+
+    // Consume one unit.
+    let allowed = manager
+        .consume_quota_with_window(&per_minute_key, limit_per_minute, 60)
+        .await
+        .unwrap_or(true); // fail open on Redis error
+
+    // Read back status for headers.
+    let status = manager
+        .check_quota_with_limit(&per_minute_key, limit_per_minute)
+        .await
+        .unwrap_or(QuotaStatus {
+            limit: limit_per_minute,
+            used: 0,
+            remaining: limit_per_minute,
+            reset_in_seconds: 60,
+        });
+
+    if !allowed {
+        let retry_after = status.reset_in_seconds.max(1).to_string();
+        let mut response = (StatusCode::TOO_MANY_REQUESTS, "Too Many Requests").into_response();
+        let headers = response.headers_mut();
+        headers.insert(
+            "X-RateLimit-Limit",
+            HeaderValue::from_str(&status.limit.to_string()).unwrap(),
+        );
+        headers.insert(
+            "X-RateLimit-Remaining",
+            HeaderValue::from_str(&status.remaining.to_string()).unwrap(),
+        );
+        headers.insert(
+            "X-RateLimit-Reset",
+            HeaderValue::from_str(&status.reset_in_seconds.to_string()).unwrap(),
+        );
+        headers.insert(
+            "Retry-After",
+            HeaderValue::from_str(&retry_after).unwrap(),
+        );
+        return response;
+    }
+
+    let mut response = next.run(req).await;
+    let headers = response.headers_mut();
+    headers.insert(
+        "X-RateLimit-Limit",
+        HeaderValue::from_str(&status.limit.to_string()).unwrap(),
+    );
+    headers.insert(
+        "X-RateLimit-Remaining",
+        HeaderValue::from_str(&status.remaining.to_string()).unwrap(),
+    );
+    headers.insert(
+        "X-RateLimit-Reset",
+        HeaderValue::from_str(&status.reset_in_seconds.to_string()).unwrap(),
+    );
+    response
 }

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,10 +1,92 @@
 use std::collections::HashMap;
 use std::env;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use tokio::sync::RwLock;
 use vaultrs::auth::approle;
 use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
 use vaultrs::kv2;
+
+/// Grace period during which the previous secret remains valid after rotation.
+const ROTATION_GRACE_PERIOD: Duration = Duration::from_secs(300);
+/// How often to poll Vault for updated secrets.
+const REFRESH_INTERVAL: Duration = Duration::from_secs(300);
+
+/// A double-buffered secret: keeps current and previous value.
+/// During the grace period both are accepted for signature validation.
+#[derive(Clone, Debug)]
+pub struct RotatingSecret {
+    pub current: String,
+    pub previous: Option<(String, Instant)>,
+}
+
+impl RotatingSecret {
+    pub fn new(value: String) -> Self {
+        Self {
+            current: value,
+            previous: None,
+        }
+    }
+
+    /// Returns all currently-valid values: current first, then previous if still in grace period.
+    pub fn valid_values(&self) -> Vec<&str> {
+        let mut values = vec![self.current.as_str()];
+        if let Some((prev, rotated_at)) = &self.previous {
+            if rotated_at.elapsed() < ROTATION_GRACE_PERIOD {
+                values.push(prev.as_str());
+            }
+        }
+        values
+    }
+
+    /// Rotate to a new value, demoting current to previous.
+    pub fn rotate(&mut self, new_value: String) {
+        let old = std::mem::replace(&mut self.current, new_value);
+        self.previous = Some((old, Instant::now()));
+    }
+}
+
+/// Thread-safe store of rotating secrets shared across the application.
+#[derive(Clone)]
+pub struct SecretsStore {
+    pub anchor_webhook_secret: Arc<RwLock<RotatingSecret>>,
+    pub admin_api_key: Arc<RwLock<RotatingSecret>>,
+}
+
+impl SecretsStore {
+    pub fn new(anchor_webhook_secret: String, admin_api_key: String) -> Self {
+        Self {
+            anchor_webhook_secret: Arc::new(RwLock::new(RotatingSecret::new(
+                anchor_webhook_secret,
+            ))),
+            admin_api_key: Arc::new(RwLock::new(RotatingSecret::new(admin_api_key))),
+        }
+    }
+
+    /// Returns all valid anchor webhook secret values (current + grace-period previous).
+    pub async fn valid_webhook_secrets(&self) -> Vec<String> {
+        self.anchor_webhook_secret
+            .read()
+            .await
+            .valid_values()
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    /// Returns all valid admin API key values (current + grace-period previous).
+    pub async fn valid_admin_keys(&self) -> Vec<String> {
+        self.admin_api_key
+            .read()
+            .await
+            .valid_values()
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
 
 pub struct SecretsManager {
     client: VaultClient,
@@ -57,6 +139,64 @@ impl SecretsManager {
             .get("secret")
             .cloned()
             .context("secret key not found in Vault secret/anchor")
+    }
+
+    pub async fn get_admin_api_key(&self) -> Result<String> {
+        let secret: HashMap<String, String> = kv2::read(&self.client, &self.kv_mount, "admin")
+            .await
+            .context("failed to read secret/admin from Vault")?;
+
+        secret
+            .get("api_key")
+            .cloned()
+            .context("api_key not found in Vault secret/admin")
+    }
+
+    /// Spawn a background task that refreshes secrets from Vault every 5 minutes.
+    /// Rotated secrets remain valid for a grace period so in-flight requests are not rejected.
+    pub fn start_refresh_task(self, store: SecretsStore) {
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(REFRESH_INTERVAL);
+            interval.tick().await; // skip the immediate first tick
+            loop {
+                interval.tick().await;
+                tracing::info!("secrets_rotation: refreshing secrets from Vault");
+
+                match self.get_anchor_secret().await {
+                    Ok(new_secret) => {
+                        let mut lock = store.anchor_webhook_secret.write().await;
+                        if lock.current != new_secret {
+                            lock.rotate(new_secret);
+                            tracing::info!(
+                                "secrets_rotation: anchor_webhook_secret rotated; \
+                                 previous value valid for {}s grace period",
+                                ROTATION_GRACE_PERIOD.as_secs()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("secrets_rotation: failed to refresh anchor secret: {e}");
+                    }
+                }
+
+                match self.get_admin_api_key().await {
+                    Ok(new_key) => {
+                        let mut lock = store.admin_api_key.write().await;
+                        if lock.current != new_key {
+                            lock.rotate(new_key);
+                            tracing::info!(
+                                "secrets_rotation: admin_api_key rotated; \
+                                 previous value valid for {}s grace period",
+                                ROTATION_GRACE_PERIOD.as_secs()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("secrets_rotation: failed to refresh admin key: {e}");
+                    }
+                }
+            }
+        });
     }
 }
 

--- a/tests/load/callback_load.js
+++ b/tests/load/callback_load.js
@@ -1,71 +1,114 @@
-import http from 'k6/http';
-import { check, sleep } from 'k6';
-import { Rate, Trend } from 'k6/metrics';
+/**
+ * callback_load.js — Sustained callback ingestion at 1000 req/s for 5 minutes.
+ *
+ * Success criteria:
+ *   - p95 latency < 200ms
+ *   - error rate < 0.1%
+ *
+ * Run:
+ *   docker compose -f docker-compose.load.yml --profile load-test run --rm k6 run /scripts/callback_load.js
+ */
 
-// Custom metrics
-const errorRate = new Rate('errors');
-const webhookDuration = new Trend('webhook_duration');
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+import { randomString, uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
 
-// Test configuration
+const errorRate = new Rate("errors");
+const callbackDuration = new Trend("callback_duration", true);
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
 export const options = {
-  stages: [
-    { duration: '2m', target: 10 },   // Ramp up to 10 users
-    { duration: '5m', target: 10 },   // Stay at 10 users
-    { duration: '2m', target: 50 },   // Ramp up to 50 users
-    { duration: '5m', target: 50 },   // Stay at 50 users
-    { duration: '2m', target: 100 },  // Ramp up to 100 users
-    { duration: '5m', target: 100 },  // Stay at 100 users
-    { duration: '2m', target: 0 },    // Ramp down to 0 users
-  ],
+  scenarios: {
+    sustained_load: {
+      executor: "constant-arrival-rate",
+      rate: 1000,
+      timeUnit: "1s",
+      duration: "5m",
+      preAllocatedVUs: 200,
+      maxVUs: 500,
+    },
+  },
   thresholds: {
-    http_req_duration: ['p(95)<500', 'p(99)<1000'], // 95% under 500ms, 99% under 1s
-    errors: ['rate<0.05'], // Error rate under 5%
-    http_req_failed: ['rate<0.05'],
+    http_req_duration: ["p(95)<200"],
+    errors: ["rate<0.001"],
   },
 };
 
-const BASE_URL = __ENV.BASE_URL || 'http://localhost:3000';
+function randomAsset() {
+  const assets = ["USDC", "USDT", "XLM", "BTC", "ETH"];
+  return assets[Math.floor(Math.random() * assets.length)];
+}
 
-// Generate realistic webhook payload
-function generateWebhookPayload() {
-  const timestamp = new Date().toISOString();
-  const txId = `tx_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
-  
-  return {
-    id: txId,
-    anchor_transaction_id: `anchor_${txId}`,
-    event_type: 'deposit_completed',
-    amount: (Math.random() * 1000 + 10).toFixed(2),
-    asset_code: 'USD',
-    user_id: `user_${Math.floor(Math.random() * 10000)}`,
-    timestamp: timestamp,
-  };
+function randomAmount() {
+  return (Math.random() * 9999 + 1).toFixed(2);
 }
 
 export default function () {
-  const payload = JSON.stringify(generateWebhookPayload());
-  const idempotencyKey = `key_${Date.now()}_${__VU}_${__ITER}`;
-  
-  const params = {
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Idempotency-Key': idempotencyKey,
-    },
-    timeout: '30s',
-  };
-
-  const response = http.post(`${BASE_URL}/webhook`, payload, params);
-  
-  // Check response
-  const success = check(response, {
-    'status is 200': (r) => r.status === 200,
-    'response has success field': (r) => JSON.parse(r.body).success === true,
-    'response time < 500ms': (r) => r.timings.duration < 500,
+  const payload = JSON.stringify({
+    stellar_account: `G${randomString(55, "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")}`,
+    amount: randomAmount(),
+    asset_code: randomAsset(),
+    anchor_transaction_id: uuidv4(),
+    callback_type: "deposit",
+    callback_status: "completed",
+    memo: `load-test-${randomString(8)}`,
+    memo_type: "text",
   });
 
-  errorRate.add(!success);
-  webhookDuration.add(response.timings.duration);
+  const params = {
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": __ENV.API_KEY || "load-test-key",
+      "Idempotency-Key": uuidv4(),
+    },
+    timeout: "10s",
+  };
 
-  // Simulate realistic think time between requests
-  sleep(Math.random() * 2 + 1); // 1-3 seconds
+  const res = http.post(`${BASE_URL}/callback`, payload, params);
+
+  const ok = check(res, {
+    "status is 201": (r) => r.status === 201,
+    "response has id": (r) => {
+      try {
+        return JSON.parse(r.body).id !== undefined;
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  errorRate.add(!ok);
+  callbackDuration.add(res.timings.duration);
+}
+
+export function handleSummary(data) {
+  return {
+    "/results/callback_load_summary.html": htmlReport(data),
+    stdout: textSummary(data, { indent: " ", enableColors: true }),
+  };
+}
+
+// Inline minimal HTML report generator (no external dependency required).
+function htmlReport(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const p99 = data.metrics.http_req_duration?.values?.["p(99)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  const reqs = data.metrics.http_reqs?.values?.count ?? 0;
+  return `<!DOCTYPE html><html><head><title>Callback Load Test</title></head><body>
+<h1>Callback Load Test Results</h1>
+<table border="1" cellpadding="6">
+  <tr><th>Metric</th><th>Value</th><th>Threshold</th><th>Pass</th></tr>
+  <tr><td>p95 latency</td><td>${p95}ms</td><td>&lt;200ms</td><td>${p95 < 200 ? "✅" : "❌"}</td></tr>
+  <tr><td>p99 latency</td><td>${p99}ms</td><td>—</td><td>—</td></tr>
+  <tr><td>Error rate</td><td>${errRate}%</td><td>&lt;0.1%</td><td>${errRate < 0.1 ? "✅" : "❌"}</td></tr>
+  <tr><td>Total requests</td><td>${reqs}</td><td>—</td><td>—</td></tr>
+</table></body></html>`;
+}
+
+function textSummary(data, _opts) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  return `\n=== Callback Load Test ===\np95 latency : ${p95}ms (threshold: <200ms)\nError rate  : ${errRate}% (threshold: <0.1%)\n`;
 }

--- a/tests/load/mixed_load.js
+++ b/tests/load/mixed_load.js
@@ -1,0 +1,175 @@
+/**
+ * mixed_load.js — Realistic mix of callbacks (60%), reads (25%), and searches (15%).
+ *
+ * Success criteria:
+ *   - p95 latency < 200ms
+ *   - error rate < 0.1%
+ *
+ * Run:
+ *   docker compose -f docker-compose.load.yml --profile load-test run --rm k6 run /scripts/mixed_load.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend, Counter } from "k6/metrics";
+import { randomString, uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+
+const errorRate = new Rate("errors");
+const callbackDuration = new Trend("callback_duration", true);
+const readDuration = new Trend("read_duration", true);
+const searchDuration = new Trend("search_duration", true);
+const callbackCount = new Counter("callback_requests");
+const readCount = new Counter("read_requests");
+const searchCount = new Counter("search_requests");
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+const ASSETS = ["USDC", "USDT", "XLM", "BTC", "ETH"];
+const STATUSES = ["pending", "completed", "failed"];
+
+// Shared pool of transaction IDs collected during the run for read requests.
+const txIds = [];
+
+export const options = {
+  scenarios: {
+    mixed_traffic: {
+      executor: "ramping-arrival-rate",
+      startRate: 100,
+      timeUnit: "1s",
+      preAllocatedVUs: 100,
+      maxVUs: 400,
+      stages: [
+        { duration: "1m", target: 200 },
+        { duration: "3m", target: 500 },
+        { duration: "1m", target: 500 },
+        { duration: "30s", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ["p(95)<200"],
+    errors: ["rate<0.001"],
+  },
+};
+
+const defaultHeaders = {
+  "Content-Type": "application/json",
+  "X-API-Key": __ENV.API_KEY || "load-test-key",
+};
+
+function doCallback() {
+  const payload = JSON.stringify({
+    stellar_account: `G${randomString(55, "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")}`,
+    amount: (Math.random() * 9999 + 1).toFixed(2),
+    asset_code: ASSETS[Math.floor(Math.random() * ASSETS.length)],
+    anchor_transaction_id: uuidv4(),
+    callback_type: "deposit",
+    callback_status: "completed",
+    memo: `mixed-${randomString(6)}`,
+    memo_type: "text",
+  });
+
+  const res = http.post(`${BASE_URL}/callback`, payload, {
+    headers: { ...defaultHeaders, "Idempotency-Key": uuidv4() },
+    timeout: "10s",
+  });
+
+  const ok = check(res, { "callback 201": (r) => r.status === 201 });
+  errorRate.add(!ok);
+  callbackDuration.add(res.timings.duration);
+  callbackCount.add(1);
+
+  // Collect IDs for subsequent read requests.
+  if (ok) {
+    try {
+      const body = JSON.parse(res.body);
+      if (body.id && txIds.length < 500) {
+        txIds.push(body.id);
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+}
+
+function doRead() {
+  if (txIds.length === 0) {
+    // No IDs yet — fall back to a callback.
+    doCallback();
+    return;
+  }
+  const id = txIds[Math.floor(Math.random() * txIds.length)];
+  const res = http.get(`${BASE_URL}/transactions/${id}`, {
+    headers: defaultHeaders,
+    timeout: "10s",
+  });
+
+  const ok = check(res, { "read 200": (r) => r.status === 200 || r.status === 404 });
+  errorRate.add(!ok);
+  readDuration.add(res.timings.duration);
+  readCount.add(1);
+}
+
+function doSearch() {
+  const params = new URLSearchParams({
+    asset_code: ASSETS[Math.floor(Math.random() * ASSETS.length)],
+    status: STATUSES[Math.floor(Math.random() * STATUSES.length)],
+    limit: String(Math.floor(Math.random() * 20) + 5),
+  });
+
+  const res = http.get(`${BASE_URL}/transactions/search?${params}`, {
+    headers: defaultHeaders,
+    timeout: "10s",
+  });
+
+  const ok = check(res, { "search 200": (r) => r.status === 200 });
+  errorRate.add(!ok);
+  searchDuration.add(res.timings.duration);
+  searchCount.add(1);
+}
+
+export default function () {
+  const roll = Math.random();
+  if (roll < 0.60) {
+    doCallback();
+  } else if (roll < 0.85) {
+    doRead();
+  } else {
+    doSearch();
+  }
+  sleep(0.01);
+}
+
+export function handleSummary(data) {
+  return {
+    "/results/mixed_load_summary.html": htmlReport(data),
+    stdout: textSummary(data),
+  };
+}
+
+function htmlReport(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const p99 = data.metrics.http_req_duration?.values?.["p(99)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  const reqs = data.metrics.http_reqs?.values?.count ?? 0;
+  const cbReqs = data.metrics.callback_requests?.values?.count ?? 0;
+  const rdReqs = data.metrics.read_requests?.values?.count ?? 0;
+  const srReqs = data.metrics.search_requests?.values?.count ?? 0;
+  return `<!DOCTYPE html><html><head><title>Mixed Load Test</title></head><body>
+<h1>Mixed Load Test Results</h1>
+<table border="1" cellpadding="6">
+  <tr><th>Metric</th><th>Value</th><th>Threshold</th><th>Pass</th></tr>
+  <tr><td>p95 latency</td><td>${p95}ms</td><td>&lt;200ms</td><td>${p95 < 200 ? "✅" : "❌"}</td></tr>
+  <tr><td>p99 latency</td><td>${p99}ms</td><td>—</td><td>—</td></tr>
+  <tr><td>Error rate</td><td>${errRate}%</td><td>&lt;0.1%</td><td>${errRate < 0.1 ? "✅" : "❌"}</td></tr>
+  <tr><td>Total requests</td><td>${reqs}</td><td>—</td><td>—</td></tr>
+  <tr><td>Callbacks</td><td>${cbReqs}</td><td>~60%</td><td>—</td></tr>
+  <tr><td>Reads</td><td>${rdReqs}</td><td>~25%</td><td>—</td></tr>
+  <tr><td>Searches</td><td>${srReqs}</td><td>~15%</td><td>—</td></tr>
+</table></body></html>`;
+}
+
+function textSummary(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  return `\n=== Mixed Load Test ===\np95 latency : ${p95}ms (threshold: <200ms)\nError rate  : ${errRate}% (threshold: <0.1%)\n`;
+}

--- a/tests/load/search_load.js
+++ b/tests/load/search_load.js
@@ -1,0 +1,117 @@
+/**
+ * search_load.js — Concurrent transaction search queries.
+ *
+ * Success criteria:
+ *   - p95 latency < 200ms
+ *   - error rate < 0.1%
+ *
+ * Run:
+ *   docker compose -f docker-compose.load.yml --profile load-test run --rm k6 run /scripts/search_load.js
+ */
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { Rate, Trend } from "k6/metrics";
+import { randomString } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+
+const errorRate = new Rate("errors");
+const searchDuration = new Trend("search_duration", true);
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:3000";
+
+export const options = {
+  scenarios: {
+    concurrent_search: {
+      executor: "ramping-vus",
+      startVUs: 0,
+      stages: [
+        { duration: "30s", target: 50 },
+        { duration: "4m", target: 50 },
+        { duration: "30s", target: 0 },
+      ],
+    },
+  },
+  thresholds: {
+    http_req_duration: ["p(95)<200"],
+    errors: ["rate<0.001"],
+  },
+};
+
+const ASSETS = ["USDC", "USDT", "XLM"];
+const STATUSES = ["pending", "completed", "failed"];
+
+function randomSearchParams() {
+  const params = new URLSearchParams();
+  // Randomly include different search dimensions.
+  if (Math.random() > 0.5) {
+    params.set("asset_code", ASSETS[Math.floor(Math.random() * ASSETS.length)]);
+  }
+  if (Math.random() > 0.5) {
+    params.set("status", STATUSES[Math.floor(Math.random() * STATUSES.length)]);
+  }
+  if (Math.random() > 0.7) {
+    params.set("memo", randomString(6));
+  }
+  params.set("limit", String(Math.floor(Math.random() * 50) + 10));
+  return params.toString();
+}
+
+export default function () {
+  const qs = randomSearchParams();
+  const url = `${BASE_URL}/transactions/search?${qs}`;
+
+  const params = {
+    headers: {
+      "X-API-Key": __ENV.API_KEY || "load-test-key",
+    },
+    timeout: "10s",
+  };
+
+  const res = http.get(url, params);
+
+  const ok = check(res, {
+    "status is 200": (r) => r.status === 200,
+    "response is array": (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body) || Array.isArray(body.data);
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  errorRate.add(!ok);
+  searchDuration.add(res.timings.duration);
+
+  sleep(0.05); // slight think-time to model realistic search cadence
+}
+
+export function handleSummary(data) {
+  return {
+    "/results/search_load_summary.html": htmlReport(data),
+    stdout: textSummary(data),
+  };
+}
+
+function htmlReport(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const p99 = data.metrics.http_req_duration?.values?.["p(99)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  const reqs = data.metrics.http_reqs?.values?.count ?? 0;
+  return `<!DOCTYPE html><html><head><title>Search Load Test</title></head><body>
+<h1>Search Load Test Results</h1>
+<table border="1" cellpadding="6">
+  <tr><th>Metric</th><th>Value</th><th>Threshold</th><th>Pass</th></tr>
+  <tr><td>p95 latency</td><td>${p95}ms</td><td>&lt;200ms</td><td>${p95 < 200 ? "✅" : "❌"}</td></tr>
+  <tr><td>p99 latency</td><td>${p99}ms</td><td>—</td><td>—</td></tr>
+  <tr><td>Error rate</td><td>${errRate}%</td><td>&lt;0.1%</td><td>${errRate < 0.1 ? "✅" : "❌"}</td></tr>
+  <tr><td>Total requests</td><td>${reqs}</td><td>—</td><td>—</td></tr>
+</table></body></html>`;
+}
+
+function textSummary(data) {
+  const p95 = data.metrics.http_req_duration?.values?.["p(95)"] ?? "N/A";
+  const errRate = ((data.metrics.errors?.values?.rate ?? 0) * 100).toFixed(3);
+  return `\n=== Search Load Test ===\np95 latency : ${p95}ms (threshold: <200ms)\nError rate  : ${errRate}% (threshold: <0.1%)\n`;
+}


### PR DESCRIPTION
- #254: Wire QuotaManager middleware into callback and webhook routes with per-tenant limits from tenants.rate_limit_per_minute, 100 req/min default for unauthenticated requests, 429 with Retry-After and X-RateLimit-* headers, admin routes excluded

- #256: Configure tower-http CORS via CORS_ALLOWED_ORIGINS env var (comma-separated), allow_credentials for admin endpoints, max_age=3600, defaults to same-origin only when env var is unset

- #257: Implement secrets rotation without downtime using double-buffered RotatingSecret and SecretsStore; SecretsManager polls Vault every 5min, old secret valid for 5min grace period; admin_auth accepts all valid keys; rotation events logged without exposing secret values

- #267: Add k6 load test scripts (callback_load.js, search_load.js, mixed_load.js) with p95<200ms and error rate<0.1% thresholds, HTML report output, and updated load-test-results.md with run instructions

Closes #254
Closes #256
Closes #257
Closes #267