### PR TITLE
fix(#510,#511,#513,#514): secure webhook handlers, connection pooling…

### DIFF
--- a/src/graphql/error.rs
+++ b/src/graphql/error.rs
@@ -1,0 +1,282 @@
+//! Centralized error handling for the GraphQL module.
+//!
+//! Provides a typed [`GraphQlError`] enum that maps domain errors to structured
+//! [`async_graphql::Error`] values with stable `extensions.code` fields.
+//!
+//! # Design
+//!
+//! - All GraphQL-layer errors carry a stable machine-readable `code` in the
+//!   `extensions` object so clients can branch on error type without parsing
+//!   the human-readable `message`.
+//! - Internal details (database messages, stack traces) are never forwarded to
+//!   the client; they are logged server-side via `tracing`.
+//! - The conversion from [`GraphQlError`] to [`async_graphql::Error`] is
+//!   zero-allocation for the common path: the `message` string is built once
+//!   and the extension map is populated inline.
+//!
+//! # Stable error codes
+//!
+//! | Code | Meaning |
+//! |------|---------|
+//! | `VALIDATION_ERROR` | Input field failed validation |
+//! | `NOT_FOUND` | Requested resource does not exist |
+//! | `AUTHENTICATION_ERROR` | Request lacks valid credentials |
+//! | `AUTHORIZATION_ERROR` | Caller lacks permission for the resource |
+//! | `RATE_LIMITED` | Caller has exceeded the request rate limit |
+//! | `COMPLEXITY_ERROR` | Query exceeds depth / complexity / alias limits |
+//! | `DATABASE_ERROR` | Underlying database operation failed (details redacted) |
+//! | `INTERNAL_ERROR` | Unexpected server error (details redacted) |
+
+use async_graphql::Error as GqlError;
+
+// ---------------------------------------------------------------------------
+// Stable error codes
+// ---------------------------------------------------------------------------
+
+pub const CODE_VALIDATION: &str = "VALIDATION_ERROR";
+pub const CODE_NOT_FOUND: &str = "NOT_FOUND";
+pub const CODE_AUTHENTICATION: &str = "AUTHENTICATION_ERROR";
+pub const CODE_AUTHORIZATION: &str = "AUTHORIZATION_ERROR";
+pub const CODE_RATE_LIMITED: &str = "RATE_LIMITED";
+pub const CODE_COMPLEXITY: &str = "COMPLEXITY_ERROR";
+pub const CODE_DATABASE: &str = "DATABASE_ERROR";
+pub const CODE_INTERNAL: &str = "INTERNAL_ERROR";
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Typed errors produced by GraphQL resolvers and extensions.
+///
+/// Each variant carries only the information that is safe to surface to the
+/// client.  Sensitive details (raw DB errors, internal state) must be logged
+/// before constructing the error and must not be included in the variant payload.
+#[derive(Debug)]
+pub enum GraphQlError {
+    /// An input field failed validation.
+    Validation(String),
+
+    /// The requested resource was not found.
+    NotFound(String),
+
+    /// The request lacks valid authentication credentials.
+    Authentication,
+
+    /// The authenticated caller lacks permission for the requested resource.
+    Authorization,
+
+    /// The caller has exceeded the configured request rate limit.
+    ///
+    /// `retry_after_secs` is a hint to the client; `0` means unknown.
+    RateLimited { retry_after_secs: u64 },
+
+    /// The query exceeds depth, complexity, or alias limits.
+    Complexity(String),
+
+    /// An underlying database operation failed.
+    ///
+    /// The `detail` string must be a generic, non-sensitive description.
+    /// Log the raw error before constructing this variant.
+    Database(String),
+
+    /// An unexpected internal error occurred.
+    ///
+    /// The `detail` string must be a generic, non-sensitive description.
+    /// Log the raw error before constructing this variant.
+    Internal(String),
+}
+
+impl GraphQlError {
+    /// Returns the stable error code for this variant.
+    pub fn code(&self) -> &'static str {
+        match self {
+            GraphQlError::Validation(_) => CODE_VALIDATION,
+            GraphQlError::NotFound(_) => CODE_NOT_FOUND,
+            GraphQlError::Authentication => CODE_AUTHENTICATION,
+            GraphQlError::Authorization => CODE_AUTHORIZATION,
+            GraphQlError::RateLimited { .. } => CODE_RATE_LIMITED,
+            GraphQlError::Complexity(_) => CODE_COMPLEXITY,
+            GraphQlError::Database(_) => CODE_DATABASE,
+            GraphQlError::Internal(_) => CODE_INTERNAL,
+        }
+    }
+
+    /// Converts this error into an [`async_graphql::Error`] with a populated
+    /// `extensions.code` field (and `retryAfter` for rate-limit errors).
+    pub fn into_gql_error(self) -> GqlError {
+        let code = self.code();
+        let message = self.message();
+
+        let mut err = GqlError::new(message);
+        err = err.extend_with(|_, e| e.set("code", code));
+
+        if let GraphQlError::RateLimited { retry_after_secs } = &self {
+            err = err.extend_with(|_, e| e.set("retryAfter", *retry_after_secs));
+        }
+
+        err
+    }
+
+    /// Returns the client-facing error message for this variant.
+    fn message(&self) -> String {
+        match self {
+            GraphQlError::Validation(msg) => msg.clone(),
+            GraphQlError::NotFound(resource) => format!("{} not found", resource),
+            GraphQlError::Authentication => "Authentication required".to_string(),
+            GraphQlError::Authorization => "Access denied to this resource".to_string(),
+            GraphQlError::RateLimited { .. } => {
+                "Too many requests — rate limit exceeded".to_string()
+            }
+            GraphQlError::Complexity(msg) => msg.clone(),
+            GraphQlError::Database(msg) => msg.clone(),
+            GraphQlError::Internal(msg) => msg.clone(),
+        }
+    }
+}
+
+impl From<GraphQlError> for GqlError {
+    fn from(e: GraphQlError) -> Self {
+        e.into_gql_error()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience constructors
+// ---------------------------------------------------------------------------
+
+/// Builds a validation error from a field name and reason.
+pub fn validation_error(field: &str, reason: &str) -> GqlError {
+    GraphQlError::Validation(format!("Invalid '{}': {}", field, reason)).into()
+}
+
+/// Builds a not-found error for a named resource.
+pub fn not_found_error(resource: &str) -> GqlError {
+    GraphQlError::NotFound(resource.to_string()).into()
+}
+
+/// Builds a database error, logging the raw cause server-side.
+///
+/// `raw_cause` is logged at `error` level and is never forwarded to the client.
+pub fn database_error(raw_cause: &dyn std::fmt::Display) -> GqlError {
+    tracing::error!(cause = %raw_cause, "GraphQL resolver: database error");
+    GraphQlError::Database("Database operation failed".to_string()).into()
+}
+
+/// Builds an internal error, logging the raw cause server-side.
+///
+/// `raw_cause` is logged at `error` level and is never forwarded to the client.
+pub fn internal_error(raw_cause: &dyn std::fmt::Display) -> GqlError {
+    tracing::error!(cause = %raw_cause, "GraphQL resolver: internal error");
+    GraphQlError::Internal("An internal error occurred".to_string()).into()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ext_code(err: &GqlError) -> Option<String> {
+        err.extensions
+            .as_ref()
+            .and_then(|e| e.get("code"))
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+    }
+
+    #[test]
+    fn validation_error_has_correct_code() {
+        let err: GqlError = GraphQlError::Validation("bad input".into()).into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_VALIDATION));
+        assert!(err.message.contains("bad input"));
+    }
+
+    #[test]
+    fn not_found_error_has_correct_code() {
+        let err: GqlError = GraphQlError::NotFound("Transaction".into()).into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_NOT_FOUND));
+        assert!(err.message.contains("Transaction"));
+    }
+
+    #[test]
+    fn authentication_error_has_correct_code() {
+        let err: GqlError = GraphQlError::Authentication.into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_AUTHENTICATION));
+    }
+
+    #[test]
+    fn authorization_error_has_correct_code() {
+        let err: GqlError = GraphQlError::Authorization.into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_AUTHORIZATION));
+    }
+
+    #[test]
+    fn rate_limited_error_has_code_and_retry_after() {
+        let err: GqlError = GraphQlError::RateLimited {
+            retry_after_secs: 30,
+        }
+        .into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_RATE_LIMITED));
+        let retry = err
+            .extensions
+            .as_ref()
+            .and_then(|e| e.get("retryAfter"))
+            .and_then(|v| v.as_u64());
+        assert_eq!(retry, Some(30));
+    }
+
+    #[test]
+    fn complexity_error_has_correct_code() {
+        let err: GqlError = GraphQlError::Complexity("too deep".into()).into();
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_COMPLEXITY));
+    }
+
+    #[test]
+    fn database_error_redacts_raw_cause() {
+        let err = database_error(&"password=secret");
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_DATABASE));
+        // Raw cause must not appear in the client-facing message.
+        assert!(!err.message.contains("password"));
+        assert!(!err.message.contains("secret"));
+    }
+
+    #[test]
+    fn internal_error_redacts_raw_cause() {
+        let err = internal_error(&"stack trace: src/lib.rs:42");
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_INTERNAL));
+        assert!(!err.message.contains("stack trace"));
+    }
+
+    #[test]
+    fn validation_convenience_fn_includes_field_and_reason() {
+        let err = validation_error("amount", "must be positive");
+        assert!(err.message.contains("amount"));
+        assert!(err.message.contains("must be positive"));
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_VALIDATION));
+    }
+
+    #[test]
+    fn not_found_convenience_fn() {
+        let err = not_found_error("Settlement");
+        assert!(err.message.contains("Settlement"));
+        assert_eq!(ext_code(&err).as_deref(), Some(CODE_NOT_FOUND));
+    }
+
+    #[test]
+    fn all_variants_have_non_empty_codes() {
+        let errors: Vec<GraphQlError> = vec![
+            GraphQlError::Validation("v".into()),
+            GraphQlError::NotFound("r".into()),
+            GraphQlError::Authentication,
+            GraphQlError::Authorization,
+            GraphQlError::RateLimited { retry_after_secs: 0 },
+            GraphQlError::Complexity("c".into()),
+            GraphQlError::Database("d".into()),
+            GraphQlError::Internal("i".into()),
+        ];
+        for e in errors {
+            assert!(!e.code().is_empty());
+        }
+    }
+}

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -22,6 +22,7 @@
 //!
 //! See [Health Checks Documentation](../../docs/graphql-health-checks.md) for detailed information.
 
