### PR TITLE
chore(ci/cd): optimize connection pooling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,12 +17,13 @@ env:
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 1G
   COVERAGE_IGNORE_REGEX: '(^|.*/)(tests?/.*|generated/.*|\.sqlx/.*)$'
-
-# Cancel in-progress runs for the same branch/PR to avoid wasted runner time
-# and stale session state from concurrent jobs sharing the same cache keys.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # CI pool sizing: keep connections low to match the single-node test DB.
+  # These are picked up by Config::load() via DB_MIN_CONNECTIONS / DB_MAX_CONNECTIONS.
+  DB_MIN_CONNECTIONS: "2"
+  DB_MAX_CONNECTIONS: "10"
+  DB_IDLE_TIMEOUT_SECS: "30"
+  DB_STATEMENT_TIMEOUT_MS: "30000"
+  DB_LONG_RUNNING_STATEMENT_TIMEOUT_MS: "120000"
 
 jobs:
   unit-tests:
@@ -98,14 +99,6 @@ jobs:
 
     - name: Run migrations
       id: run_migrations
-      run: |
-        set -e
-        echo "Starting database migrations..."
-        if ! sqlx migrate run; then
-          echo "::error::Migration failed. Check migration files for errors."
-          exit 1
-        fi
-        echo "Migrations completed successfully"
       run: |
         for i in 1 2 3; do
           sqlx migrate run && break
@@ -234,6 +227,9 @@ jobs:
     - name: Install sccache
       uses: taiki-e/install-action@sccache
 
+    - name: Start sccache session
+      run: sccache --start-server || true
+
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v4
       with:
@@ -333,6 +329,9 @@ jobs:
 
     - name: Install sccache
       uses: taiki-e/install-action@sccache
+
+    - name: Start sccache session
+      run: sccache --start-server || true
 
     - name: Cache Cargo registry and build artifacts
       uses: actions/cache@v4

--- a/src/db/pool_manager.rs
+++ b/src/db/pool_manager.rs
@@ -1,5 +1,5 @@
 use sqlx::{postgres::PgPoolOptions, PgPool};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
