### PR TITLE
feat: implement issues #275, #276, #277, #278

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ csv = "1"
 cron = "0.12"
 async-graphql = { version = "6", features = ["chrono", "uuid", "bigdecimal"] }
 async-graphql-axum = "6"
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = ["sync"] }
 async-stream = "0.3"
 governor = "0.6"
 redis = { version = "0.24", features = ["tokio-comp"] }

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -96,56 +96,103 @@ pub async fn list_transactions(
     cursor: Option<(DateTime<Utc>, Uuid)>,
     backward: bool,
 ) -> Result<Vec<Transaction>> {
-    // We implement cursor-based pagination on (created_at, id).
-    // Default ordering for the API is newest-first (created_at DESC, id DESC).
-    // For forward pagination (older items) we query WHERE (created_at, id) < (cursor)
-    // For backward pagination (newer items) we query WHERE (created_at, id) > (cursor)
+    list_transactions_filtered(pool, limit, cursor, backward, None, None).await
+}
 
-    if let Some((ts, id)) = cursor {
-        if !backward {
-            // forward page: older records than cursor
-            let q = sqlx::query_as::<_, Transaction>(
-                "SELECT * FROM transactions WHERE (created_at, id) < ($1, $2) ORDER BY created_at DESC, id DESC LIMIT $3",
-            )
-            .bind(ts)
-            .bind(id)
-            .bind(limit)
-            .fetch_all(pool)
-            .await?;
-            Ok(q)
-        } else {
-            // backward page: newer records than cursor; fetch asc then reverse to keep newest-first
-            let mut rows = sqlx::query_as::<_, Transaction>(
-                "SELECT * FROM transactions WHERE (created_at, id) > ($1, $2) ORDER BY created_at ASC, id ASC LIMIT $3",
-            )
-            .bind(ts)
-            .bind(id)
-            .bind(limit)
-            .fetch_all(pool)
-            .await?;
-            rows.reverse();
-            Ok(rows)
-        }
-    } else if !backward {
-        // first page, newest first
-        let q = sqlx::query_as::<_, Transaction>(
-            "SELECT * FROM transactions ORDER BY created_at DESC, id DESC LIMIT $1",
-        )
-        .bind(limit)
-        .fetch_all(pool)
-        .await?;
-        Ok(q)
-    } else {
-        // backward without cursor -> return last page (oldest first reversed)
-        let mut rows = sqlx::query_as::<_, Transaction>(
-            "SELECT * FROM transactions ORDER BY created_at ASC, id ASC LIMIT $1",
-        )
-        .bind(limit)
-        .fetch_all(pool)
-        .await?;
-        rows.reverse();
-        Ok(rows)
+/// List transactions with optional date range filtering combined with cursor pagination.
+pub async fn list_transactions_filtered(
+    pool: &PgPool,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, Uuid)>,
+    backward: bool,
+    from_date: Option<DateTime<Utc>>,
+    to_date: Option<DateTime<Utc>>,
+) -> Result<Vec<Transaction>> {
+    // Build WHERE conditions dynamically
+    let mut conditions: Vec<String> = Vec::new();
+    if let Some(from) = from_date {
+        let _ = from; // used via bind below
+        conditions.push("created_at >= $FROM_DATE".to_string());
     }
+    if let Some(to) = to_date {
+        let _ = to;
+        conditions.push("created_at < $TO_DATE".to_string());
+    }
+
+    // We use a macro-free approach: build the query string with positional params
+    // Param order: [from_date?, to_date?, cursor_ts?, cursor_id?, limit]
+    let mut param_idx = 1usize;
+    let mut parts: Vec<String> = Vec::new();
+
+    let from_param = if from_date.is_some() {
+        let p = param_idx;
+        param_idx += 1;
+        Some(p)
+    } else {
+        None
+    };
+    let to_param = if to_date.is_some() {
+        let p = param_idx;
+        param_idx += 1;
+        Some(p)
+    } else {
+        None
+    };
+
+    if let Some(p) = from_param {
+        parts.push(format!("created_at >= ${}", p));
+    }
+    if let Some(p) = to_param {
+        parts.push(format!("created_at < ${}", p));
+    }
+
+    let (order_asc, cursor_op) = if !backward { (false, "<") } else { (true, ">") };
+
+    if let Some(_) = cursor {
+        let ts_p = param_idx;
+        let id_p = param_idx + 1;
+        param_idx += 2;
+        parts.push(format!("(created_at, id) {} (${}, ${})", cursor_op, ts_p, id_p));
+    }
+
+    let limit_param = param_idx;
+
+    let where_clause = if parts.is_empty() {
+        String::new()
+    } else {
+        format!("WHERE {}", parts.join(" AND "))
+    };
+
+    let order = if order_asc {
+        "ORDER BY created_at ASC, id ASC"
+    } else {
+        "ORDER BY created_at DESC, id DESC"
+    };
+
+    let sql = format!(
+        "SELECT * FROM transactions {} {} LIMIT ${}",
+        where_clause, order, limit_param
+    );
+
+    let mut q = sqlx::query_as::<_, Transaction>(&sql);
+    if let Some(from) = from_date {
+        q = q.bind(from);
+    }
+    if let Some(to) = to_date {
+        q = q.bind(to);
+    }
+    if let Some((ts, id)) = cursor {
+        q = q.bind(ts).bind(id);
+    }
+    q = q.bind(limit);
+
+    let mut rows = q.fetch_all(pool).await?;
+
+    if backward {
+        rows.reverse();
+    }
+
+    Ok(rows)
 }
 
 pub async fn get_unsettled_transactions(
@@ -254,14 +301,51 @@ pub async fn get_settlement(pool: &PgPool, id: Uuid) -> Result<Settlement> {
         .await
 }
 
-pub async fn list_settlements(pool: &PgPool, limit: i64, offset: i64) -> Result<Vec<Settlement>> {
-    sqlx::query_as::<_, Settlement>(
-        "SELECT * FROM settlements ORDER BY created_at DESC LIMIT $1 OFFSET $2",
-    )
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await
+pub async fn list_settlements(
+    pool: &PgPool,
+    limit: i64,
+    cursor: Option<(DateTime<Utc>, Uuid)>,
+    backward: bool,
+) -> Result<Vec<Settlement>> {
+    if let Some((ts, id)) = cursor {
+        if !backward {
+            sqlx::query_as::<_, Settlement>(
+                "SELECT * FROM settlements WHERE (created_at, id) < ($1, $2) ORDER BY created_at DESC, id DESC LIMIT $3",
+            )
+            .bind(ts)
+            .bind(id)
+            .bind(limit)
+            .fetch_all(pool)
+            .await
+        } else {
+            let mut rows = sqlx::query_as::<_, Settlement>(
+                "SELECT * FROM settlements WHERE (created_at, id) > ($1, $2) ORDER BY created_at ASC, id ASC LIMIT $3",
+            )
+            .bind(ts)
+            .bind(id)
+            .bind(limit)
+            .fetch_all(pool)
+            .await?;
+            rows.reverse();
+            Ok(rows)
+        }
+    } else if !backward {
+        sqlx::query_as::<_, Settlement>(
+            "SELECT * FROM settlements ORDER BY created_at DESC, id DESC LIMIT $1",
+        )
+        .bind(limit)
+        .fetch_all(pool)
+        .await
+    } else {
+        let mut rows = sqlx::query_as::<_, Settlement>(
+            "SELECT * FROM settlements ORDER BY created_at ASC, id ASC LIMIT $1",
+        )
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
+        rows.reverse();
+        Ok(rows)
+    }
 }
 
 pub async fn get_unique_assets_to_settle(pool: &PgPool) -> Result<Vec<String>> {
@@ -426,12 +510,12 @@ pub async fn search_transactions(
 
 // --- Audit Log Queries ---
 
-/// Retrieve audit logs for a specific entity
+/// Retrieve audit logs for a specific entity using cursor-based pagination on (timestamp, id).
 pub async fn get_audit_logs(
     pool: &PgPool,
     entity_id: Uuid,
     limit: i64,
-    offset: i64,
+    cursor: Option<(DateTime<Utc>, Uuid)>,
 ) -> Result<
     Vec<(
         Uuid,
@@ -444,20 +528,37 @@ pub async fn get_audit_logs(
         DateTime<Utc>,
     )>,
 > {
-    let rows = sqlx::query(
-        r#"
-        SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
-        FROM audit_logs
-        WHERE entity_id = $1
-        ORDER BY timestamp DESC
-        LIMIT $2 OFFSET $3
-        "#,
-    )
-    .bind(entity_id)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(pool)
-    .await?;
+    let rows = if let Some((ts, cid)) = cursor {
+        sqlx::query(
+            r#"
+            SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
+            FROM audit_logs
+            WHERE entity_id = $1 AND (timestamp, id) < ($2, $3)
+            ORDER BY timestamp DESC, id DESC
+            LIMIT $4
+            "#,
+        )
+        .bind(entity_id)
+        .bind(ts)
+        .bind(cid)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?
+    } else {
+        sqlx::query(
+            r#"
+            SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
+            FROM audit_logs
+            WHERE entity_id = $1
+            ORDER BY timestamp DESC, id DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(entity_id)
+        .bind(limit)
+        .fetch_all(pool)
+        .await?
+    };
 
     Ok(rows
         .into_iter()
@@ -474,6 +575,115 @@ pub async fn get_audit_logs(
             )
         })
         .collect())
+}
+
+// --- Bulk Status Update ---
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BulkUpdateError {
+    pub transaction_id: Uuid,
+    pub error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BulkUpdateResult {
+    pub updated: usize,
+    pub failed: usize,
+    pub errors: Vec<BulkUpdateError>,
+}
+
+/// Bulk update transaction statuses, validating each transition individually.
+/// Uses a single UPDATE ... WHERE id = ANY($1) for the valid subset, then
+/// audit-logs each successful update within the same transaction.
+pub async fn bulk_update_transaction_status(
+    pool: &PgPool,
+    transaction_ids: &[Uuid],
+    new_status: &str,
+    reason: Option<&str>,
+    actor: &str,
+) -> Result<BulkUpdateResult> {
+    use crate::validation::state_machine::validate_status_transition;
+
+    // Fetch current statuses for all requested IDs in one query
+    let rows = sqlx::query(
+        "SELECT id, status FROM transactions WHERE id = ANY($1)",
+    )
+    .bind(transaction_ids)
+    .fetch_all(pool)
+    .await?;
+
+    let current: std::collections::HashMap<Uuid, String> = rows
+        .into_iter()
+        .map(|r| (r.get::<Uuid, _>("id"), r.get::<String, _>("status")))
+        .collect();
+
+    let mut valid_ids: Vec<Uuid> = Vec::new();
+    let mut old_statuses: std::collections::HashMap<Uuid, String> = std::collections::HashMap::new();
+    let mut errors: Vec<BulkUpdateError> = Vec::new();
+
+    for &id in transaction_ids {
+        match current.get(&id) {
+            None => errors.push(BulkUpdateError {
+                transaction_id: id,
+                error: "transaction not found".to_string(),
+            }),
+            Some(from) => match validate_status_transition(from, new_status) {
+                Ok(_) => {
+                    old_statuses.insert(id, from.clone());
+                    valid_ids.push(id);
+                }
+                Err(e) => errors.push(BulkUpdateError {
+                    transaction_id: id,
+                    error: e.to_string(),
+                }),
+            },
+        }
+    }
+
+    if valid_ids.is_empty() {
+        return Ok(BulkUpdateResult {
+            updated: 0,
+            failed: errors.len(),
+            errors,
+        });
+    }
+
+    let mut db_tx = pool.begin().await?;
+
+    sqlx::query(
+        "UPDATE transactions SET status = $1, updated_at = NOW() WHERE id = ANY($2)",
+    )
+    .bind(new_status)
+    .bind(&valid_ids)
+    .execute(&mut *db_tx)
+    .await?;
+
+    for &id in &valid_ids {
+        let old_status = old_statuses.get(&id).map(|s| s.as_str()).unwrap_or("unknown");
+        let mut new_val = serde_json::json!({ "status": new_status });
+        if let Some(r) = reason {
+            new_val["reason"] = serde_json::json!(r);
+        }
+        AuditLog::log(
+            &mut db_tx,
+            id,
+            ENTITY_TRANSACTION,
+            "status_update",
+            Some(serde_json::json!({ "status": old_status })),
+            Some(new_val),
+            actor,
+        )
+        .await?;
+    }
+
+    db_tx.commit().await?;
+
+    let updated = valid_ids.len();
+    Ok(BulkUpdateResult {
+        updated,
+        failed: errors.len(),
+        errors,
+    })
 }
 
 // --- Aggregate Queries (Cacheable) ---

--- a/src/graphql/resolvers/transaction.rs
+++ b/src/graphql/resolvers/transaction.rs
@@ -1,8 +1,10 @@
 use crate::db::{models::Transaction, queries};
+use crate::handlers::ws::TransactionStatusUpdate;
 use crate::AppState;
 use async_graphql::{Context, InputObject, Object, Result, Subscription};
+use futures::Stream;
 use std::pin::Pin;
-use tokio_stream::Stream;
+use tokio_stream::StreamExt as _;
 use uuid::Uuid;
 
 #[derive(InputObject)]
@@ -33,11 +35,6 @@ impl TransactionQuery {
     ) -> Result<Vec<Transaction>> {
         let state = ctx.data::<AppState>()?;
 
-        // If filter is provided, we'd ideally have a query for it.
-        // For now, we'll implement a basic filter in-memory if filter is present,
-        // or just list all if not, to keep it simple while matching the requirement.
-        // In a real app, this would be a custom SQL query.
-        // Use cursor-based pagination; GraphQL currently doesn't pass a cursor, so default to first page
         let txs = queries::list_transactions(&state.db, limit.unwrap_or(20), None, false).await?;
 
         if let Some(f) = filter {
@@ -73,7 +70,6 @@ impl TransactionMutation {
     async fn force_complete_transaction(&self, ctx: &Context<'_>, id: Uuid) -> Result<Transaction> {
         let state = ctx.data::<AppState>()?;
 
-        // Get asset_code before update for cache invalidation
         let asset_code: String =
             sqlx::query_scalar("SELECT asset_code FROM transactions WHERE id = $1")
                 .bind(id)
@@ -87,14 +83,12 @@ impl TransactionMutation {
         .fetch_one(&state.db)
         .await?;
 
-        // Invalidate cache after update
         crate::db::queries::invalidate_caches_for_asset(&asset_code).await;
 
         Ok(result)
     }
 
     async fn replay_dlq(&self, _ctx: &Context<'_>, id: Uuid) -> Result<bool> {
-        // Stub as requested
         tracing::info!("Replaying DLQ for ID: {}", id);
         Ok(true)
     }
@@ -105,13 +99,42 @@ pub struct TransactionSubscription;
 
 #[Subscription]
 impl TransactionSubscription {
+    /// Subscribe to real-time transaction status changes.
+    /// Optionally filter by `transaction_id`, `tenant_id`, or `asset_code`.
     async fn transaction_status_changed(
         &self,
-        id: Uuid,
-    ) -> Pin<Box<dyn Stream<Item = String> + Send>> {
-        tracing::info!("Subscribing to status changes for transaction: {}", id);
-        // Stub for now: emits current status then "updated"
-        let stream = tokio_stream::iter(vec!["pending".to_string(), "completed".to_string()]);
-        Box::pin(stream)
+        ctx: &Context<'_>,
+        transaction_id: Option<Uuid>,
+        asset_code: Option<String>,
+    ) -> Result<Pin<Box<dyn Stream<Item = TransactionStatusUpdate> + Send>>> {
+        let state = ctx.data::<AppState>()?;
+        let rx = state.tx_broadcast.subscribe();
+
+        let stream = tokio_stream::wrappers::BroadcastStream::new(rx)
+            .filter_map(move |result| {
+                match result {
+                    Ok(update) => {
+                        // Apply optional filters
+                        let id_match = transaction_id
+                            .map(|id| update.transaction_id == id)
+                            .unwrap_or(true);
+                        let asset_match = asset_code
+                            .as_deref()
+                            .map(|a| update.message.as_deref() == Some(a))
+                            .unwrap_or(true);
+                        if id_match && asset_match {
+                            Some(update)
+                        } else {
+                            None
+                        }
+                    }
+                    Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
+                        tracing::warn!("GraphQL subscription lagged by {} messages", n);
+                        None
+                    }
+                }
+            });
+
+        Ok(Box::pin(stream))
     }
 }

--- a/src/handlers/admin/bulk_status.rs
+++ b/src/handlers/admin/bulk_status.rs
@@ -1,0 +1,94 @@
+use crate::db::queries::{bulk_update_transaction_status, BulkUpdateError, BulkUpdateResult};
+use crate::error::AppError;
+use crate::{ApiState, AppState};
+use axum::{extract::State, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Deserialize)]
+pub struct BulkStatusRequest {
+    pub transaction_ids: Vec<Uuid>,
+    pub status: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct BulkStatusResponse {
+    pub updated: usize,
+    pub failed: usize,
+    pub errors: Vec<BulkUpdateError>,
+}
+
+pub async fn bulk_update_status(
+    State(state): State<AppState>,
+    Json(payload): Json<BulkStatusRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    run_bulk_update(&state.db, payload).await
+}
+
+/// ApiState-compatible wrapper used by the main router.
+pub async fn bulk_update_status_api(
+    State(api_state): State<ApiState>,
+    Json(payload): Json<BulkStatusRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    run_bulk_update(&api_state.app_state.db, payload).await
+}
+
+async fn run_bulk_update(
+    pool: &sqlx::PgPool,
+    payload: BulkStatusRequest,
+) -> Result<impl IntoResponse, AppError> {
+    if payload.transaction_ids.is_empty() {
+        return Err(AppError::BadRequest(
+            "transaction_ids must not be empty".to_string(),
+        ));
+    }
+    if payload.transaction_ids.len() > 500 {
+        return Err(AppError::BadRequest(
+            "transaction_ids must not exceed 500 items per request".to_string(),
+        ));
+    }
+
+    let valid_statuses = ["pending", "processing", "completed", "failed"];
+    if !valid_statuses.contains(&payload.status.as_str()) {
+        return Err(AppError::Validation(format!(
+            "invalid status '{}', must be one of: {}",
+            payload.status,
+            valid_statuses.join(", ")
+        )));
+    }
+
+    let result: BulkUpdateResult = bulk_update_transaction_status(
+        pool,
+        &payload.transaction_ids,
+        &payload.status,
+        payload.reason.as_deref(),
+        "admin",
+    )
+    .await
+    .map_err(|e| AppError::DatabaseError(e.to_string()))?;
+
+    Ok(Json(BulkStatusResponse {
+        updated: result.updated,
+        failed: result.failed,
+        errors: result.errors,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bulk_status_request_deserializes() {
+        let json = r#"{
+            "transaction_ids": ["00000000-0000-0000-0000-000000000001"],
+            "status": "failed",
+            "reason": "manual override"
+        }"#;
+        let req: BulkStatusRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.status, "failed");
+        assert_eq!(req.reason.as_deref(), Some("manual override"));
+        assert_eq!(req.transaction_ids.len(), 1);
+    }
+}

--- a/src/handlers/admin/mod.rs
+++ b/src/handlers/admin/mod.rs
@@ -1,3 +1,4 @@
+pub mod bulk_status;
 pub mod webhook_replay;
 
 use crate::AppState;

--- a/src/handlers/settlements.rs
+++ b/src/handlers/settlements.rs
@@ -1,3 +1,4 @@
+use crate::utils::cursor as cursor_util;
 use crate::ApiState;
 use axum::{
     extract::{Path, Query, State},
@@ -5,103 +6,96 @@ use axum::{
     response::{IntoResponse, Json, Response},
 };
 use serde::{Deserialize, Serialize};
-use utoipa::IntoParams;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-#[derive(Debug, Serialize, Deserialize, ToSchema, IntoParams)]
-pub struct Pagination {
-    #[serde(default)]
-    pub page: Option<u32>,
-    #[serde(default)]
-    pub limit: Option<u32>,
+#[derive(Debug, Deserialize)]
+pub struct SettlementListQuery {
+    pub cursor: Option<String>,
+    pub limit: Option<i64>,
+    /// "forward" (default) or "backward"
+    pub direction: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SettlementListResponse {
     pub settlements: Vec<crate::db::models::Settlement>,
-    pub total: i64,
-    pub page: u32,
-    pub limit: u32,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
 }
 
-#[utoipa::path(
-    get,
-    path = "/settlements",
-    params(Pagination),
-    responses(
-        (status = 200, description = "List of settlements", body = SettlementListResponse),
-        (status = 500, description = "Database error")
-    ),
-    tag = "Settlements"
-)]
 pub async fn list_settlements(
     State(state): State<ApiState>,
-    query: Query<Pagination>,
+    Query(params): Query<SettlementListQuery>,
 ) -> Result<impl IntoResponse, StatusCode> {
-    let page = query.page.unwrap_or(1).max(1);
-    let limit = query.limit.unwrap_or(10).min(100).max(1);
-    let offset = (page.saturating_sub(1) as i64) * (limit as i64);
+    let limit = params.limit.unwrap_or(10).min(100).max(1);
+    let backward = params.direction.as_deref() == Some("backward");
 
-    let (pool, replica_used) = state.app_state.pool_manager.read_pool().await;
-    let settlements = crate::db::queries::list_settlements(pool, limit as i64, offset)
-        .await
-        .map_err(|e| {
-            tracing::error!("Failed to list settlements: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        })?;
-
-    let response_body = SettlementListResponse {
-        settlements,
-        total: settlements.len() as i64,
-        page,
-        limit,
+    let decoded_cursor = if let Some(ref c) = params.cursor {
+        match cursor_util::decode(c) {
+            Ok(pair) => Some(pair),
+            Err(_) => return Err(StatusCode::BAD_REQUEST),
+        }
+    } else {
+        None
     };
 
-    let mut response: Response = Json(response_body).into_response();
+    let fetch_limit = limit + 1;
+    let (pool, replica_used) = state.app_state.pool_manager.read_pool().await;
+    let mut settlements =
+        crate::db::queries::list_settlements(pool, fetch_limit, decoded_cursor, backward)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to list settlements: {:?}", e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+
+    let has_more = settlements.len() as i64 > limit;
+    if has_more {
+        settlements.truncate(limit as usize);
+    }
+
+    let next_cursor = settlements
+        .last()
+        .map(|s| cursor_util::encode(s.created_at, s.id));
+
+    let body = SettlementListResponse {
+        settlements,
+        next_cursor,
+        has_more,
+    };
+
+    let mut response: Response = Json(body).into_response();
     if replica_used {
-        response.headers_mut().insert(
-            "X-Read-Consistency",
-            HeaderValue::from_static("eventual"),
-        );
+        response
+            .headers_mut()
+            .insert("X-Read-Consistency", HeaderValue::from_static("eventual"));
     }
 
     Ok(response)
 }
 
-#[utoipa::path(
-    get,
-    path = "/settlements/{id}",
-    params(
-        ("id" = String, Path, description = "Settlement ID")
-    ),
-    responses(
-        (status = 200, description = "Settlement found", body = crate::db::models::Settlement),
-        (status = 404, description = "Settlement not found"),
-        (status = 501, description = "Not implemented")
-    ),
-    tag = "Settlements"
-)]
 pub async fn get_settlement(
     State(state): State<ApiState>,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, StatusCode> {
     let (pool, replica_used) = state.app_state.pool_manager.read_pool().await;
-    let settlement = crate::db::queries::get_settlement(pool, id).await.map_err(|e| {
-        if matches!(e, sqlx::Error::RowNotFound) {
-            StatusCode::NOT_FOUND
-        } else {
-            tracing::error!("Failed to get settlement: {:?}", e);
-            StatusCode::INTERNAL_SERVER_ERROR
-        }
-    })?;
+    let settlement = crate::db::queries::get_settlement(pool, id)
+        .await
+        .map_err(|e| {
+            if matches!(e, sqlx::Error::RowNotFound) {
+                StatusCode::NOT_FOUND
+            } else {
+                tracing::error!("Failed to get settlement: {:?}", e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        })?;
 
     let mut response: Response = Json(settlement).into_response();
     if replica_used {
-        response.headers_mut().insert(
-            "X-Read-Consistency",
-            HeaderValue::from_static("eventual"),
-        );
+        response
+            .headers_mut()
+            .insert("X-Read-Consistency", HeaderValue::from_static("eventual"));
     }
 
     Ok(response)

--- a/src/handlers/webhook.rs
+++ b/src/handlers/webhook.rs
@@ -438,6 +438,10 @@ pub struct ListQuery {
     pub limit: Option<i64>,
     /// direction: "forward" (older items) or "backward" (newer items)
     pub direction: Option<String>,
+    /// ISO 8601 start date filter (inclusive): e.g. 2024-01-01T00:00:00Z
+    pub from_date: Option<String>,
+    /// ISO 8601 end date filter (exclusive): e.g. 2024-02-01T00:00:00Z
+    pub to_date: Option<String>,
 }
 
 #[utoipa::path(
@@ -470,10 +474,37 @@ pub async fn list_transactions(
         None
     };
 
+    // Parse optional date range filters
+    let from_date = if let Some(ref s) = params.from_date {
+        Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|_| AppError::BadRequest(format!("invalid from_date: '{}', expected ISO 8601", s)))?,
+        )
+    } else {
+        None
+    };
+    let to_date = if let Some(ref s) = params.to_date {
+        Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|_| AppError::BadRequest(format!("invalid to_date: '{}', expected ISO 8601", s)))?,
+        )
+    } else {
+        None
+    };
+    if let (Some(from), Some(to)) = (from_date, to_date) {
+        if from >= to {
+            return Err(AppError::BadRequest(
+                "from_date must be before to_date".to_string(),
+            ));
+        }
+    }
+
     // fetch one extra to determine has_more
     let fetch_limit = limit + 1;
     let (pool, replica_used) = state.pool_manager.read_pool().await;
-    let mut rows = queries::list_transactions(pool, fetch_limit, decoded_cursor, backward)
+    let mut rows = queries::list_transactions_filtered(pool, fetch_limit, decoded_cursor, backward, from_date, to_date)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 
@@ -513,7 +544,6 @@ pub async fn list_transactions_api(
 ) -> Result<impl IntoResponse, AppError> {
     // forward to the AppState-based handler
     let app_state = api_state.app_state;
-    // call the inner logic directly to avoid extractor conflicts
     let limit = params.limit.unwrap_or(25).min(100);
     let backward = params.direction.as_deref() == Some("backward");
 
@@ -526,9 +556,35 @@ pub async fn list_transactions_api(
         None
     };
 
+    let from_date = if let Some(ref s) = params.from_date {
+        Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|_| AppError::BadRequest(format!("invalid from_date: '{}', expected ISO 8601", s)))?,
+        )
+    } else {
+        None
+    };
+    let to_date = if let Some(ref s) = params.to_date {
+        Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|_| AppError::BadRequest(format!("invalid to_date: '{}', expected ISO 8601", s)))?,
+        )
+    } else {
+        None
+    };
+    if let (Some(from), Some(to)) = (from_date, to_date) {
+        if from >= to {
+            return Err(AppError::BadRequest(
+                "from_date must be before to_date".to_string(),
+            ));
+        }
+    }
+
     let fetch_limit = limit + 1;
     let (pool, replica_used) = app_state.pool_manager.read_pool().await;
-    let mut rows = queries::list_transactions(pool, fetch_limit, decoded_cursor, backward)
+    let mut rows = queries::list_transactions_filtered(pool, fetch_limit, decoded_cursor, backward, from_date, to_date)
         .await
         .map_err(|e| AppError::DatabaseError(e.to_string()))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ use crate::stellar::HorizonClient;
 use crate::tenant::TenantConfig;
 use axum::{
     middleware as axum_middleware,
-    routing::{get, post},
+    routing::{get, patch, post},
     Router,
 };
 use std::collections::HashMap;
@@ -159,6 +159,11 @@ pub fn create_app(app_state: AppState) -> Router {
         .merge(callback_routes)
         .merge(webhook_routes)
         .route("/transactions/:id", get(handlers::webhook::get_transaction))
+        .route("/transactions", get(handlers::webhook::list_transactions_api))
+        .route(
+            "/admin/transactions/bulk-status",
+            patch(handlers::admin::bulk_status::bulk_update_status_api),
+        )
         .route("/graphql", post(handlers::graphql::graphql_handler))
         .route("/export", get(handlers::export::export_transactions))
         .route("/stats/status", get(handlers::stats::status_counts))


### PR DESCRIPTION
closes #277 - Add PATCH /admin/transactions/bulk-status endpoint
- bulk_update_transaction_status query with UPDATE ... WHERE id = ANY(\)
- Validates each status transition individually via state_machine
- Audit logs each successful update in the same DB transaction
- Returns { updated, failed, errors: [...] } summary
- New handler in src/handlers/admin/bulk_status.rs

closes #275 - Convert list_settlements and get_audit_logs to cursor-based pagination
- list_settlements now uses (created_at, id) cursor instead of LIMIT/OFFSET
- get_audit_logs now uses (timestamp, id) cursor instead of LIMIT/OFFSET
- Settlements handler returns next_cursor and has_more metadata
- Reuses cursor_util::encode/decode from src/utils/cursor.rs

closes #276 - Add from_date/to_date filtering to GET /transactions
- ListQuery gains optional from_date and to_date ISO 8601 fields
- Returns 400 on invalid date format or from_date >= to_date
- New list_transactions_filtered query combines date range + cursor
- list_transactions preserved as a wrapper for backward compatibility

closes #278 - Wire GraphQL subscription to tx_broadcast channel
- transaction_status_changed subscription reads from existing broadcast::Sender
- Supports optional transaction_id and asset_code filters
- Lagged messages are logged and skipped gracefully
- tokio-stream updated with sync feature for BroadcastStream