+pub mod error;
 pub mod input_validation;
 pub mod pagination;
 pub mod rate_limiting;

--- a/src/payments/connection_pool.rs
+++ b/src/payments/connection_pool.rs
@@ -1,0 +1,491 @@
+//! Secure connection pool for the Payments / settlement module.
+//!
+//! Provides a bounded, validated connection pool for the database connections
+//! used by settlement logic.  The pool enforces hard resource caps, validates
+//! endpoint configuration at construction time, and evicts stale connections
+//! lazily to prevent unbounded resource hold.
+//!
+//! # Security guarantees
+//!
+//! - The database URL is validated for scheme (`postgres://` / `postgresql://`)
+//!   and maximum length before any connection is created, preventing injection
+//!   and SSRF vectors.
+//! - Pool size is hard-capped at [`PaymentsPoolConfig::max_size`]; acquisition
+//!   attempts beyond this limit return [`PaymentsPoolError::Exhausted`] rather
+//!   than blocking or allocating unboundedly.
+//! - Stale idle connections are evicted lazily on the next pool operation.
+//! - Poisoned mutexes are recovered non-fatally so a panicking thread cannot
+//!   permanently disable the payments layer.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use synapse_core::payments::connection_pool::{PaymentsConnectionPool, PaymentsPoolConfig};
+//!
+//! let pool = PaymentsConnectionPool::new()?;
+//! let conn = pool.acquire()?;
+//! // … execute settlement query …
+//! pool.release(conn);
+//! ```
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::payments::error::PaymentError;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum allowed length for a database URL.
+const MAX_DB_URL_LEN: usize = 2048;
+
+/// Allowed URL schemes for payments database connections.
+const ALLOWED_SCHEMES: &[&str] = &["postgres://", "postgresql://"];
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the payments connection pool.
+#[derive(Debug, Clone)]
+pub struct PaymentsPoolConfig {
+    /// Maximum number of connections the pool may hold at once.
+    ///
+    /// Acquisition attempts beyond this limit return [`PaymentsPoolError::Exhausted`].
+    pub max_size: usize,
+
+    /// Connections idle longer than this duration are evicted on the next operation.
+    pub max_idle: Duration,
+
+    /// Database URL.
+    ///
+    /// Must use the `postgres://` or `postgresql://` scheme and must not exceed
+    /// [`MAX_DB_URL_LEN`] characters.
+    pub database_url: String,
+}
+
+impl Default for PaymentsPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_size: 10,
+            max_idle: Duration::from_secs(300),
+            database_url: "postgres://localhost:5432/synapse".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the payments connection pool.
+#[derive(Debug, thiserror::Error)]
+pub enum PaymentsPoolError {
+    /// All connections are in use; the pool is at capacity.
+    #[error("Payments connection pool exhausted: all {0} connections in use")]
+    Exhausted(usize),
+
+    /// The pool configuration is invalid.
+    #[error("Invalid payments pool configuration: {0}")]
+    InvalidConfig(String),
+}
+
+impl From<PaymentsPoolError> for PaymentError {
+    fn from(e: PaymentsPoolError) -> Self {
+        tracing::error!(error = %e, "Payments connection pool error");
+        PaymentError::Database(format!("Connection pool error: {}", e))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+/// A single connection managed by the payments pool.
+#[derive(Debug)]
+pub struct PaymentsConnection {
+    /// Unique connection identifier within the pool.
+    pub id: u64,
+    /// Database URL this connection targets (scheme + host only; no credentials).
+    pub endpoint: String,
+    last_used: Instant,
+}
+
+impl PaymentsConnection {
+    fn new(id: u64, endpoint: String) -> Self {
+        Self {
+            id,
+            endpoint,
+            last_used: Instant::now(),
+        }
+    }
+
+    fn is_stale(&self, max_idle: Duration) -> bool {
+        self.last_used.elapsed() > max_idle
+    }
+
+    fn touch(&mut self) {
+        self.last_used = Instant::now();
+    }
+}
+
+struct PoolState {
+    available: VecDeque<PaymentsConnection>,
+    /// Total connections in existence (idle + currently in use).
+    total: usize,
+    next_id: u64,
+}
+
+impl PoolState {
+    fn new() -> Self {
+        Self {
+            available: VecDeque::new(),
+            total: 0,
+            next_id: 1,
+        }
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pool
+// ---------------------------------------------------------------------------
+
+/// Bounded, secure connection pool for the payments / settlement module.
+///
+/// See the [module-level documentation](self) for security guarantees.
+#[derive(Debug, Clone)]
+pub struct PaymentsConnectionPool {
+    config: PaymentsPoolConfig,
+    state: Arc<Mutex<PoolState>>,
+}
+
+impl PaymentsConnectionPool {
+    /// Creates a pool with default configuration.
+    ///
+    /// # Errors
+    /// Returns [`PaymentsPoolError::InvalidConfig`] if the default database URL is invalid.
+    pub fn new() -> Result<Self, PaymentsPoolError> {
+        Self::with_config(PaymentsPoolConfig::default())
+    }
+
+    /// Creates a pool with the supplied configuration.
+    ///
+    /// Validates the database URL and pool size at construction time.
+    ///
+    /// # Errors
+    /// - [`PaymentsPoolError::InvalidConfig`] when `max_size` is zero.
+    /// - [`PaymentsPoolError::InvalidConfig`] when `database_url` uses a disallowed scheme.
+    /// - [`PaymentsPoolError::InvalidConfig`] when `database_url` exceeds [`MAX_DB_URL_LEN`].
+    pub fn with_config(config: PaymentsPoolConfig) -> Result<Self, PaymentsPoolError> {
+        validate_database_url(&config.database_url)?;
+
+        if config.max_size == 0 {
+            return Err(PaymentsPoolError::InvalidConfig(
+                "max_size must be at least 1".into(),
+            ));
+        }
+
+        Ok(Self {
+            config,
+            state: Arc::new(Mutex::new(PoolState::new())),
+        })
+    }
+
+    /// Acquires a connection from the pool.
+    ///
+    /// Stale idle connections are evicted before the availability check.
+    ///
+    /// # Errors
+    /// [`PaymentsPoolError::Exhausted`] when all `max_size` connections are in use.
+    pub fn acquire(&self) -> Result<PaymentsConnection, PaymentsPoolError> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        self.evict_stale_locked(&mut state);
+
+        if let Some(conn) = state.available.pop_front() {
+            return Ok(conn);
+        }
+
+        if state.total >= self.config.max_size {
+            return Err(PaymentsPoolError::Exhausted(self.config.max_size));
+        }
+
+        let id = state.next_id();
+        state.total += 1;
+        // Store only the scheme+host portion to avoid logging credentials.
+        let endpoint = safe_endpoint_label(&self.config.database_url);
+        Ok(PaymentsConnection::new(id, endpoint))
+    }
+
+    /// Returns a connection to the pool after use.
+    ///
+    /// Stale connections are discarded; non-stale connections are re-queued.
+    /// Recovers gracefully from poisoned mutexes.
+    pub fn release(&self, mut conn: PaymentsConnection) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if conn.is_stale(self.config.max_idle) {
+            state.total = state.total.saturating_sub(1);
+            return;
+        }
+
+        conn.touch();
+        state.available.push_back(conn);
+    }
+
+    /// Number of idle connections currently available in the pool.
+    pub fn idle_count(&self) -> usize {
+        self.state
+            .lock()
+            .map(|s| s.available.len())
+            .unwrap_or(0)
+    }
+
+    /// Total connections managed by the pool (idle + currently in use).
+    pub fn total_count(&self) -> usize {
+        self.state
+            .lock()
+            .map(|s| s.total)
+            .unwrap_or(0)
+    }
+
+    fn evict_stale_locked(&self, state: &mut PoolState) {
+        let max_idle = self.config.max_idle;
+        let before = state.available.len();
+        state.available.retain(|c| !c.is_stale(max_idle));
+        let evicted = before - state.available.len();
+        state.total = state.total.saturating_sub(evicted);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Validates a database URL for use in the payments pool.
+///
+/// Only `postgres://` and `postgresql://` schemes are accepted.
+fn validate_database_url(url: &str) -> Result<(), PaymentsPoolError> {
+    if url.is_empty() {
+        return Err(PaymentsPoolError::InvalidConfig(
+            "database_url must not be empty".into(),
+        ));
+    }
+
+    if url.len() > MAX_DB_URL_LEN {
+        return Err(PaymentsPoolError::InvalidConfig(format!(
+            "database_url exceeds maximum length of {} characters",
+            MAX_DB_URL_LEN
+        )));
+    }
+
+    let scheme_ok = ALLOWED_SCHEMES.iter().any(|s| url.starts_with(s));
+    if !scheme_ok {
+        return Err(PaymentsPoolError::InvalidConfig(
+            "database_url must use the postgres:// or postgresql:// scheme".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Returns a safe label for the endpoint (scheme + host only, no credentials).
+///
+/// Strips the userinfo component (`user:pass@`) so connection IDs logged in
+/// traces never contain database credentials.
+fn safe_endpoint_label(url: &str) -> String {
+    // Find the scheme end ("://")
+    if let Some(after_scheme) = url.find("://").map(|i| i + 3) {
+        let rest = &url[after_scheme..];
+        // Strip userinfo if present (everything before the last '@' before the first '/')
+        let host_start = rest
+            .rfind('@')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let host_and_path = &rest[host_start..];
+        // Keep only up to the first '/' (host:port)
+        let host = host_and_path.split('/').next().unwrap_or(host_and_path);
+        let scheme = &url[..after_scheme];
+        return format!("{}{}", scheme, host);
+    }
+    // Fallback: return a generic label rather than the raw URL
+    "<payments-db>".to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- URL validation --
+
+    #[test]
+    fn postgres_url_accepted() {
+        assert!(validate_database_url("postgres://localhost:5432/synapse").is_ok());
+    }
+
+    #[test]
+    fn postgresql_url_accepted() {
+        assert!(validate_database_url("postgresql://localhost:5432/synapse").is_ok());
+    }
+
+    #[test]
+    fn http_url_rejected() {
+        assert!(validate_database_url("http://localhost:5432/synapse").is_err());
+    }
+
+    #[test]
+    fn empty_url_rejected() {
+        assert!(validate_database_url("").is_err());
+    }
+
+    #[test]
+    fn url_too_long_rejected() {
+        let long = format!("postgres://{}", "a".repeat(MAX_DB_URL_LEN));
+        assert!(validate_database_url(&long).is_err());
+    }
+
+    // -- safe_endpoint_label --
+
+    #[test]
+    fn credentials_stripped_from_label() {
+        let url = "postgres://user:secret@db.internal:5432/payments";
+        let label = safe_endpoint_label(url);
+        assert!(!label.contains("secret"));
+        assert!(!label.contains("user"));
+        assert!(label.contains("db.internal"));
+    }
+
+    #[test]
+    fn label_without_credentials_preserved() {
+        let url = "postgres://db.internal:5432/payments";
+        let label = safe_endpoint_label(url);
+        assert!(label.contains("db.internal"));
+    }
+
+    // -- pool construction --
+
+    #[test]
+    fn default_pool_constructs_successfully() {
+        assert!(PaymentsConnectionPool::new().is_ok());
+    }
+
+    #[test]
+    fn zero_max_size_rejected() {
+        let config = PaymentsPoolConfig {
+            max_size: 0,
+            ..Default::default()
+        };
+        assert!(PaymentsConnectionPool::with_config(config).is_err());
+    }
+
+    #[test]
+    fn invalid_scheme_rejected_at_construction() {
+        let config = PaymentsPoolConfig {
+            database_url: "mysql://localhost:3306/synapse".to_string(),
+            ..Default::default()
+        };
+        assert!(PaymentsConnectionPool::with_config(config).is_err());
+    }
+
+    // -- acquire / release --
+
+    #[test]
+    fn acquire_creates_connection() {
+        let pool = PaymentsConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        assert_eq!(conn.id, 1);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn release_returns_connection_to_pool() {
+        let pool = PaymentsConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        pool.release(conn);
+        assert_eq!(pool.idle_count(), 1);
+    }
+
+    #[test]
+    fn acquire_reuses_idle_connection() {
+        let pool = PaymentsConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        let id = conn.id;
+        pool.release(conn);
+        let conn2 = pool.acquire().unwrap();
+        assert_eq!(conn2.id, id);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn exhausted_error_at_capacity() {
+        let config = PaymentsPoolConfig {
+            max_size: 2,
+            ..Default::default()
+        };
+        let pool = PaymentsConnectionPool::with_config(config).unwrap();
+        let _c1 = pool.acquire().unwrap();
+        let _c2 = pool.acquire().unwrap();
+        assert!(matches!(
+            pool.acquire(),
+            Err(PaymentsPoolError::Exhausted(2))
+        ));
+    }
+
+    #[test]
+    fn stale_idle_connections_evicted_on_acquire() {
+        let config = PaymentsPoolConfig {
+            max_idle: Duration::from_nanos(1),
+            ..Default::default()
+        };
+        let pool = PaymentsConnectionPool::with_config(config).unwrap();
+        let conn = pool.acquire().unwrap();
+        pool.release(conn);
+        std::thread::sleep(Duration::from_millis(1));
+        let conn2 = pool.acquire().unwrap();
+        assert_eq!(conn2.id, 2);
+    }
+
+    #[test]
+    fn stale_release_decrements_total() {
+        let config = PaymentsPoolConfig {
+            max_idle: Duration::from_nanos(1),
+            ..Default::default()
+        };
+        let pool = PaymentsConnectionPool::with_config(config).unwrap();
+        let conn = pool.acquire().unwrap();
+        assert_eq!(pool.total_count(), 1);
+        std::thread::sleep(Duration::from_millis(1));
+        pool.release(conn);
+        assert_eq!(pool.total_count(), 0);
+    }
+
+    #[test]
+    fn pool_error_converts_to_payment_error() {
+        let pool_err = PaymentsPoolError::Exhausted(10);
+        let payment_err: PaymentError = pool_err.into();
+        assert!(matches!(payment_err, PaymentError::Database(_)));
+    }
+
+    #[test]
+    fn connection_endpoint_does_not_contain_credentials() {
+        let config = PaymentsPoolConfig {
+            database_url: "postgres://admin:hunter2@db.internal:5432/payments".to_string(),
+            ..Default::default()
+        };
+        let pool = PaymentsConnectionPool::with_config(config).unwrap();
+        let conn = pool.acquire().unwrap();
+        assert!(!conn.endpoint.contains("hunter2"));
+        assert!(!conn.endpoint.contains("admin"));
+    }
+}

--- a/src/payments/mod.rs
+++ b/src/payments/mod.rs
@@ -1,6 +1,11 @@
 /// Payments module — settlement logic, data export, and pagination.
+pub mod connection_pool;
+pub mod error;
 pub mod export;
+pub mod input_validation;
 pub mod pagination;
 
+pub use connection_pool::{PaymentsConnectionPool, PaymentsPoolConfig, PaymentsPoolError};
+pub use error::PaymentError;
 pub use export::*;
 pub use pagination::{PaginationManager, PaginationParams, PaginationConfig, PaginatedResponse};

--- a/src/security/connection_pool.rs
+++ b/src/security/connection_pool.rs
@@ -1,0 +1,450 @@
+//! Bounded connection pool for the Security module.
+//!
+//! Provides a hard-capped, validated connection pool for security-layer
+//! backends (e.g. Vault, auth service).  The design mirrors the telemetry
+//! pool ([`crate::telemetry::connection_pool`]) so the two modules share the
+//! same structural conventions.
+//!
+//! # Security guarantees
+//!
+//! - The backend URL is validated against an allow-list of safe schemes
+//!   (`https` only for security backends) and a maximum length at construction
+//!   time, preventing SSRF and injection vectors.
+//! - Pool size is hard-capped at [`SecurityPoolConfig::max_size`]; acquisition
+//!   attempts beyond this limit return [`SecurityPoolError::Exhausted`] rather
+//!   than blocking or allocating unboundedly.
+//! - Stale idle connections are evicted lazily on the next pool operation,
+//!   preventing unbounded resource hold when the backend endpoint changes.
+//! - Poisoned mutexes are recovered non-fatally so a panicking thread cannot
+//!   permanently disable the security layer.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use synapse_core::security::connection_pool::{SecurityConnectionPool, SecurityPoolConfig};
+//!
+//! let pool = SecurityConnectionPool::new()?;
+//! let conn = pool.acquire()?;
+//! // … use conn …
+//! pool.release(conn);
+//! ```
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::security::error::SecurityError;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum allowed length for a backend URL.
+const MAX_ENDPOINT_LEN: usize = 2048;
+
+/// Allowed URL schemes for security backends.
+/// Only HTTPS is permitted; plain HTTP is rejected to prevent credential leakage.
+const ALLOWED_SCHEMES: &[&str] = &["https://"];
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the security-layer connection pool.
+#[derive(Debug, Clone)]
+pub struct SecurityPoolConfig {
+    /// Maximum number of connections the pool may hold at once.
+    ///
+    /// Acquisition attempts beyond this limit return [`SecurityPoolError::Exhausted`].
+    pub max_size: usize,
+
+    /// Connections idle longer than this duration are evicted on the next operation.
+    pub max_idle: Duration,
+
+    /// Backend endpoint URL.
+    ///
+    /// Must use the `https://` scheme and must not exceed [`MAX_ENDPOINT_LEN`] characters.
+    pub endpoint: String,
+}
+
+impl Default for SecurityPoolConfig {
+    fn default() -> Self {
+        Self {
+            max_size: 5,
+            max_idle: Duration::from_secs(120),
+            endpoint: "https://localhost:8200".to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the security connection pool.
+#[derive(Debug, thiserror::Error)]
+pub enum SecurityPoolError {
+    /// All connections are in use; the pool is at capacity.
+    ///
+    /// The caller should back off and retry, or fail the security operation
+    /// gracefully.
+    #[error("Security connection pool exhausted: all {0} connections in use")]
+    Exhausted(usize),
+
+    /// The pool configuration is invalid.
+    ///
+    /// Indicates `max_size` is zero, the endpoint scheme is not allowed, or
+    /// the endpoint URL exceeds the maximum length.
+    #[error("Invalid security pool configuration: {0}")]
+    InvalidConfig(String),
+}
+
+impl From<SecurityPoolError> for SecurityError {
+    fn from(e: SecurityPoolError) -> Self {
+        // Pool errors are surfaced as rate-limit exceeded (429) because they
+        // indicate the security backend is under load, not a client mistake.
+        tracing::error!(error = %e, "Security connection pool error");
+        SecurityError::RateLimitExceeded
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+/// A single connection managed by the pool.
+#[derive(Debug)]
+pub struct SecurityConnection {
+    /// Unique connection identifier within the pool.
+    pub id: u64,
+    /// Backend endpoint this connection targets.
+    pub endpoint: String,
+    last_used: Instant,
+}
+
+impl SecurityConnection {
+    fn new(id: u64, endpoint: String) -> Self {
+        Self {
+            id,
+            endpoint,
+            last_used: Instant::now(),
+        }
+    }
+
+    fn is_stale(&self, max_idle: Duration) -> bool {
+        self.last_used.elapsed() > max_idle
+    }
+
+    fn touch(&mut self) {
+        self.last_used = Instant::now();
+    }
+}
+
+struct PoolState {
+    available: VecDeque<SecurityConnection>,
+    /// Total connections in existence (idle + currently in use).
+    total: usize,
+    next_id: u64,
+}
+
+impl PoolState {
+    fn new() -> Self {
+        Self {
+            available: VecDeque::new(),
+            total: 0,
+            next_id: 1,
+        }
+    }
+
+    fn next_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pool
+// ---------------------------------------------------------------------------
+
+/// Bounded, secure connection pool for security-layer backends.
+///
+/// See the [module-level documentation](self) for security guarantees.
+#[derive(Debug, Clone)]
+pub struct SecurityConnectionPool {
+    config: SecurityPoolConfig,
+    state: Arc<Mutex<PoolState>>,
+}
+
+impl SecurityConnectionPool {
+    /// Creates a pool with default configuration.
+    ///
+    /// # Errors
+    /// Returns [`SecurityPoolError::InvalidConfig`] if the default endpoint is invalid.
+    pub fn new() -> Result<Self, SecurityPoolError> {
+        Self::with_config(SecurityPoolConfig::default())
+    }
+
+    /// Creates a pool with the supplied configuration.
+    ///
+    /// Validates the endpoint URL and pool size at construction time, failing
+    /// fast if configuration is invalid.
+    ///
+    /// # Errors
+    /// - [`SecurityPoolError::InvalidConfig`] when `max_size` is zero.
+    /// - [`SecurityPoolError::InvalidConfig`] when `endpoint` uses a disallowed scheme.
+    /// - [`SecurityPoolError::InvalidConfig`] when `endpoint` exceeds [`MAX_ENDPOINT_LEN`].
+    pub fn with_config(config: SecurityPoolConfig) -> Result<Self, SecurityPoolError> {
+        validate_endpoint(&config.endpoint)?;
+
+        if config.max_size == 0 {
+            return Err(SecurityPoolError::InvalidConfig(
+                "max_size must be at least 1".into(),
+            ));
+        }
+
+        Ok(Self {
+            config,
+            state: Arc::new(Mutex::new(PoolState::new())),
+        })
+    }
+
+    /// Acquires a connection from the pool.
+    ///
+    /// Stale idle connections are evicted before the availability check.
+    /// Returns a fresh connection if the pool has capacity and no idle
+    /// connections are available.
+    ///
+    /// # Errors
+    /// [`SecurityPoolError::Exhausted`] when all `max_size` connections are in use.
+    pub fn acquire(&self) -> Result<SecurityConnection, SecurityPoolError> {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        self.evict_stale_locked(&mut state);
+
+        if let Some(conn) = state.available.pop_front() {
+            return Ok(conn);
+        }
+
+        if state.total >= self.config.max_size {
+            return Err(SecurityPoolError::Exhausted(self.config.max_size));
+        }
+
+        let id = state.next_id();
+        state.total += 1;
+        Ok(SecurityConnection::new(id, self.config.endpoint.clone()))
+    }
+
+    /// Returns a connection to the pool after use.
+    ///
+    /// Stale connections are discarded and the pool size is decremented.
+    /// Non-stale connections are re-queued for future acquisition.
+    /// Recovers gracefully from poisoned mutexes.
+    pub fn release(&self, mut conn: SecurityConnection) {
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+
+        if conn.is_stale(self.config.max_idle) {
+            state.total = state.total.saturating_sub(1);
+            return;
+        }
+
+        conn.touch();
+        state.available.push_back(conn);
+    }
+
+    /// Number of idle connections currently available in the pool.
+    pub fn idle_count(&self) -> usize {
+        self.state
+            .lock()
+            .map(|s| s.available.len())
+            .unwrap_or(0)
+    }
+
+    /// Total connections managed by the pool (idle + currently in use).
+    pub fn total_count(&self) -> usize {
+        self.state
+            .lock()
+            .map(|s| s.total)
+            .unwrap_or(0)
+    }
+
+    fn evict_stale_locked(&self, state: &mut PoolState) {
+        let max_idle = self.config.max_idle;
+        let before = state.available.len();
+        state.available.retain(|c| !c.is_stale(max_idle));
+        let evicted = before - state.available.len();
+        state.total = state.total.saturating_sub(evicted);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Endpoint validation
+// ---------------------------------------------------------------------------
+
+/// Validates a backend endpoint URL for use in the security pool.
+///
+/// Only `https://` scheme is accepted to prevent credential leakage over
+/// plain HTTP.  The URL must not exceed [`MAX_ENDPOINT_LEN`] characters.
+fn validate_endpoint(endpoint: &str) -> Result<(), SecurityPoolError> {
+    if endpoint.is_empty() {
+        return Err(SecurityPoolError::InvalidConfig(
+            "endpoint must not be empty".into(),
+        ));
+    }
+
+    if endpoint.len() > MAX_ENDPOINT_LEN {
+        return Err(SecurityPoolError::InvalidConfig(format!(
+            "endpoint exceeds maximum length of {} characters",
+            MAX_ENDPOINT_LEN
+        )));
+    }
+
+    let scheme_ok = ALLOWED_SCHEMES.iter().any(|s| endpoint.starts_with(s));
+    if !scheme_ok {
+        return Err(SecurityPoolError::InvalidConfig(
+            "endpoint must use the https:// scheme".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- endpoint validation --
+
+    #[test]
+    fn https_endpoint_accepted() {
+        assert!(validate_endpoint("https://vault.internal:8200").is_ok());
+    }
+
+    #[test]
+    fn http_endpoint_rejected() {
+        assert!(validate_endpoint("http://vault.internal:8200").is_err());
+    }
+
+    #[test]
+    fn ftp_endpoint_rejected() {
+        assert!(validate_endpoint("ftp://vault.internal:8200").is_err());
+    }
+
+    #[test]
+    fn empty_endpoint_rejected() {
+        assert!(validate_endpoint("").is_err());
+    }
+
+    #[test]
+    fn endpoint_too_long_rejected() {
+        let long = format!("https://{}", "a".repeat(MAX_ENDPOINT_LEN));
+        assert!(validate_endpoint(&long).is_err());
+    }
+
+    // -- pool construction --
+
+    #[test]
+    fn default_pool_constructs_successfully() {
+        assert!(SecurityConnectionPool::new().is_ok());
+    }
+
+    #[test]
+    fn zero_max_size_rejected() {
+        let config = SecurityPoolConfig {
+            max_size: 0,
+            ..Default::default()
+        };
+        assert!(SecurityConnectionPool::with_config(config).is_err());
+    }
+
+    #[test]
+    fn invalid_endpoint_scheme_rejected_at_construction() {
+        let config = SecurityPoolConfig {
+            endpoint: "http://vault.internal:8200".to_string(),
+            ..Default::default()
+        };
+        assert!(SecurityConnectionPool::with_config(config).is_err());
+    }
+
+    // -- acquire / release --
+
+    #[test]
+    fn acquire_creates_connection() {
+        let pool = SecurityConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        assert_eq!(conn.id, 1);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn release_returns_connection_to_pool() {
+        let pool = SecurityConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        pool.release(conn);
+        assert_eq!(pool.idle_count(), 1);
+    }
+
+    #[test]
+    fn acquire_reuses_idle_connection() {
+        let pool = SecurityConnectionPool::new().unwrap();
+        let conn = pool.acquire().unwrap();
+        let id = conn.id;
+        pool.release(conn);
+        let conn2 = pool.acquire().unwrap();
+        assert_eq!(conn2.id, id);
+        assert_eq!(pool.total_count(), 1);
+    }
+
+    #[test]
+    fn exhausted_error_at_capacity() {
+        let config = SecurityPoolConfig {
+            max_size: 2,
+            ..Default::default()
+        };
+        let pool = SecurityConnectionPool::with_config(config).unwrap();
+        let _c1 = pool.acquire().unwrap();
+        let _c2 = pool.acquire().unwrap();
+        assert!(matches!(
+            pool.acquire(),
+            Err(SecurityPoolError::Exhausted(2))
+        ));
+    }
+
+    #[test]
+    fn stale_idle_connections_evicted_on_acquire() {
+        let config = SecurityPoolConfig {
+            max_idle: Duration::from_nanos(1),
+            ..Default::default()
+        };
+        let pool = SecurityConnectionPool::with_config(config).unwrap();
+        let conn = pool.acquire().unwrap();
+        pool.release(conn);
+        std::thread::sleep(Duration::from_millis(1));
+        // Stale idle conn is evicted; a fresh one with a new id is created.
+        let conn2 = pool.acquire().unwrap();
+        assert_eq!(conn2.id, 2);
+    }
+
+    #[test]
+    fn stale_release_decrements_total() {
+        let config = SecurityPoolConfig {
+            max_idle: Duration::from_nanos(1),
+            ..Default::default()
+        };
+        let pool = SecurityConnectionPool::with_config(config).unwrap();
+        let conn = pool.acquire().unwrap();
+        assert_eq!(pool.total_count(), 1);
+        std::thread::sleep(Duration::from_millis(1));
+        pool.release(conn);
+        assert_eq!(pool.total_count(), 0);
+    }
+
+    #[test]
+    fn pool_error_converts_to_security_error() {
+        let pool_err = SecurityPoolError::Exhausted(5);
+        let _: SecurityError = pool_err.into();
+    }
+}

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,6 +1,8 @@
-/// Security module — rate limiting and session validation.
+/// Security module — rate limiting, session validation, and connection pooling.
+pub mod connection_pool;
 pub mod error;
 pub mod session;
 
+pub use connection_pool::{SecurityConnectionPool, SecurityPoolConfig, SecurityPoolError};
 pub use error::SecurityError;
 pub use session::*;

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,35 +1,22 @@
-//! Telemetry module with input validation, reconnection logic, connection pooling, secure health checks, and metrics optimization.
-
-pub mod connection_pool;
-pub mod error_handling;
-pub mod health_checks;
-pub mod input_validation;
-pub mod metrics_optimization;
-pub mod reconnection;
-
-pub use connection_pool::{ConnectionPool, PoolConfig, PoolError};
-pub use error_handling::{ErrorAction, ErrorHandler, TelemetryError, TelemetryResult};
-pub use health_checks::{HealthCheckManager, HealthCheckResult, HealthCheckConfig};
-//! Telemetry module with input validation, reconnection logic, and connection pooling.
-//!
-//! This module provides comprehensive telemetry functionality including:
-//! - Error handling with consolidated TelemetryError enum
-//! - Input validation for spans, attributes, and endpoints
-//! - Connection pooling with resource limits and eviction
-//! - Reconnection management with exponential backoff and circuit breaker
-//! - Data export with batching and buffering
+//! Telemetry module — OpenTelemetry tracing, connection pooling, webhook handlers,
+//! input validation, reconnection logic, health checks, and metrics optimization.
 //!
 //! All error paths are designed to degrade gracefully without panicking.
 
 pub mod connection_pool;
 pub mod data_export;
 pub mod error_handling;
+pub mod health_checks;
 pub mod input_validation;
+pub mod metrics_optimization;
 pub mod reconnection;
+pub mod webhook;
 
-pub use connection_pool::ConnectionPool;
+pub use connection_pool::{ConnectionPool, PoolConfig};
 pub use data_export::{DataExportService, ExportBatch, ExportConfig, TelemetryRecord};
 pub use error_handling::{ErrorAction, ErrorHandler, TelemetryError, TelemetryResult};
+pub use health_checks::{HealthCheckConfig, HealthCheckManager, HealthCheckResult};
 pub use input_validation::InputValidator;
-pub use metrics_optimization::{MetricsInstruments, CardinalityLimiter};
+pub use metrics_optimization::{CardinalityLimiter, MetricsInstruments};
 pub use reconnection::ReconnectionManager;
+pub use webhook::{TelemetryWebhookHandler, WebhookPayload, WebhookResult};

--- a/src/telemetry/webhook.rs
+++ b/src/telemetry/webhook.rs
@@ -1,0 +1,402 @@
+//! Secure webhook handler for the Telemetry module.
+//!
+//! Validates and processes incoming webhook payloads that carry OpenTelemetry
+//! tracing events from external services.  Every payload is authenticated,
+//! size-checked, and structurally validated before any tracing data is
+//! recorded, preventing injection, replay, and resource-exhaustion attacks.
+//!
+//! # Security guarantees
+//!
+//! - **HMAC-SHA256 signature verification** — payloads without a valid
+//!   `X-Webhook-Signature` header are rejected before deserialization.
+//! - **Payload size cap** — payloads exceeding [`MAX_PAYLOAD_BYTES`] are
+//!   rejected immediately to prevent memory exhaustion.
+//! - **Structural validation** — event type, source, and span fields are
+//!   validated via [`crate::telemetry::input_validation::InputValidator`]
+//!   before any tracing call is made.
+//! - **Replay protection** — each payload carries a `timestamp_ms` field;
+//!   payloads older than [`MAX_TIMESTAMP_SKEW_SECS`] are rejected.
+//! - **Constant-time comparison** — HMAC verification uses `subtle::ConstantTimeEq`
+//!   to prevent timing side-channels.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::telemetry::error_handling::TelemetryError;
+use crate::telemetry::input_validation::InputValidator;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Maximum accepted payload size in bytes (64 KiB).
+///
+/// Payloads larger than this are rejected before deserialization to prevent
+/// memory exhaustion attacks.
+pub const MAX_PAYLOAD_BYTES: usize = 64 * 1024;
+
+/// Maximum allowed clock skew between the sender and receiver in seconds.
+///
+/// Payloads with a `timestamp_ms` older than this window are rejected as
+/// potential replays.
+pub const MAX_TIMESTAMP_SKEW_SECS: u64 = 300; // 5 minutes
+
+/// Header name carrying the HMAC-SHA256 signature.
+pub const SIGNATURE_HEADER: &str = "X-Webhook-Signature";
+
+// ---------------------------------------------------------------------------
+// Payload types
+// ---------------------------------------------------------------------------
+
+/// An incoming webhook payload carrying a telemetry tracing event.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct WebhookPayload {
+    /// Milliseconds since Unix epoch when the event was emitted.
+    pub timestamp_ms: u64,
+
+    /// Source service that emitted the event (validated as an identifier).
+    pub source: String,
+
+    /// Event type (validated as an identifier).
+    pub event_type: String,
+
+    /// Optional span name associated with the event.
+    pub span_name: Option<String>,
+
+    /// Optional key-value attributes attached to the event.
+    #[serde(default)]
+    pub attributes: std::collections::HashMap<String, String>,
+}
+
+/// Result of processing a webhook payload.
+#[derive(Debug, Clone)]
+pub struct WebhookResult {
+    /// Whether the payload was accepted and recorded.
+    pub accepted: bool,
+    /// Human-readable status message.
+    pub message: String,
+}
+
+impl WebhookResult {
+    fn accepted(message: impl Into<String>) -> Self {
+        Self { accepted: true, message: message.into() }
+    }
+
+    fn rejected(message: impl Into<String>) -> Self {
+        Self { accepted: false, message: message.into() }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+/// Secure webhook handler for telemetry tracing events.
+///
+/// Validates signatures, enforces size limits, checks timestamps for replay
+/// protection, and validates all payload fields before recording spans.
+#[derive(Debug, Clone)]
+pub struct TelemetryWebhookHandler {
+    /// HMAC secret used to verify incoming webhook signatures.
+    secret: Vec<u8>,
+}
+
+impl TelemetryWebhookHandler {
+    /// Creates a new handler with the given HMAC secret.
+    ///
+    /// # Errors
+    /// Returns [`TelemetryError::PoolConfigError`] if the secret is empty.
+    pub fn new(secret: impl Into<Vec<u8>>) -> Result<Self, TelemetryError> {
+        let secret = secret.into();
+        if secret.is_empty() {
+            return Err(TelemetryError::PoolConfigError(
+                "webhook HMAC secret must not be empty".into(),
+            ));
+        }
+        Ok(Self { secret })
+    }
+
+    /// Processes a raw webhook request.
+    ///
+    /// Steps performed in order:
+    /// 1. Reject oversized payloads.
+    /// 2. Verify HMAC-SHA256 signature.
+    /// 3. Deserialize JSON body.
+    /// 4. Validate timestamp (replay protection).
+    /// 5. Validate all string fields.
+    /// 6. Record the tracing span.
+    ///
+    /// # Arguments
+    /// - `body` — raw request body bytes.
+    /// - `signature` — value of the `X-Webhook-Signature` header (hex-encoded HMAC).
+    ///
+    /// # Errors
+    /// Returns a [`TelemetryError`] variant describing the first validation failure.
+    pub fn process(
+        &self,
+        body: &[u8],
+        signature: &str,
+    ) -> Result<WebhookResult, TelemetryError> {
+        // 1. Size check — before any allocation-heavy work.
+        if body.len() > MAX_PAYLOAD_BYTES {
+            tracing::warn!(
+                size = body.len(),
+                max = MAX_PAYLOAD_BYTES,
+                "Telemetry webhook rejected: payload too large"
+            );
+            return Err(TelemetryError::PayloadTooLarge(MAX_PAYLOAD_BYTES));
+        }
+
+        // 2. Signature verification.
+        self.verify_signature(body, signature)?;
+
+        // 3. Deserialize.
+        let payload: WebhookPayload = serde_json::from_slice(body)
+            .map_err(|e| TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::InvalidFormat(
+                    format!("invalid JSON: {}", e),
+                ),
+            ))?;
+
+        // 4. Replay protection.
+        self.check_timestamp(payload.timestamp_ms)?;
+
+        // 5. Field validation.
+        self.validate_payload(&payload)?;
+
+        // 6. Record span.
+        tracing::info!(
+            source = %payload.source,
+            event_type = %payload.event_type,
+            span_name = ?payload.span_name,
+            "Telemetry webhook event received"
+        );
+
+        Ok(WebhookResult::accepted("event recorded"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /// Verifies the HMAC-SHA256 signature of the raw body.
+    ///
+    /// Uses constant-time comparison to prevent timing side-channels.
+    fn verify_signature(&self, body: &[u8], signature: &str) -> Result<(), TelemetryError> {
+        if signature.is_empty() {
+            return Err(TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::EmptyValue(
+                    "missing webhook signature".into(),
+                ),
+            ));
+        }
+
+        let expected = hex::decode(signature).map_err(|_| {
+            TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::InvalidFormat(
+                    "signature must be hex-encoded".into(),
+                ),
+            )
+        })?;
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.secret)
+            .map_err(|e| TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::InvalidFormat(
+                    format!("HMAC init error: {}", e),
+                ),
+            ))?;
+        mac.update(body);
+
+        mac.verify_slice(&expected).map_err(|_| {
+            tracing::warn!("Telemetry webhook rejected: invalid signature");
+            TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::InvalidFormat(
+                    "invalid webhook signature".into(),
+                ),
+            )
+        })
+    }
+
+    /// Checks that the payload timestamp is within the allowed skew window.
+    fn check_timestamp(&self, timestamp_ms: u64) -> Result<(), TelemetryError> {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let skew_ms = MAX_TIMESTAMP_SKEW_SECS * 1_000;
+
+        // Reject if timestamp is too far in the past or future.
+        let too_old = now_ms.saturating_sub(timestamp_ms) > skew_ms;
+        let too_new = timestamp_ms.saturating_sub(now_ms) > skew_ms;
+
+        if too_old || too_new {
+            tracing::warn!(
+                timestamp_ms,
+                now_ms,
+                "Telemetry webhook rejected: timestamp outside allowed window"
+            );
+            return Err(TelemetryError::ValidationError(
+                crate::telemetry::input_validation::ValidationError::InvalidFormat(
+                    "webhook timestamp is outside the allowed window (possible replay)".into(),
+                ),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Validates all string fields in the payload.
+    fn validate_payload(&self, payload: &WebhookPayload) -> Result<(), TelemetryError> {
+        // source and event_type must be valid identifiers.
+        InputValidator::validate_span_name(&payload.source)?;
+        InputValidator::validate_span_name(&payload.event_type)?;
+
+        // span_name is optional but must be valid if present.
+        if let Some(span_name) = &payload.span_name {
+            InputValidator::validate_span_name(span_name)?;
+        }
+
+        // Validate all attribute values.
+        for (key, value) in &payload.attributes {
+            InputValidator::validate_span_name(key)?;
+            InputValidator::validate_attribute_value(value)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    const SECRET: &[u8] = b"test-secret-key-for-unit-tests";
+
+    fn sign(body: &[u8]) -> String {
+        let mut mac = Hmac::<Sha256>::new_from_slice(SECRET).unwrap();
+        mac.update(body);
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0)
+    }
+
+    fn valid_body(ts: u64) -> Vec<u8> {
+        serde_json::json!({
+            "timestamp_ms": ts,
+            "source": "payment-service",
+            "event_type": "settlement_completed",
+            "span_name": "process_settlement",
+            "attributes": {}
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[test]
+    fn empty_secret_rejected() {
+        assert!(TelemetryWebhookHandler::new(b"".to_vec()).is_err());
+    }
+
+    #[test]
+    fn valid_payload_accepted() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = valid_body(now_ms());
+        let sig = sign(&body);
+        let result = handler.process(&body, &sig).unwrap();
+        assert!(result.accepted);
+    }
+
+    #[test]
+    fn invalid_signature_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = valid_body(now_ms());
+        let result = handler.process(&body, "deadbeef");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_signature_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = valid_body(now_ms());
+        let result = handler.process(&body, "");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn oversized_payload_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = vec![0u8; MAX_PAYLOAD_BYTES + 1];
+        let sig = sign(&body);
+        let result = handler.process(&body, &sig);
+        assert!(matches!(result, Err(TelemetryError::PayloadTooLarge(_))));
+    }
+
+    #[test]
+    fn stale_timestamp_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        // Timestamp 10 minutes in the past.
+        let old_ts = now_ms().saturating_sub(600_000);
+        let body = valid_body(old_ts);
+        let sig = sign(&body);
+        let result = handler.process(&body, &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn future_timestamp_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        // Timestamp 10 minutes in the future.
+        let future_ts = now_ms() + 600_000;
+        let body = valid_body(future_ts);
+        let sig = sign(&body);
+        let result = handler.process(&body, &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_json_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = b"not json at all";
+        let sig = sign(body);
+        let result = handler.process(body, &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_source_field_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = serde_json::json!({
+            "timestamp_ms": now_ms(),
+            "source": "bad source with spaces!",
+            "event_type": "test_event",
+            "attributes": {}
+        })
+        .to_string()
+        .into_bytes();
+        let sig = sign(&body);
+        let result = handler.process(&body, &sig);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn non_hex_signature_rejected() {
+        let handler = TelemetryWebhookHandler::new(SECRET.to_vec()).unwrap();
+        let body = valid_body(now_ms());
+        let result = handler.process(&body, "not-hex!!");
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
# After push completes, open GitHub in browser and create PR, or use:
# (if you install gh CLI later)
gh pr create \
  --title "fix: secure webhook handlers, connection pooling & GraphQL error handling (#510, #511, #513, #514)" \
  --body "## Summary

Addresses four issues in a single PR.

### #514 — Optimize Error Handling in GraphQL
- Added \`src/graphql/error.rs\` with a typed \`GraphQlError\` enum
- Stable \`extensions.code\` fields on all errors (VALIDATION_ERROR, NOT_FOUND, RATE_LIMITED, etc.)
- \`database_error\` / \`internal_error\` helpers log raw causes server-side and redact them from client responses

### #513 — Refactor Connection Pooling in Security
- Added \`src/security/connection_pool.rs\` with \`SecurityConnectionPool\`
- HTTPS-only endpoint validation, hard max_size cap, stale connection eviction
- Maps pool errors to \`SecurityError::RateLimitExceeded\` (429)

### #511 — Secure Connection Pooling in Payments
- Added \`src/payments/connection_pool.rs\` with \`PaymentsConnectionPool\`
- Validates \`postgres://\` / \`postgresql://\` scheme only
- Strips credentials from connection labels to prevent log leakage
- Maps pool errors to \`PaymentError::Database\`

### #510 — Secure Webhook Handlers in Telemetry
- Added \`src/telemetry/webhook.rs\` with \`TelemetryWebhookHandler\`
- HMAC-SHA256 signature verification (constant-time via \`hmac::verify_slice\`)
- 64 KiB payload size cap, 5-minute replay-protection window
- Full field validation via \`InputValidator\` before any tracing call

Closes #510
Closes #511
Closes #513
Closes #514
