### PR TITLE
Fix quota TTL race and Redis fail-open bypass

### DIFF
--- a/src/middleware/quota.rs
+++ b/src/middleware/quota.rs
@@ -1,6 +1,32 @@
 use crate::middleware::idempotency::RedisCircuitBreaker;
 use redis::{AsyncCommands, Client};
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+    time::{Duration, Instant},
+};
+
+const INCREMENT_WITH_EXPIRY_SCRIPT: &str = r#"
+local current = redis.call('INCR', KEYS[1])
+-- The TTL check also repairs counters left without an expiry by older versions.
+if current == 1 or redis.call('TTL', KEYS[1]) < 0 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return current
+"#;
+
+async fn increment_with_expiry(
+    conn: &mut redis::aio::MultiplexedConnection,
+    key: &str,
+    ttl_seconds: i64,
+) -> redis::RedisResult<u32> {
+    redis::Script::new(INCREMENT_WITH_EXPIRY_SCRIPT)
+        .key(key)
+        .arg(ttl_seconds)
+        .invoke_async(conn)
+        .await
+}
 
 fn redis_cb_err(e: crate::middleware::idempotency::RedisError) -> redis::RedisError {
     match e {
@@ -116,11 +142,7 @@ impl QuotaManager {
             .cb
             .call(|| async move {
                 let mut conn = client.get_multiplexed_async_connection().await?;
-                let current: u32 = conn.incr(&usage_key2, 1).await?;
-                if current == 1 {
-                    let _: () = conn.expire(&usage_key2, ttl).await?;
-                }
-                Ok(current)
+                increment_with_expiry(&mut conn, &usage_key2, ttl).await
             })
             .await
             .map_err(redis_cb_err)?;
@@ -223,11 +245,7 @@ impl QuotaManager {
             .cb
             .call(|| async move {
                 let mut conn = client.get_multiplexed_async_connection().await?;
-                let current: u32 = conn.incr(&usage_key2, 1).await?;
-                if current == 1 {
-                    let _: () = conn.expire(&usage_key2, window_secs).await?;
-                }
-                Ok(current)
+                increment_with_expiry(&mut conn, &usage_key2, window_secs).await
             })
             .await
             .map_err(redis_cb_err)?;
@@ -303,6 +321,92 @@ use axum::{
 use crate::AppState;
 
 const DEFAULT_RATE_LIMIT_PER_MINUTE: u32 = 100;
+const LOCAL_FALLBACK_MAX_BUCKETS: usize = 10_000;
+const RATE_LIMIT_WINDOW: Duration = Duration::from_secs(60);
+
+#[derive(Debug)]
+struct LocalBucket {
+    window_started: Instant,
+    used: u32,
+}
+
+#[derive(Debug, Default)]
+struct LocalFallbackLimiter {
+    buckets: HashMap<String, LocalBucket>,
+}
+
+#[derive(Debug)]
+struct LocalQuotaResult {
+    allowed: bool,
+    status: QuotaStatus,
+}
+
+impl LocalFallbackLimiter {
+    fn consume(&mut self, key: &str, limit: u32, now: Instant) -> LocalQuotaResult {
+        if !self.buckets.contains_key(key) && self.buckets.len() >= LOCAL_FALLBACK_MAX_BUCKETS {
+            // Sweep only when capacity is needed, keeping the common request
+            // path O(1) while still reclaiming expired tenant buckets.
+            self.buckets.retain(|_, bucket| {
+                now.saturating_duration_since(bucket.window_started) < RATE_LIMIT_WINDOW
+            });
+        }
+
+        if !self.buckets.contains_key(key) && self.buckets.len() >= LOCAL_FALLBACK_MAX_BUCKETS {
+            return LocalQuotaResult {
+                allowed: false,
+                status: QuotaStatus {
+                    limit,
+                    used: limit,
+                    remaining: 0,
+                    reset_in_seconds: RATE_LIMIT_WINDOW.as_secs(),
+                },
+            };
+        }
+
+        let bucket = self.buckets.entry(key.to_owned()).or_insert(LocalBucket {
+            window_started: now,
+            used: 0,
+        });
+        if now.saturating_duration_since(bucket.window_started) >= RATE_LIMIT_WINDOW {
+            bucket.window_started = now;
+            bucket.used = 0;
+        }
+        bucket.used = bucket.used.saturating_add(1);
+        let elapsed = now.saturating_duration_since(bucket.window_started);
+        let reset_in_seconds = RATE_LIMIT_WINDOW.saturating_sub(elapsed).as_secs().max(1);
+
+        LocalQuotaResult {
+            allowed: bucket.used <= limit,
+            status: QuotaStatus {
+                limit,
+                used: bucket.used,
+                remaining: limit.saturating_sub(bucket.used),
+                reset_in_seconds,
+            },
+        }
+    }
+}
+
+fn local_fallback() -> &'static Mutex<LocalFallbackLimiter> {
+    static LIMITER: OnceLock<Mutex<LocalFallbackLimiter>> = OnceLock::new();
+    LIMITER.get_or_init(|| Mutex::new(LocalFallbackLimiter::default()))
+}
+
+/// Produce exactly one namespaced bucket whether the identifier is raw or was
+/// already namespaced by the tenant header path.
+fn canonical_quota_key(identifier: &str) -> String {
+    let identifier = identifier.trim_start_matches("tenant:");
+    format!("tenant:{identifier}")
+}
+
+fn consume_local_fallback(key: &str, limit: u32) -> LocalQuotaResult {
+    // Recovering from a poisoned mutex is safe here: all bucket updates happen
+    // while holding the guard, so the map remains structurally valid.
+    local_fallback()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .consume(key, limit, Instant::now())
+}
 
 /// Per-tenant rate limiting middleware.
 ///
@@ -346,42 +450,46 @@ pub async fn rate_limit_middleware(
             .unwrap_or(DEFAULT_RATE_LIMIT_PER_MINUTE)
     };
 
-    // Build a QuotaManager backed by the app's Redis URL.
-    let manager = match QuotaManager::new(&state.redis_url) {
-        Ok(m) => m,
-        Err(_) => {
-            // Redis unavailable — fail open to avoid blocking all traffic.
-            tracing::warn!("rate_limit: Redis unavailable, skipping quota check");
-            return next.run(req).await;
+    let per_minute_key = canonical_quota_key(&quota_key);
+
+    // Overload policy: Redis is authoritative when available. If it cannot be
+    // reached (including an open circuit), enforce the same fixed-window limit
+    // in a bounded, process-local map. The cap prevents attacker-controlled
+    // identifiers from growing memory without bound; new identifiers fail
+    // closed once the cap is full. In a multi-instance deployment the outage
+    // limit is per instance until Redis recovers.
+    let redis_result = match QuotaManager::new(&state.redis_url) {
+        Ok(manager) => manager
+            .consume_quota_with_window(&per_minute_key, limit_per_minute, 60)
+            .await
+            .map(|allowed| (manager, allowed)),
+        Err(error) => Err(error),
+    };
+
+    let (allowed, status) = match redis_result {
+        Ok((manager, allowed)) => {
+            let fallback_used = if allowed {
+                1
+            } else {
+                limit_per_minute.saturating_add(1)
+            };
+            let status = manager
+                .check_quota_with_limit(&per_minute_key, limit_per_minute)
+                .await
+                .unwrap_or(QuotaStatus {
+                    limit: limit_per_minute,
+                    used: fallback_used,
+                    remaining: limit_per_minute.saturating_sub(fallback_used),
+                    reset_in_seconds: RATE_LIMIT_WINDOW.as_secs(),
+                });
+            (allowed, status)
+        }
+        Err(error) => {
+            tracing::warn!(%error, "rate_limit: Redis unavailable; using bounded local limiter");
+            let result = consume_local_fallback(&per_minute_key, limit_per_minute);
+            (result.allowed, result.status)
         }
     };
-
-    // Override the quota config with the per-tenant per-minute limit.
-    let per_minute_key = format!("tenant:{quota_key}");
-    let quota_cfg = Quota {
-        tier: Tier::Free,
-        custom_limit: Some(limit_per_minute),
-        reset_schedule: ResetSchedule::Hourly, // TTL managed manually below
-    };
-    // Best-effort: set config (ignore errors).
-    let _ = manager.set_quota_config(&per_minute_key, &quota_cfg).await;
-
-    // Consume one unit.
-    let allowed = manager
-        .consume_quota_with_window(&per_minute_key, limit_per_minute, 60)
-        .await
-        .unwrap_or(true); // fail open on Redis error
-
-    // Read back status for headers.
-    let status = manager
-        .check_quota_with_limit(&per_minute_key, limit_per_minute)
-        .await
-        .unwrap_or(QuotaStatus {
-            limit: limit_per_minute,
-            used: 0,
-            remaining: limit_per_minute,
-            reset_in_seconds: 60,
-        });
 
     if !allowed {
         let retry_after = status.reset_in_seconds.max(1).to_string();
@@ -418,4 +526,42 @@ pub async fn rate_limit_middleware(
         HeaderValue::from_str(&status.reset_in_seconds.to_string()).unwrap(),
     );
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quota_key_is_canonical_for_raw_and_namespaced_identifiers() {
+        assert_eq!(canonical_quota_key("abc"), "tenant:abc");
+        assert_eq!(canonical_quota_key("tenant:abc"), "tenant:abc");
+        assert_eq!(canonical_quota_key("tenant:tenant:abc"), "tenant:abc");
+    }
+
+    #[test]
+    fn redis_down_fallback_does_not_allow_unlimited_requests() {
+        let mut limiter = LocalFallbackLimiter::default();
+        let now = Instant::now();
+
+        assert!(limiter.consume("tenant:a", 2, now).allowed);
+        assert!(limiter.consume("tenant:a", 2, now).allowed);
+        let rejected = limiter.consume("tenant:a", 2, now);
+        assert!(!rejected.allowed);
+        assert_eq!(rejected.status.remaining, 0);
+    }
+
+    #[test]
+    fn local_fallback_starts_a_new_window_after_expiry() {
+        let mut limiter = LocalFallbackLimiter::default();
+        let now = Instant::now();
+
+        assert!(limiter.consume("tenant:a", 1, now).allowed);
+        assert!(!limiter.consume("tenant:a", 1, now).allowed);
+        assert!(
+            limiter
+                .consume("tenant:a", 1, now + RATE_LIMIT_WINDOW)
+                .allowed
+        );
+    }
 }

--- a/tests/tenant_quota_test.rs
+++ b/tests/tenant_quota_test.rs
@@ -1,3 +1,4 @@
+use redis::AsyncCommands;
 /// Tests for #271 — Tenant-Specific Rate Limiting and Quota Management
 ///
 /// Validates:
@@ -113,4 +114,30 @@ async fn test_quota_reset_clears_usage() {
 
     let after = mgr.check_quota_with_limit(&k, 10).await.unwrap();
     assert_eq!(after.used, 0, "usage should be 0 after reset");
+}
+
+#[tokio::test]
+#[ignore = "Requires Redis"]
+async fn test_new_counter_always_has_a_ttl() {
+    let mgr = make_manager();
+    let k = key("atomic_ttl");
+
+    // Reproduce the state left by the former INCR-then-EXPIRE race: a usage
+    // counter exists but the process died before assigning its expiry.
+    let redis_url =
+        std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let client = redis::Client::open(redis_url).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+    let usage_key = format!("quota:usage:{k}");
+    let _: () = conn.set(&usage_key, 1_u32).await.unwrap();
+    let ttl_before: i64 = conn.ttl(&usage_key).await.unwrap();
+    assert_eq!(ttl_before, -1, "test setup must create a TTL-less counter");
+
+    assert!(mgr.consume_quota_with_window(&k, 10, 60).await.unwrap());
+
+    let status = mgr.check_quota_with_limit(&k, 10).await.unwrap();
+    assert!(
+        status.reset_in_seconds > 0 && status.reset_in_seconds <= 60,
+        "the atomic increment must never leave a counter without a TTL"
+    );
 }


### PR DESCRIPTION
Closes #586

## Summary
- replace the separate `INCR` / `EXPIRE` calls with one atomic Lua operation in both quota consumption paths
- repair legacy usage counters that already exist without a TTL
- remove the redundant per-request quota-config write
- normalize raw and already-prefixed tenant identifiers to one `tenant:<id>` bucket
- replace blanket Redis fail-open behavior with a bounded local fixed-window limiter

## Overload policy
Redis remains authoritative while available. If Redis is unavailable or its circuit is open, requests use a process-local 60-second fixed-window limiter with the tenant's configured limit. The fallback tracks at most 10,000 active buckets; expired buckets are reclaimed when capacity is needed, and unknown buckets fail closed when the cap remains full. During a multi-instance Redis outage, enforcement is per instance until Redis recovers.

## Tests
- `cargo test middleware::quota::tests --lib` (3 passed)
- `cargo test --test tenant_quota_test test_new_counter_always_has_a_ttl -- --ignored --nocapture` against Redis 7 (passed)
- `cargo clippy --lib -- -D warnings`
- `cargo fmt -- --check`

The Redis regression recreates the old failure state by seeding a counter without a TTL, then verifies that quota consumption atomically assigns a TTL.