@@ -17,19 +17,15 @@ struct FailoverState {
 }
 
 impl PoolManager {
-    pub async fn new(primary_url: &str, replica_url: Option<&str>) -> Result<Self, sqlx::Error> {
-        let primary = PgPoolOptions::new()
-            .max_connections(10)
-            .connect(primary_url)
-            .await?;
+    pub async fn new(
+        primary_url: &str,
+        replica_url: Option<&str>,
+        max_connections: u32,
+    ) -> Result<Self, sqlx::Error> {
+        let primary = build_pool(primary_url, max_connections).await?;
 
         let replica = if let Some(url) = replica_url {
-            Some(
-                PgPoolOptions::new()
-                    .max_connections(10)
-                    .connect(url)
-                    .await?,
-            )
+            Some(build_pool(url, max_connections).await?)
         } else {
             None
         };
@@ -72,4 +68,15 @@ impl PoolManager {
     pub async fn get_write_pool(&self) -> &PgPool {
         &self.primary
     }
+}
+
+fn build_pool(
+    url: &str,
+    max_connections: u32,
+) -> impl std::future::Future<Output = Result<PgPool, sqlx::Error>> + '_ {
+    PgPoolOptions::new()
+        .max_connections(max_connections)
+        // Fail fast instead of hanging when the pool is exhausted.
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(url)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl AppState {
             AssetCache::start(pool.clone(), std::time::Duration::from_secs(300)).await;
         Self {
             db: pool.clone(),
-            pool_manager: crate::db::pool_manager::PoolManager::new(database_url, None)
+            pool_manager: crate::db::pool_manager::PoolManager::new(database_url, None, 10)
                 .await
                 .unwrap(),
             horizon_client: HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,7 @@ async fn serve(config: config::Config) -> anyhow::Result<()> {
 
     // Initialize pool manager for multi-region failover
     let pool_manager =
-        PoolManager::new(&config.database_url, config.database_replica_url.as_deref()).await?;
+        PoolManager::new(&config.database_url, config.database_replica_url.as_deref(), config.db_max_connections).await?;
 
     if pool_manager.replica().is_some() {
         tracing::info!("Database replica configured - read queries will be routed to replica");

--- a/tests/api_versioning_test.rs
+++ b/tests/api_versioning_test.rs
@@ -35,7 +35,7 @@ async fn test_api_versioning_headers() {
     // Start App
     let app_state = AppState {
         db: pool.clone(),
-        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None)
+        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None, 5)
             .await
             .unwrap(),
         horizon_client: synapse_core::stellar::HorizonClient::new(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -58,7 +58,7 @@ impl TestApp {
         let (tx_broadcast, _) = tokio::sync::broadcast::channel(100);
         let app_state = AppState {
             db: pool.clone(),
-            pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None)
+            pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None, 5)
                 .await
                 .unwrap(),
             horizon_client: synapse_core::stellar::HorizonClient::new(

--- a/tests/db_failover_test.rs
+++ b/tests/db_failover_test.rs
@@ -29,7 +29,7 @@ async fn start_db() -> (String, ContainerAsync<Postgres>) {
 async fn test_pool_manager_primary_only() {
     let (url, _container) = start_db().await;
 
-    let pool_manager = PoolManager::new(&url, None)
+    let pool_manager = PoolManager::new(&url, None, 5)
         .await
         .expect("Failed to create pool manager");
 
@@ -51,7 +51,7 @@ async fn test_pool_manager_with_replica() {
 
     let (url, _container) = start_db().await;
 
-    let pool_manager = PoolManager::new(&url, replica_url.as_deref())
+    let pool_manager = PoolManager::new(&url, replica_url.as_deref(), 5)
         .await
         .expect("Failed to create pool manager");
 
@@ -67,7 +67,7 @@ async fn test_pool_manager_with_replica() {
 async fn test_query_routing() {
     let (url, _container) = start_db().await;
 
-    let pool_manager = PoolManager::new(&url, None)
+    let pool_manager = PoolManager::new(&url, None, 5)
         .await
         .expect("Failed to create pool manager");
 
@@ -88,7 +88,7 @@ async fn test_health_check_with_invalid_replica() {
     let (url, _container) = start_db().await;
 
     let result =
-        PoolManager::new(&url, Some("postgres://invalid:invalid@nonexistent:5432/db")).await;
+        PoolManager::new(&url, Some("postgres://invalid:invalid@nonexistent:5432/db"), 5).await;
 
     assert!(result.is_err());
 }

--- a/tests/export_test.rs
+++ b/tests/export_test.rs
@@ -55,7 +55,7 @@ async fn setup_test_app() -> (String, PgPool, impl std::any::Any) {
 
     let app_state = AppState {
         db: pool.clone(),
-        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None)
+        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None, 5)
             .await
             .unwrap(),
         horizon_client: synapse_core::stellar::HorizonClient::new(

--- a/tests/graphql_test.rs
+++ b/tests/graphql_test.rs
@@ -54,7 +54,7 @@ async fn test_graphql_queries() {
     .execute(&pool)
     .await;
 
-    let pool_manager = PoolManager::new(&database_url, None).await.unwrap();
+    let pool_manager = PoolManager::new(&database_url, None, 5).await.unwrap();
     let feature_flags = FeatureFlagService::new(pool.clone());
     let (tx_broadcast, _) = tokio::sync::broadcast::channel(100);
     let readiness = synapse_core::ReadinessState::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -55,7 +55,7 @@ async fn setup_test_app() -> (String, PgPool, impl std::any::Any) {
 
     let app_state = AppState {
         db: pool.clone(),
-        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None)
+        pool_manager: synapse_core::db::pool_manager::PoolManager::new(&database_url, None, 5)
             .await
             .unwrap(),
         horizon_client: synapse_core::stellar::HorizonClient::new(

--- a/tests/search_test.rs
+++ b/tests/search_test.rs
@@ -29,7 +29,7 @@ async fn setup_test_app() -> (String, PgPool, impl std::any::Any) {
     .unwrap();
     migrator.run(&pool).await.unwrap();
 
-    let pool_manager = PoolManager::new(&database_url, None).await.unwrap();
+    let pool_manager = PoolManager::new(&database_url, None, 5).await.unwrap();
     let (tx_broadcast, _) = tokio::sync::broadcast::channel(100);
     let _query_cache = synapse_core::services::QueryCache::new("redis://localhost:6379").unwrap();
 

--- a/tests/websocket_test.rs
+++ b/tests/websocket_test.rs
@@ -35,7 +35,7 @@ async fn setup_test_app() -> (
     .unwrap();
     migrator.run(&pool).await.unwrap();
 
-    let pool_manager = PoolManager::new(&database_url, None).await.unwrap();
+    let pool_manager = PoolManager::new(&database_url, None, 5).await.unwrap();
     let (tx_broadcast, _) = broadcast::channel::<TransactionStatusUpdate>(100);
     let _query_cache = synapse_core::services::QueryCache::new("redis://localhost:6379").unwrap();
 


### PR DESCRIPTION
Closes #443 

- Remove duplicate concurrency block from rust.yml (YAML error)
- Fix duplicate  key in unit-tests migration step
- Add workflow-level DB pool env vars (DB_MIN_CONNECTIONS=2, DB_MAX_CONNECTIONS=10, DB_IDLE_TIMEOUT_SECS=30) so all CI jobs use consistent, single-node-appropriate pool sizing via Config::load()
- Start sccache daemon in integration-tests and coverage jobs (was installed but never started, making RUSTC_WRAPPER=sccache a no-op)
- Accept max_connections param in PoolManager::new instead of hardcoding 10, wiring production to config.db_max_connections
- Add acquire_timeout(5s) to PoolManager pools to fail fast on pool exhaustion instead of hanging
