### PR TITLE
feat: exactly-once webhook delivery, DLQ routing, and per-endpoint circuit breaker

### DIFF
--- a/migrations/20260601000000_webhook_exactly_once_delivery.down.sql
+++ b/migrations/20260601000000_webhook_exactly_once_delivery.down.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS webhook_delivery_dlq;
+
+ALTER TABLE webhook_endpoints
+    DROP COLUMN IF EXISTS circuit_opened_at,
+    DROP COLUMN IF EXISTS circuit_failure_count,
+    DROP COLUMN IF EXISTS circuit_state;
+
+ALTER TABLE webhook_deliveries
+    DROP COLUMN IF EXISTS claimed_at,
+    DROP COLUMN IF EXISTS attempt_history;

--- a/migrations/20260601000000_webhook_exactly_once_delivery.sql
+++ b/migrations/20260601000000_webhook_exactly_once_delivery.sql
@@ -1,0 +1,68 @@
+-- Add exactly-once delivery support, DLQ routing, and circuit breaker columns
+-- to the webhook delivery system.
+
+-- ── 1. New columns on webhook_deliveries ────────────────────────────────────
+
+-- Store full attempt history as JSONB array for DLQ routing
+ALTER TABLE webhook_deliveries
+    ADD COLUMN IF NOT EXISTS attempt_history JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+-- Track which worker claimed a delivery (for reclaim of crashed workers)
+ALTER TABLE webhook_deliveries
+    ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+
+-- Index for reclaim queries (stale in_progress rows)
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_claimed_at
+    ON webhook_deliveries(claimed_at)
+    WHERE status = 'in_progress';
+
+-- Update the status comment: pending | in_progress | delivered | failed
+COMMENT ON COLUMN webhook_deliveries.status IS
+    'pending | in_progress | delivered | failed';
+
+-- ── 2. Circuit breaker columns on webhook_endpoints ─────────────────────────
+
+ALTER TABLE webhook_endpoints
+    ADD COLUMN IF NOT EXISTS circuit_state VARCHAR(20) NOT NULL DEFAULT 'closed';
+ALTER TABLE webhook_endpoints
+    ADD COLUMN IF NOT EXISTS circuit_failure_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE webhook_endpoints
+    ADD COLUMN IF NOT EXISTS circuit_opened_at TIMESTAMPTZ;
+
+-- ── 3. Webhook delivery DLQ table ───────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS webhook_delivery_dlq (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    delivery_id         UUID NOT NULL,
+    endpoint_id         UUID NOT NULL REFERENCES webhook_endpoints(id) ON DELETE CASCADE,
+    transaction_id      UUID NOT NULL,
+    event_type          TEXT NOT NULL,
+    payload             JSONB NOT NULL,
+    attempt_history     JSONB NOT NULL DEFAULT '[]'::jsonb,
+    attempt_count       INTEGER NOT NULL,
+    last_response_status INTEGER,
+    last_response_body  TEXT,
+    last_error          TEXT,
+    moved_to_dlq_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    replayed_at         TIMESTAMPTZ,
+    replay_count        INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_dlq_endpoint_id
+    ON webhook_delivery_dlq(endpoint_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_dlq_transaction_id
+    ON webhook_delivery_dlq(transaction_id);
+CREATE INDEX IF NOT EXISTS idx_webhook_dlq_moved_at
+    ON webhook_delivery_dlq(moved_to_dlq_at DESC);
+CREATE INDEX IF NOT EXISTS idx_webhook_dlq_replay_count
+    ON webhook_delivery_dlq(replay_count)
+    WHERE replay_count > 0;
+
+COMMENT ON TABLE webhook_delivery_dlq IS
+    'Dead-letter queue for webhook deliveries that exhausted all retry attempts';
+COMMENT ON COLUMN webhook_delivery_dlq.delivery_id IS
+    'Original webhook_deliveries.id (kept for traceability across re-enqueues)';
+COMMENT ON COLUMN webhook_delivery_dlq.attempt_history IS
+    'JSON array of {attempt, attempted_at, response_status, response_body, error} objects';
+COMMENT ON COLUMN webhook_delivery_dlq.replay_count IS
+    'Number of times this DLQ entry has been replayed back to the dispatcher';

--- a/src/db/webhook.rs
+++ b/src/db/webhook.rs
@@ -45,13 +45,25 @@
 //! `webhook_deliveries` for enabled `webhook_endpoints`. The delivery table is
 //! intentionally append/update oriented:
 //!
-//! - `webhook_deliveries.status` tracks `pending`, `delivered`, or `failed`;
+//! - `webhook_deliveries.status` tracks `pending`, `in_progress`, `delivered`, or `failed`;
+//!   `in_progress` means a worker has claimed the row (see `claimed_at`); workers
+//!   reclaim stale `in_progress` rows older than `CLAIM_TIMEOUT_SECS` (default 5 min);
 //! - `attempt_count`, `last_attempt_at`, and `next_attempt_at` support retry
 //!   scheduling;
 //! - `response_status` and `response_body` capture endpoint responses for
 //!   diagnostics;
+//! - `attempt_history` stores every attempt as a `JSONB` array of
+//!   `{attempt, attempted_at, response_status, response_body, error}` objects,
+//!   used for DLQ routing and operator inspection;
+//! - `claimed_at` records when a worker claimed the row for processing; older
+//!   `in_progress` rows are candidates for reclaim after a crash;
 //! - the `(endpoint_id, transaction_id, event_type)` uniqueness constraint
-//!   prevents duplicate delivery rows for the same event.
+//!   prevents duplicate delivery rows for the same event;
+//! - exhausted deliveries (after `MAX_ATTEMPTS`) are inserted into
+//!   `webhook_delivery_dlq` with the full `attempt_history` for replay;
+//! - per-endpoint circuit breaker state is kept in Redis (`webhook_cb:<id>`);
+//!   when open, the dispatcher skips and reschedules deliveries without
+//!   consuming attempt budget.
 //!
 //! The dispatcher batches pending deliveries and endpoint lookups to avoid an
 //! N+1 query pattern. New query paths should preserve that shape: select a

--- a/src/services/webhook_dispatcher.rs
+++ b/src/services/webhook_dispatcher.rs
@@ -7,7 +7,7 @@
 use chrono::Utc;
 use futures::stream::{self, StreamExt};
 use hmac::{Hmac, Mac};
-use redis::{AsyncCommands, Client};
+use redis::{AsyncCommands, Client, Script};
 use reqwest::Client as HttpClient;
 use serde::{Deserialize, Serialize};
 use sha2::{Sha256, Sha512};
@@ -18,6 +18,13 @@ use uuid::Uuid;
 const MAX_ATTEMPTS: i32 = 5;
 /// Base delay in seconds for exponential backoff (2^attempt * BASE_DELAY_SECS)
 const BASE_DELAY_SECS: i64 = 10;
+/// How long (seconds) before a claimed in_progress delivery can be reclaimed
+/// by another worker (crash recovery).
+const CLAIM_TIMEOUT_SECS: i64 = 300;
+/// Circuit breaker: consecutive failures before tripping open.
+const CB_FAILURE_THRESHOLD: u32 = 3;
+/// Circuit breaker: seconds before an open breaker transitions to half-open.
+const CB_RESET_TIMEOUT_SECS: i64 = 300;
 
 // ── Domain types ─────────────────────────────────────────────────────────────
 
@@ -49,6 +56,8 @@ pub struct WebhookDelivery {
     pub response_body: Option<String>,
     pub created_at: chrono::DateTime<Utc>,
     pub max_delivery_rate: i32,
+    pub attempt_history: Option<serde_json::Value>,
+    pub claimed_at: Option<chrono::DateTime<Utc>>,
 }
 
 /// Payload sent to external endpoints.
@@ -137,20 +146,37 @@ impl WebhookDispatcher {
     }
 
     /// Process all pending deliveries concurrently using `buffer_unordered`.
-    /// Batch-loads all endpoints in a single query to avoid N+1 pattern.
+    /// Uses `FOR UPDATE SKIP LOCKED` in a CTE to claim rows atomically so
+    /// concurrent replicas never deliver the same event twice.
+    /// Also reclaims stuck `in_progress` rows past `CLAIM_TIMEOUT_SECS`.
     pub async fn process_pending(&self) -> anyhow::Result<()> {
+        let reclaim_cutoff = Utc::now() - chrono::Duration::seconds(CLAIM_TIMEOUT_SECS);
+
+        // Atomic claim via a CTE: the inner SELECT … FOR UPDATE SKIP LOCKED
+        // picks rows that are not already locked by another transaction, then
+        // the outer UPDATE claims them and returns the joined result.
         let deliveries: Vec<WebhookDelivery> = sqlx::query_as(
             r#"
-            SELECT wd.*, we.max_delivery_rate
-            FROM webhook_deliveries wd
-            JOIN webhook_endpoints we ON wd.endpoint_id = we.id
-            WHERE wd.status = 'pending'
-              AND (wd.next_attempt_at IS NULL OR wd.next_attempt_at <= NOW())
+            WITH candidate AS (
+                SELECT id FROM webhook_deliveries
+                WHERE (status = 'pending'
+                   AND (next_attempt_at IS NULL OR next_attempt_at <= NOW()))
+                   OR (status = 'in_progress' AND claimed_at <= $1)
+                ORDER BY created_at
+                LIMIT 100
+                FOR UPDATE SKIP LOCKED
+            )
+            UPDATE webhook_deliveries wd
+            SET status   = 'in_progress',
+                claimed_at = NOW()
+            FROM webhook_endpoints we, candidate c
+            WHERE wd.id = c.id
+              AND wd.endpoint_id = we.id
               AND we.enabled = true
-            ORDER BY wd.created_at
-            LIMIT 100
+            RETURNING wd.*, we.max_delivery_rate
             "#,
         )
+        .bind(reclaim_cutoff)
         .fetch_all(&self.pool)
         .await?;
 
@@ -158,13 +184,13 @@ impl WebhookDispatcher {
             return Ok(());
         }
 
-        // Batch-load all unique endpoints in a single query
-        let endpoint_ids: Vec<Uuid> = deliveries
-            .iter()
-            .map(|d| d.endpoint_id)
-            .collect::<std::collections::HashSet<_>>()
-            .into_iter()
-            .collect();
+        // Group claimed deliveries by endpoint for circuit-breaker checks.
+        let mut by_endpoint: HashMap<Uuid, Vec<WebhookDelivery>> = HashMap::new();
+        for d in deliveries {
+            by_endpoint.entry(d.endpoint_id).or_default().push(d);
+        }
+
+        let endpoint_ids: Vec<Uuid> = by_endpoint.keys().copied().collect();
 
         let endpoints: Vec<WebhookEndpoint> =
             sqlx::query_as("SELECT * FROM webhook_endpoints WHERE id = ANY($1) AND enabled = true")
@@ -172,19 +198,63 @@ impl WebhookDispatcher {
                 .fetch_all(&self.pool)
                 .await?;
 
-        // Create HashMap for O(1) lookups
         let endpoint_map: HashMap<Uuid, WebhookEndpoint> =
             endpoints.into_iter().map(|ep| (ep.id, ep)).collect();
 
-        let query_count = 2; // 1 for deliveries + 1 for endpoints
+        for ep_id in &endpoint_ids {
+            if let Some(ep) = endpoint_map.get(ep_id) {
+                let blocked = self
+                    .circuit_breaker_is_open(ep_id, &ep.url)
+                    .await
+                    .unwrap_or(false);
+
+                if blocked {
+                    // Reschedule every delivery for this endpoint without
+                    // burning an attempt, then release the claim.
+                    if let Some(deliveries) = by_endpoint.get(ep_id) {
+                        let next_cycle =
+                            Utc::now() + chrono::Duration::seconds(CB_RESET_TIMEOUT_SECS);
+                        for d in deliveries {
+                            sqlx::query(
+                                r#"
+                                UPDATE webhook_deliveries
+                                SET status        = 'pending',
+                                    claimed_at    = NULL,
+                                    next_attempt_at = $1
+                                WHERE id = $2
+                                "#,
+                            )
+                            .bind(next_cycle)
+                            .bind(d.id)
+                            .execute(&self.pool)
+                            .await?;
+
+                            tracing::warn!(
+                                delivery_id = %d.id,
+                                endpoint_id = %ep_id,
+                                "Circuit breaker open, rescheduled delivery without consuming attempt"
+                            );
+                        }
+                    }
+                    by_endpoint.remove(ep_id);
+                }
+            }
+        }
+
+        // Flatten remaining (non-blocked) deliveries
+        let remaining: Vec<WebhookDelivery> = by_endpoint.into_values().flatten().collect();
+
+        if remaining.is_empty() {
+            return Ok(());
+        }
+
         tracing::info!(
-            delivery_count = deliveries.len(),
+            delivery_count = remaining.len(),
             endpoint_count = endpoint_map.len(),
-            query_count = query_count,
-            "Webhook dispatcher batch-loaded endpoints (N+1 optimization)"
+            "Webhook dispatcher processing claimed deliveries"
         );
 
-        stream::iter(deliveries)
+        stream::iter(remaining)
             .map(|delivery| {
                 let dispatcher = self.clone();
                 let endpoint_map = endpoint_map.clone();
@@ -256,7 +326,9 @@ impl WebhookDispatcher {
             sqlx::query(
                 r#"
                 UPDATE webhook_deliveries
-                SET next_attempt_at = $1
+                SET status = 'pending',
+                    claimed_at = NULL,
+                    next_attempt_at = $1
                 WHERE id = $2
                 "#,
             )
@@ -280,11 +352,63 @@ impl WebhookDispatcher {
                     endpoint_id = %delivery.endpoint_id,
                     "Endpoint not found in batch-loaded map"
                 );
+                // Release claim so it can be picked up next cycle
+                sqlx::query(
+                    "UPDATE webhook_deliveries SET status = 'pending', claimed_at = NULL WHERE id = $1",
+                )
+                .bind(delivery.id)
+                .execute(&self.pool)
+                .await?;
                 return Ok(());
             }
         };
 
-        self.send_webhook(delivery, endpoint).await
+        let result = self.send_webhook(delivery, endpoint).await;
+
+        // Record circuit breaker outcome
+        match &result {
+            Ok(()) => {
+                let _ = self.circuit_breaker_succeeded(&delivery.endpoint_id).await;
+            }
+            Err(_) => {
+                let _ = self.circuit_breaker_failed(&delivery.endpoint_id).await;
+            }
+        }
+
+        result
+    }
+
+    /// Build an attempt-history entry and append it to the delivery's JSONB column.
+    async fn append_attempt_history(
+        &self,
+        delivery_id: Uuid,
+        attempt: i32,
+        attempted_at: chrono::DateTime<Utc>,
+        response_status: Option<i32>,
+        response_body: Option<String>,
+        error: Option<String>,
+    ) -> anyhow::Result<()> {
+        let entry = serde_json::json!({
+            "attempt": attempt,
+            "attempted_at": attempted_at.to_rfc3339(),
+            "response_status": response_status,
+            "response_body": response_body,
+            "error": error,
+        });
+
+        sqlx::query(
+            r#"
+            UPDATE webhook_deliveries
+            SET attempt_history = COALESCE(attempt_history, '[]'::jsonb) || $1::jsonb
+            WHERE id = $2
+            "#,
+        )
+        .bind(entry.to_string())
+        .bind(delivery_id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
     }
 
     async fn send_webhook(
@@ -336,6 +460,17 @@ impl WebhookDispatcher {
                 let resp_body = resp.text().await.unwrap_or_default();
                 let success = (200..300).contains(&(status_code as u16));
 
+                // Record attempt history
+                self.append_attempt_history(
+                    delivery.id,
+                    new_attempt_count,
+                    now,
+                    Some(status_code),
+                    Some(resp_body.clone()),
+                    None,
+                )
+                .await?;
+
                 if success {
                     sqlx::query(
                         r#"
@@ -344,7 +479,8 @@ impl WebhookDispatcher {
                             attempt_count = $1,
                             last_attempt_at = $2,
                             response_status = $3,
-                            response_body = $4
+                            response_body = $4,
+                            claimed_at = NULL
                         WHERE id = $5
                         "#,
                     )
@@ -373,7 +509,20 @@ impl WebhookDispatcher {
                 }
             }
             Err(e) => {
-                self.handle_failure(delivery, new_attempt_count, now, None, Some(e.to_string()))
+                let err_msg = e.to_string();
+
+                // Record attempt history
+                self.append_attempt_history(
+                    delivery.id,
+                    new_attempt_count,
+                    now,
+                    None,
+                    None,
+                    Some(err_msg.clone()),
+                )
+                .await?;
+
+                self.handle_failure(delivery, new_attempt_count, now, None, Some(err_msg))
                     .await?;
             }
         }
@@ -393,7 +542,9 @@ impl WebhookDispatcher {
             sqlx::query(
                 r#"
                 UPDATE webhook_deliveries
-                SET next_attempt_at = $1
+                SET status = 'pending',
+                    claimed_at = NULL,
+                    next_attempt_at = $1
                 WHERE id = $2
                 "#,
             )
@@ -418,6 +569,12 @@ impl WebhookDispatcher {
         self.send_webhook(delivery, &endpoint).await
     }
 
+    /// Handle a failed delivery attempt.
+    ///
+    /// * If `attempt_count < MAX_ATTEMPTS`: schedule a retry with exponential
+    ///   backoff and keep the status as `pending`.
+    /// * If `attempt_count >= MAX_ATTEMPTS`: move the delivery to the DLQ table
+    ///   with full attempt history, set status to `failed`.
     async fn handle_failure(
         &self,
         delivery: &WebhookDelivery,
@@ -429,8 +586,9 @@ impl WebhookDispatcher {
         let (new_status, next_attempt_at) = if attempt_count >= MAX_ATTEMPTS {
             tracing::warn!(
                 delivery_id = %delivery.id,
-                "Webhook delivery permanently failed after {} attempts",
-                attempt_count
+                endpoint_id = %delivery.endpoint_id,
+                attempt_count = attempt_count,
+                "Webhook delivery exhausted, routing to DLQ"
             );
             ("failed", None)
         } else {
@@ -445,6 +603,7 @@ impl WebhookDispatcher {
             ("pending", Some(next))
         };
 
+        // Update delivery record
         sqlx::query(
             r#"
             UPDATE webhook_deliveries
@@ -453,7 +612,8 @@ impl WebhookDispatcher {
                 last_attempt_at = $3,
                 next_attempt_at = $4,
                 response_status = $5,
-                response_body = $6
+                response_body = $6,
+                claimed_at = NULL
             WHERE id = $7
             "#,
         )
@@ -462,12 +622,227 @@ impl WebhookDispatcher {
         .bind(now)
         .bind(next_attempt_at)
         .bind(response_status)
-        .bind(response_body)
+        .bind(response_body.clone())
         .bind(delivery.id)
         .execute(&self.pool)
         .await?;
 
+        // Route to DLQ on exhaustion
+        if attempt_count >= MAX_ATTEMPTS {
+            self.route_to_dlq(delivery, attempt_count, response_status, response_body)
+                .await?;
+        }
+
         Ok(())
+    }
+
+    /// Insert an exhausted delivery into the DLQ table with the full attempt
+    /// history so operators can inspect and replay.
+    async fn route_to_dlq(
+        &self,
+        delivery: &WebhookDelivery,
+        attempt_count: i32,
+        response_status: Option<i32>,
+        response_body: Option<String>,
+    ) -> anyhow::Result<()> {
+        // Fetch the latest attempt_history persisted by append_attempt_history
+        let history: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT attempt_history FROM webhook_deliveries WHERE id = $1")
+                .bind(delivery.id)
+                .fetch_optional(&self.pool)
+                .await?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO webhook_delivery_dlq
+                (delivery_id, endpoint_id, transaction_id, event_type,
+                 payload, attempt_history, attempt_count,
+                 last_response_status, last_response_body, last_error)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (delivery_id) DO NOTHING
+            "#,
+        )
+        .bind(delivery.id)
+        .bind(delivery.endpoint_id)
+        .bind(delivery.transaction_id)
+        .bind(&delivery.event_type)
+        .bind(&delivery.payload)
+        .bind(history.unwrap_or(serde_json::Value::Array(vec![])))
+        .bind(attempt_count)
+        .bind(response_status)
+        .bind(response_body)
+        .bind(None::<String>)
+        .execute(&self.pool)
+        .await?;
+
+        tracing::info!(
+            delivery_id = %delivery.id,
+            endpoint_id = %delivery.endpoint_id,
+            "Webhook delivery moved to DLQ"
+        );
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // Circuit breaker helpers (Redis-backed)
+    // -------------------------------------------------------------------
+
+    /// Check whether the circuit breaker is open for this endpoint.
+    /// Returns `true` if the endpoint is temporarily blocked.
+    async fn circuit_breaker_is_open(
+        &self,
+        endpoint_id: &Uuid,
+        _url: &str,
+    ) -> anyhow::Result<bool> {
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+        let key = format!("webhook_cb:{endpoint_id}");
+        let data: Option<String> = conn.get(&key).await?;
+
+        match data {
+            Some(json) => {
+                let state: serde_json::Value = serde_json::from_str(&json)?;
+                if state["state"] == "open" {
+                    let opened_at = state["opened_at"]
+                        .as_str()
+                        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                        .map(|dt| dt.with_timezone(&Utc))
+                        .unwrap_or(Utc::now());
+                    let elapsed = Utc::now() - opened_at;
+                    if elapsed < chrono::Duration::seconds(CB_RESET_TIMEOUT_SECS) {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            None => Ok(false),
+        }
+    }
+
+    /// Record a successful delivery — reset the circuit breaker.
+    async fn circuit_breaker_succeeded(&self, endpoint_id: &Uuid) -> anyhow::Result<()> {
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+        let key = format!("webhook_cb:{endpoint_id}");
+        let _: i32 = redis::cmd("DEL").arg(&key).query_async(&mut conn).await?;
+        Ok(())
+    }
+
+    /// Record a failed delivery — may trip the circuit breaker open.
+    async fn circuit_breaker_failed(&self, endpoint_id: &Uuid) -> anyhow::Result<()> {
+        let mut conn = self.redis.get_multiplexed_async_connection().await?;
+        let key = format!("webhook_cb:{endpoint_id}");
+
+        // Use a Redis Lua script for atomic read-modify-write
+        let script = Script::new(
+            r#"
+            local data = redis.call('GET', KEYS[1])
+            local state
+            if data then
+                state = cjson.decode(data)
+                state.failure_count = (state.failure_count or 0) + 1
+            else
+                state = { state = 'closed', failure_count = 1, opened_at = nil, last_error = nil }
+            end
+            state.last_error = ARGV[1]
+            if state.failure_count >= tonumber(ARGV[2]) then
+                state.state = 'open'
+                state.opened_at = ARGV[3]
+            else
+                state.state = 'closed'
+            end
+            redis.call('SETEX', KEYS[1], ARGV[4], cjson.encode(state))
+            return state.failure_count
+            "#,
+        );
+
+        let _: i32 = script
+            .key(&key)
+            .arg("delivery failed")
+            .arg(CB_FAILURE_THRESHOLD)
+            .arg(Utc::now().to_rfc3339())
+            .arg(CB_RESET_TIMEOUT_SECS)
+            .invoke_async(&mut conn)
+            .await?;
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------
+    // DLQ replay
+    // -------------------------------------------------------------------
+
+    /// Replay a webhook delivery from the DLQ back into the delivery table.
+    /// The delivery is re-enqueued as a fresh `pending` row with the original
+    /// payload and a reset attempt counter. Returns the new delivery id.
+    pub async fn replay_from_dlq(&self, dlq_id: Uuid) -> anyhow::Result<Uuid> {
+        let dlq_row = sqlx::query(
+            r#"
+            SELECT delivery_id, endpoint_id, transaction_id, event_type, payload
+            FROM webhook_delivery_dlq
+            WHERE id = $1
+            "#,
+        )
+        .bind(dlq_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let (delivery_id, endpoint_id, transaction_id, event_type, payload) = match dlq_row {
+            Some(row) => (
+                row.try_get::<Uuid, _>("delivery_id")?,
+                row.try_get::<Uuid, _>("endpoint_id")?,
+                row.try_get::<Uuid, _>("transaction_id")?,
+                row.try_get::<String, _>("event_type")?,
+                row.try_get::<serde_json::Value, _>("payload")?,
+            ),
+            None => anyhow::bail!("DLQ entry {dlq_id} not found"),
+        };
+
+        // Re-insert into deliveries (ON CONFLICT DO NOTHING means if the
+        // original row still exists we reuse it)
+        let new_id = sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO webhook_deliveries
+                (endpoint_id, transaction_id, event_type, payload, status, next_attempt_at, attempt_history)
+            VALUES ($1, $2, $3, $4, 'pending', NOW(), '[]'::jsonb)
+            ON CONFLICT (endpoint_id, transaction_id, event_type)
+            DO UPDATE SET status = 'pending',
+                          next_attempt_at = NOW(),
+                          attempt_count = 0,
+                          response_status = NULL,
+                          response_body = NULL,
+                          attempt_history = '[]'::jsonb,
+                          claimed_at = NULL
+            RETURNING id
+            "#,
+        )
+        .bind(endpoint_id)
+        .bind(transaction_id)
+        .bind(&event_type)
+        .bind(&payload)
+        .fetch_one(&self.pool)
+        .await?;
+
+        // Increment replay counter on DLQ entry
+        sqlx::query(
+            r#"
+            UPDATE webhook_delivery_dlq
+            SET replay_count = replay_count + 1,
+                replayed_at = NOW()
+            WHERE id = $1
+            "#,
+        )
+        .bind(dlq_id)
+        .execute(&self.pool)
+        .await?;
+
+        tracing::info!(
+            dlq_id = %dlq_id,
+            delivery_id = %delivery_id,
+            new_delivery_id = %new_id,
+            "Webhook delivery replayed from DLQ"
+        );
+
+        Ok(new_id)
     }
 
     async fn endpoints_for_event(

--- a/tests/webhook_concurrent_delivery_test.rs
+++ b/tests/webhook_concurrent_delivery_test.rs
@@ -1,0 +1,410 @@
+use mockito::Server;
+use redis::Client as RedisClient;
+use sqlx::migrate::Migrator;
+use sqlx::{PgPool, Row};
+use std::path::Path;
+use synapse_core::services::WebhookDispatcher;
+use testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+use testcontainers_modules::postgres::Postgres;
+use uuid::Uuid;
+
+/// Set up a test Postgres instance with all migrations applied.
+/// Also ensures the current month partition exists for the transactions table.
+async fn setup_postgres() -> (PgPool, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_tag("14-alpine")
+        .start()
+        .await
+        .unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{}/postgres", port);
+
+    let pool = PgPool::connect(&url).await.unwrap();
+
+    Migrator::new(Path::new(env!("CARGO_MANIFEST_DIR")).join("migrations"))
+        .await
+        .unwrap()
+        .run(&pool)
+        .await
+        .unwrap();
+
+    // Ensure current month partition for transactions table
+    let _ = sqlx::query(
+        r#"
+        DO $$
+        DECLARE
+            p_date DATE := DATE_TRUNC('month', NOW());
+            p_name TEXT := 'transactions_y' || TO_CHAR(p_date, 'YYYY') || 'm' || TO_CHAR(p_date, 'MM');
+        BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = p_name) THEN
+                EXECUTE format(
+                    'CREATE TABLE %I PARTITION OF transactions FOR VALUES FROM (%L) TO (%L)',
+                    p_name,
+                    TO_CHAR(p_date, 'YYYY-MM-DD'),
+                    TO_CHAR(p_date + INTERVAL '1 month', 'YYYY-MM-DD')
+                );
+            END IF;
+        END $$;
+        "#,
+    )
+    .execute(&pool)
+    .await;
+
+    (pool, container)
+}
+
+/// Set up Redis – tries testcontainers first, falls back to REDIS_URL env var.
+async fn setup_redis() -> (String, Option<ContainerAsync<testcontainers::GenericImage>>) {
+    // Prefer a running Redis from the environment.
+    if let Ok(url) = std::env::var("REDIS_URL") {
+        return (url, None);
+    }
+    // Fallback: start a Redis container with testcontainers.
+    let image = testcontainers::GenericImage::new("redis", "7-alpine");
+    let container = image.start().await.unwrap();
+    let port = container.get_host_port_ipv4(6379).await.unwrap();
+    let url = format!("redis://127.0.0.1:{}/", port);
+    (url, Some(container))
+}
+
+/// Helper: insert a webhook endpoint and a pending delivery row.
+async fn insert_endpoint_and_delivery(
+    pool: &PgPool,
+    url: &str,
+    max_delivery_rate: i32,
+    event_type: &str,
+) -> (Uuid, Uuid) {
+    let endpoint_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO webhook_endpoints (url, secret, event_types, max_delivery_rate)
+        VALUES ($1, 'test-secret', ARRAY[$3], $2)
+        RETURNING id
+        "#,
+    )
+    .bind(url)
+    .bind(max_delivery_rate)
+    .bind(event_type)
+    .fetch_one(pool)
+    .await
+    .expect("Failed to insert endpoint");
+
+    let delivery_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO webhook_deliveries
+            (endpoint_id, transaction_id, event_type, payload, status, next_attempt_at)
+        VALUES ($1, $2, $3, $4, 'pending', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(endpoint_id)
+    .bind(Uuid::new_v4())
+    .bind(event_type)
+    .bind(serde_json::json!({"event_type": event_type, "transaction_id": "test", "timestamp": "2025-01-01T00:00:00Z", "data": {"key": "value"}}))
+    .fetch_one(pool)
+    .await
+    .expect("Failed to insert delivery");
+
+    (endpoint_id, delivery_id)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 1: Two concurrent process_pending runs deliver each event exactly once
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_concurrent_process_pending_delivers_exactly_once() {
+    let (pool, _pg) = setup_postgres().await;
+    let (redis_url, _redis) = setup_redis().await;
+
+    // Start a mock server that accepts POSTs and returns 200.
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/webhook")
+        .with_status(200)
+        .expect(1) // Exactly one delivery expected
+        .create();
+
+    let endpoint_url = format!("{}/webhook", server.url());
+
+    // Insert one endpoint + one delivery.
+    let (_ep_id, delivery_id) =
+        insert_endpoint_and_delivery(&pool, &endpoint_url, 100, "test.event").await;
+
+    // Create two independent dispatcher instances (simulating two replicas).
+    let dispatcher1 =
+        WebhookDispatcher::new(pool.clone(), &redis_url).expect("dispatcher 1");
+    let dispatcher2 =
+        WebhookDispatcher::new(pool.clone(), &redis_url).expect("dispatcher 2");
+
+    // Run both process_pending calls concurrently.
+    let (r1, r2) = tokio::join!(dispatcher1.process_pending(), dispatcher2.process_pending());
+    assert!(r1.is_ok(), "first process_pending should succeed: {:?}", r1);
+    assert!(r2.is_ok(), "second process_pending should succeed: {:?}", r2);
+
+    // The mock was set to expect(1), so mockito will assert that only one
+    // request was received.
+    mock.assert_async().await;
+
+    // Verify the delivery row was marked as 'delivered'.
+    let status: String = sqlx::query_scalar("SELECT status FROM webhook_deliveries WHERE id = $1")
+        .bind(delivery_id)
+        .fetch_one(&pool)
+        .await
+        .expect("delivery should exist");
+    assert_eq!(status, "delivered", "delivery should be delivered exactly once");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 2: An exhausted delivery lands in the DLQ with full attempt history
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_exhausted_delivery_routed_to_dlq_with_history() {
+    let (pool, _pg) = setup_postgres().await;
+    let (redis_url, _redis) = setup_redis().await;
+
+    // Mock endpoint always returns 500 so the delivery exhausts.
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/fail")
+        .with_status(500)
+        .expect(5) // Exactly MAX_ATTEMPTS (5) attempts
+        .create();
+
+    let endpoint_url = format!("{}/fail", server.url());
+    let (_ep_id, delivery_id) =
+        insert_endpoint_and_delivery(&pool, &endpoint_url, 100, "test.exhaust").await;
+
+    let dispatcher =
+        WebhookDispatcher::new(pool.clone(), &redis_url).expect("dispatcher");
+
+    // Run process_pending in a loop to exhaust the delivery.
+    // After each failure, reset next_attempt_at so the next cycle picks it up
+    // immediately, bypassing the exponential backoff.
+    for _ in 0..6 {
+        let _ = dispatcher.process_pending().await;
+        sqlx::query(
+            "UPDATE webhook_deliveries SET next_attempt_at = NOW() WHERE status = 'pending'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    mock.assert_async().await;
+
+    // Verify the delivery is now 'failed'.
+    let status: String = sqlx::query_scalar("SELECT status FROM webhook_deliveries WHERE id = $1")
+        .bind(delivery_id)
+        .fetch_one(&pool)
+        .await
+        .expect("delivery should exist");
+    assert_eq!(status, "failed", "delivery should be failed after exhaustion");
+
+    // Verify the DLQ entry exists.
+    let dlq_entry: Option<(Uuid, i32, serde_json::Value)> = sqlx::query_as(
+        r#"
+        SELECT id, attempt_count, attempt_history
+        FROM webhook_delivery_dlq
+        WHERE delivery_id = $1
+        "#,
+    )
+    .bind(delivery_id)
+    .fetch_optional(&pool)
+    .await
+    .expect("DLQ query should succeed");
+
+    assert!(
+        dlq_entry.is_some(),
+        "Delivery should be in the DLQ after exhaustion"
+    );
+
+    let (_dlq_id, attempt_count, attempt_history) = dlq_entry.unwrap();
+    assert_eq!(attempt_count, 5, "DLQ should record 5 attempts");
+
+    // attempt_history should be a JSON array with 5 entries
+    if let Some(history_array) = attempt_history.as_array() {
+        assert!(
+            history_array.len() >= 5,
+            "DLQ attempt history should have at least 5 entries, got {}",
+            history_array.len()
+        );
+        // Each entry should have an attempt field
+        for entry in history_array {
+            assert!(
+                entry.get("attempt").is_some(),
+                "Each history entry should have an 'attempt' field"
+            );
+        }
+    } else {
+        panic!("attempt_history should be a JSON array, got {:?}", attempt_history);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Test 3: A failing endpoint trips its breaker without starving healthy endpoints
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+#[ignore = "Requires Docker"]
+async fn test_circuit_breaker_isolates_failing_endpoint() {
+    let (pool, _pg) = setup_postgres().await;
+    let (redis_url, _redis) = setup_redis().await;
+
+    // Two separate mock servers: one that always fails, one that succeeds.
+    let mut fail_server = Server::new_async().await;
+    let _failing_mock = fail_server
+        .mock("POST", "/fail-endpoint")
+        .with_status(500)
+        .create(); // No fixed expect count – it will trip the breaker.
+
+    let mut ok_server = Server::new_async().await;
+    let _healthy_mock = ok_server
+        .mock("POST", "/healthy-endpoint")
+        .with_status(200)
+        .create();
+
+    let fail_url = format!("{}/fail-endpoint", fail_server.url());
+    let ok_url = format!("{}/healthy-endpoint", ok_server.url());
+
+    // Insert two endpoints: one failing, one healthy.
+    let failing_ep_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO webhook_endpoints (url, secret, event_types, max_delivery_rate)
+        VALUES ($1, 'fail-secret', ARRAY['fail.event'], 100)
+        RETURNING id
+        "#,
+    )
+    .bind(&fail_url)
+    .fetch_one(&pool)
+    .await
+    .expect("Failed to insert failing endpoint");
+
+    let healthy_ep_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO webhook_endpoints (url, secret, event_types, max_delivery_rate)
+        VALUES ($1, 'ok-secret', ARRAY['ok.event'], 100)
+        RETURNING id
+        "#,
+    )
+    .bind(&ok_url)
+    .fetch_one(&pool)
+    .await
+    .expect("Failed to insert healthy endpoint");
+
+    // Insert 3 deliveries for the failing endpoint to trip the breaker.
+    let mut failing_delivery_ids = Vec::new();
+    for _ in 0..3 {
+        let did: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO webhook_deliveries
+                (endpoint_id, transaction_id, event_type, payload, status, next_attempt_at)
+            VALUES ($1, $2, 'fail.event', $3, 'pending', NOW())
+            RETURNING id
+            "#,
+        )
+        .bind(failing_ep_id)
+        .bind(Uuid::new_v4())
+        .bind(serde_json::json!({"event_type": "fail.event", "transaction_id": "fail", "timestamp": "2025-01-01T00:00:00Z", "data": {}}))
+        .fetch_one(&pool)
+        .await
+        .expect("Failed to insert failing delivery");
+        failing_delivery_ids.push(did);
+    }
+
+    // Insert 1 delivery for the healthy endpoint.
+    let healthy_delivery_id: Uuid = sqlx::query_scalar(
+        r#"
+        INSERT INTO webhook_deliveries
+            (endpoint_id, transaction_id, event_type, payload, status, next_attempt_at)
+        VALUES ($1, $2, 'ok.event', $3, 'pending', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(healthy_ep_id)
+    .bind(Uuid::new_v4())
+    .bind(serde_json::json!({"event_type": "ok.event", "transaction_id": "ok", "timestamp": "2025-01-01T00:00:00Z", "data": {}}))
+    .fetch_one(&pool)
+    .await
+    .expect("Failed to insert healthy delivery");
+
+    let dispatcher =
+        WebhookDispatcher::new(pool.clone(), &redis_url).expect("dispatcher");
+
+    // Run process_pending multiple times, resetting next_attempt_at so the
+    // failures happen back-to-back (bypassing exponential backoff).
+    // The failing endpoint should trip the circuit breaker after
+    // CB_FAILURE_THRESHOLD (3) failures.
+    // The healthy endpoint should always be delivered.
+    for _ in 0..6 {
+        let _ = dispatcher.process_pending().await;
+        sqlx::query(
+            "UPDATE webhook_deliveries SET next_attempt_at = NOW() WHERE status = 'pending'",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    // All failing deliveries should still be pending (not burned), but their
+    // next_attempt_at should be pushed into the future by the circuit breaker.
+    for did in &failing_delivery_ids {
+        let row = sqlx::query(
+            "SELECT status, attempt_count, next_attempt_at FROM webhook_deliveries WHERE id = $1",
+        )
+        .bind(did)
+        .fetch_one(&pool)
+        .await
+        .expect("failing delivery should exist");
+
+        let status: String = row.get("status");
+        let attempt_count: i32 = row.get("attempt_count");
+
+        assert_eq!(
+            status, "pending",
+            "failing delivery {} should still be pending (not consumed)",
+            did
+        );
+        assert!(
+            attempt_count < 5,
+            "failing delivery {} should not have exhausted attempts (was {})",
+            did,
+            attempt_count
+        );
+    }
+
+    // The healthy delivery should have been delivered.
+    let healthy_status: String =
+        sqlx::query_scalar("SELECT status FROM webhook_deliveries WHERE id = $1")
+            .bind(healthy_delivery_id)
+            .fetch_one(&pool)
+            .await
+            .expect("healthy delivery should exist");
+    assert_eq!(
+        healthy_status, "delivered",
+        "healthy endpoint delivery should succeed despite failing endpoint"
+    );
+
+    // Verify the circuit breaker key exists in Redis.
+    let mut redis_conn = RedisClient::open(redis_url.as_str())
+        .unwrap()
+        .get_multiplexed_async_connection()
+        .await
+        .unwrap();
+    let cb_key = format!("webhook_cb:{failing_ep_id}");
+    let cb_data: Option<String> = redis::cmd("GET")
+        .arg(&cb_key)
+        .query_async(&mut redis_conn)
+        .await
+        .unwrap();
+    assert!(
+        cb_data.is_some(),
+        "Circuit breaker state should be persisted in Redis for failing endpoint"
+    );
+    if let Some(data) = cb_data {
+        let state: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert_eq!(state["state"], "open", "Circuit breaker should be open");
+    }
+}


### PR DESCRIPTION
## Summary

Implements three remaining gaps for multi-replica webhook delivery safety:

### 1. Cross-instance double-delivery
`process_pending` now claims rows via a CTE with `SELECT ... FOR UPDATE SKIP LOCKED` — each pending row is atomically owned by exactly one worker. Stuck `in_progress` rows are reclaimed after `CLAIM_TIMEOUT_SECS` (5 minutes).

**Claim mechanism note:** Uses a CTE (`WITH candidate AS (SELECT ... FOR UPDATE SKIP LOCKED)`) because PostgreSQL does not allow `FOR UPDATE` in subqueries referencing the same table being modified. The CTE approach is the standard pattern for atomic job queues in PostgreSQL.

**Reclaim timeout:** `CLAIM_TIMEOUT_SECS = 300`. A crashed worker's `in_progress` rows become eligible for reclaim after this window.

### 2. Dead-letter queue on exhaustion
`handle_failure` routes exhausted deliveries (≥`MAX_ATTEMPTS` = 5) into `webhook_delivery_dlq` with the full JSONB `attempt_history`. `replay_from_dlq` re-enqueues entries with reset counters.

### 3. Per-endpoint circuit breaker
Redis-backed circuit breaker per endpoint (key `webhook_cb:{endpoint_id}`):
- **Threshold:** 3 consecutive failures (`CB_FAILURE_THRESHOLD`)
- **Reset timeout:** 300 seconds (`CB_RESET_TIMEOUT_SECS`)
- When open: deliveries are rescheduled without consuming attempt budget
- Lua script for atomic read-modify-write on failure

### Preserved unchanged
- HMAC-SHA256 signing with versioned timestamp
- `X-Webhook-Signature`, `X-Webhook-Timestamp`, `X-Webhook-Event` headers
- `ON CONFLICT (endpoint_id, transaction_id, event_type) DO NOTHING` enqueue dedup

## Verification

- `cargo check --tests` — compiles clean
- `cargo clippy --lib --tests -- -D warnings` — zero warnings
- `cargo test --lib` — 783 passed, 0 failed

Closes #578 