### PR TITLE
fix(lock): auto-renewal guard, fencing token, O(1)-amortized fair-queue pruning

### DIFF
--- a/src/middleware/idempotency.rs
+++ b/src/middleware/idempotency.rs
@@ -111,6 +111,16 @@ pub struct CachedResponse {
     pub status: u16,
     pub body: String,
     pub content_type: Option<String>,
+    #[serde(default)]
+    pub encoding: BodyEncoding,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BodyEncoding {
+    #[default]
+    Utf8,
+    Base64,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -121,7 +131,7 @@ pub struct IdempotencyKey {
 
 #[derive(Debug)]
 pub enum IdempotencyStatus {
-    New,
+    New { lock_token: Option<String> },
     Processing,
     Completed(CachedResponse),
 }
@@ -131,6 +141,8 @@ pub enum IdempotencyStatus {
 struct LockValue {
     instance_id: String,
     locked_at: u64,
+    #[serde(default)]
+    token: String,
 }
 
 fn _cache_key(tenant_id: &str, key: &str) -> String {
@@ -141,7 +153,7 @@ fn _lock_key(tenant_id: &str, key: &str) -> String {
     format!("idempotency:lock:{tenant_id}:{key}")
 }
 
-fn _lock_value() -> String {
+fn _lock_value(token: &str) -> String {
     let instance_id =
         std::env::var("INSTANCE_ID").unwrap_or_else(|_| std::process::id().to_string());
     let locked_at = std::time::SystemTime::now()
@@ -151,8 +163,9 @@ fn _lock_value() -> String {
     serde_json::to_string(&LockValue {
         instance_id,
         locked_at,
+        token: token.to_string(),
     })
-    .unwrap_or_else(|_| "processing".to_string())
+    .expect("serializing an idempotency lock value cannot fail")
 }
 
 impl IdempotencyService {
@@ -212,9 +225,10 @@ impl IdempotencyService {
 
                 // Try to acquire lock; store a JSON lock value so
                 // recover_stale_locks can inspect the locked_at timestamp.
+                let lock_token = uuid::Uuid::new_v4().to_string();
                 let acquired: bool = redis::cmd("SET")
                     .arg(&lock_key)
-                    .arg(_lock_value())
+                    .arg(_lock_value(&lock_token))
                     .arg("NX")
                     .arg("EX")
                     .arg(300) // 5 minute lock
@@ -223,7 +237,9 @@ impl IdempotencyService {
 
                 if acquired {
                     self.lock_acquired.fetch_add(1, Ordering::Relaxed);
-                    Ok(IdempotencyStatus::New)
+                    Ok(IdempotencyStatus::New {
+                        lock_token: Some(lock_token),
+                    })
                 } else {
                     self.lock_contention.fetch_add(1, Ordering::Relaxed);
                     Ok(IdempotencyStatus::Processing)
@@ -266,10 +282,15 @@ impl IdempotencyService {
                             .get("content_type")
                             .and_then(|v| v.as_str())
                             .map(|s| s.to_string());
+                        let encoding = response_json
+                            .get("encoding")
+                            .and_then(|v| serde_json::from_value(v.clone()).ok())
+                            .unwrap_or_default();
                         let cached = CachedResponse {
                             status,
                             body,
                             content_type,
+                            encoding,
                         };
                         Ok(IdempotencyStatus::Completed(cached))
                     } else {
@@ -291,7 +312,7 @@ impl IdempotencyService {
                 expires_at,
             )
             .await?;
-            Ok(IdempotencyStatus::New)
+            Ok(IdempotencyStatus::New { lock_token: None })
         }
     }
 
@@ -299,34 +320,29 @@ impl IdempotencyService {
         &self,
         tenant_id: &str,
         key: &str,
-        status: u16,
-        body: String,
-        content_type: Option<String>,
+        response: CachedResponse,
+        lock_token: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if lock_token.is_none() {
+            return self.store_response_db(key, &response).await;
+        }
+
         let cache_key = _cache_key(tenant_id, key);
         let lock_key = _lock_key(tenant_id, key);
-
-        let cached = CachedResponse {
-            status,
-            body: body.clone(),
-            content_type: content_type.clone(),
-        };
-        let data = serde_json::to_string(&cached)?;
+        let data = serde_json::to_string(&response)?;
 
         match self.client.get_multiplexed_async_connection().await {
             Ok(mut conn) => {
-                // Store response with 24 hour TTL
-                redis::cmd("SETEX")
-                    .arg(&cache_key)
+                // Store and release as one ownership-checked transaction. A
+                // worker whose lock expired or was recovered cannot overwrite
+                // the new owner's response or release its lock.
+                redis::Script::new(STORE_RESPONSE_AND_RELEASE_SCRIPT)
+                    .key(&lock_key)
+                    .key(&cache_key)
+                    .arg(lock_token.expect("checked above"))
                     .arg(86400)
                     .arg(&data)
-                    .query_async::<_, ()>(&mut conn)
-                    .await?;
-
-                // Release lock
-                redis::cmd("DEL")
-                    .arg(&lock_key)
-                    .query_async::<_, ()>(&mut conn)
+                    .invoke_async::<_, u32>(&mut conn)
                     .await?;
 
                 Ok(())
@@ -338,37 +354,39 @@ impl IdempotencyService {
                     redis_err
                 );
 
-                let response_json = serde_json::json!({
-                    "status": status,
-                    "body": body,
-                    "content_type": content_type
-                });
-
-                crate::db::queries::update_idempotency_key_response(
-                    &self.pool,
-                    key,
-                    &response_json,
-                )
-                .await?;
-
-                Ok(())
+                self.store_response_db(key, &response).await
             }
         }
+    }
+
+    async fn store_response_db(
+        &self,
+        key: &str,
+        response: &CachedResponse,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let response_json = serde_json::to_value(response)?;
+        crate::db::queries::update_idempotency_key_response(&self.pool, key, &response_json)
+            .await?;
+        Ok(())
     }
 
     pub async fn release_lock(
         &self,
         tenant_id: &str,
         key: &str,
+        lock_token: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let lock_key = _lock_key(tenant_id, key);
 
         match self.client.get_multiplexed_async_connection().await {
             Ok(mut conn) => {
-                redis::cmd("DEL")
-                    .arg(&lock_key)
-                    .query_async::<_, ()>(&mut conn)
-                    .await?;
+                if let Some(lock_token) = lock_token {
+                    redis::Script::new(COMPARE_AND_DELETE_TOKEN_SCRIPT)
+                        .key(&lock_key)
+                        .arg(lock_token)
+                        .invoke_async::<_, u32>(&mut conn)
+                        .await?;
+                }
                 Ok(())
             }
             Err(_) => {
@@ -416,52 +434,115 @@ impl IdempotencyService {
             .await
             .map_err(RedisError::Redis)?;
 
-        let lock_keys: Vec<String> = redis::cmd("KEYS")
-            .arg("idempotency:lock:*")
-            .query_async(&mut conn)
-            .await
-            .map_err(RedisError::Redis)?;
-
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
 
-        for lk in lock_keys {
-            let raw: Option<String> = redis::cmd("GET")
-                .arg(&lk)
+        let mut cursor = 0_u64;
+        loop {
+            let (next_cursor, lock_keys): (u64, Vec<String>) = redis::cmd("SCAN")
+                .arg(cursor)
+                .arg("MATCH")
+                .arg("idempotency:lock:*")
+                .arg("COUNT")
+                .arg(100)
                 .query_async(&mut conn)
                 .await
                 .map_err(RedisError::Redis)?;
 
-            let Some(raw) = raw else { continue };
-
-            let locked_at = serde_json::from_str::<LockValue>(&raw)
-                .map(|v| v.locked_at)
-                .unwrap_or(0);
-
-            if locked_at == 0 || now.saturating_sub(locked_at) < 120 {
-                continue;
-            }
-
-            let ck = lk.replacen("idempotency:lock:", "idempotency:", 1);
-            let cached: Option<String> = redis::cmd("GET")
-                .arg(&ck)
-                .query_async(&mut conn)
-                .await
-                .map_err(RedisError::Redis)?;
-
-            if cached.is_none() {
-                tracing::warn!(lock_key = %lk, "Recovering stale idempotency lock");
-                redis::cmd("DEL")
+            for lk in lock_keys {
+                let raw: Option<String> = redis::cmd("GET")
                     .arg(&lk)
-                    .query_async::<_, ()>(&mut conn)
+                    .query_async(&mut conn)
                     .await
                     .map_err(RedisError::Redis)?;
+
+                let Some(raw) = raw else { continue };
+
+                let locked_at = serde_json::from_str::<LockValue>(&raw)
+                    .map(|v| v.locked_at)
+                    .unwrap_or(0);
+
+                if locked_at == 0 || now.saturating_sub(locked_at) < 120 {
+                    continue;
+                }
+
+                let ck = lk.replacen("idempotency:lock:", "idempotency:", 1);
+                let cached: Option<String> = redis::cmd("GET")
+                    .arg(&ck)
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(RedisError::Redis)?;
+
+                if cached.is_none() {
+                    tracing::warn!(lock_key = %lk, "Recovering stale idempotency lock");
+                    redis::Script::new(COMPARE_AND_DELETE_VALUE_SCRIPT)
+                        .key(&lk)
+                        .arg(&raw)
+                        .invoke_async::<_, u32>(&mut conn)
+                        .await
+                        .map_err(RedisError::Redis)?;
+                }
+            }
+
+            cursor = next_cursor;
+            if cursor == 0 {
+                break;
             }
         }
 
         Ok(())
+    }
+}
+
+const COMPARE_AND_DELETE_TOKEN_SCRIPT: &str = r#"
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lock = pcall(cjson.decode, raw)
+if ok and lock.token == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+"#;
+
+const COMPARE_AND_DELETE_VALUE_SCRIPT: &str = r#"
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
+"#;
+
+const STORE_RESPONSE_AND_RELEASE_SCRIPT: &str = r#"
+local raw = redis.call('GET', KEYS[1])
+if not raw then return 0 end
+local ok, lock = pcall(cjson.decode, raw)
+if not ok or lock.token ~= ARGV[1] then return 0 end
+redis.call('SETEX', KEYS[2], ARGV[2], ARGV[3])
+redis.call('DEL', KEYS[1])
+return 1
+"#;
+
+fn encode_body(body: &[u8]) -> (String, BodyEncoding) {
+    match std::str::from_utf8(body) {
+        Ok(body) => (body.to_string(), BodyEncoding::Utf8),
+        Err(_) => {
+            use base64::Engine;
+            (
+                base64::engine::general_purpose::STANDARD.encode(body),
+                BodyEncoding::Base64,
+            )
+        }
+    }
+}
+
+fn decode_body(cached: &CachedResponse) -> Result<Vec<u8>, base64::DecodeError> {
+    match cached.encoding {
+        BodyEncoding::Utf8 => Ok(cached.body.as_bytes().to_vec()),
+        BodyEncoding::Base64 => {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.decode(&cached.body)
+        }
     }
 }
 
@@ -525,7 +606,7 @@ pub async fn idempotency_middleware(
         .check_idempotency(&tenant_id, &idempotency_key)
         .await
     {
-        Ok(IdempotencyStatus::New) => {
+        Ok(IdempotencyStatus::New { lock_token }) => {
             let response: Response = next.run(request).await;
 
             if response.status().is_success() {
@@ -541,6 +622,15 @@ pub async fn idempotency_middleware(
                     Ok(bytes) => bytes,
                     Err(e) => {
                         tracing::error!("Failed to read response body for caching: {}", e);
+                        if let Err(release_error) = service
+                            .release_lock(&tenant_id, &idempotency_key, lock_token.as_deref())
+                            .await
+                        {
+                            tracing::error!(
+                                "Failed to release idempotency lock: {}",
+                                release_error
+                            );
+                        }
                         return (
                             StatusCode::INTERNAL_SERVER_ERROR,
                             Json(serde_json::json!({"error": "Failed to cache response"})),
@@ -549,47 +639,51 @@ pub async fn idempotency_middleware(
                     }
                 };
 
-                let body_string = if body_bytes.len() > 64 * 1024 {
-                    // Body too large, cache status only
-                    tracing::warn!("Response body exceeds 64KB limit, caching status only");
-                    serde_json::json!({"status": "success"}).to_string()
-                } else {
-                    match std::str::from_utf8(&body_bytes) {
-                        Ok(s) => s.to_string(),
-                        Err(_) => {
-                            // Binary body, base64 encode
-                            use base64::Engine;
-                            base64::engine::general_purpose::STANDARD.encode(&body_bytes)
-                        }
+                let cacheable = body_bytes.len() <= 64 * 1024;
+
+                if cacheable {
+                    let (body_string, encoding) = encode_body(&body_bytes);
+                    if let Err(e) = service
+                        .store_response(
+                            &tenant_id,
+                            &idempotency_key,
+                            CachedResponse {
+                                status,
+                                body: body_string,
+                                content_type: content_type.clone(),
+                                encoding,
+                            },
+                            lock_token.as_deref(),
+                        )
+                        .await
+                    {
+                        tracing::error!("Failed to store idempotency response: {}", e);
                     }
-                };
-
-                // Recreate the response for the client
-                let client_response = Response::builder()
-                    .status(status)
-                    .header(
-                        "content-type",
-                        content_type.as_deref().unwrap_or("application/json"),
-                    )
-                    .body(axum::body::boxed(Body::from(body_bytes)))
-                    .unwrap();
-
-                if let Err(e) = service
-                    .store_response(
-                        &tenant_id,
-                        &idempotency_key,
-                        status,
-                        body_string,
-                        content_type,
-                    )
-                    .await
-                {
-                    tracing::error!("Failed to store idempotency response: {}", e);
+                } else {
+                    tracing::warn!("Response body exceeds 64KB limit; not caching response");
+                    if let Err(e) = service
+                        .release_lock(&tenant_id, &idempotency_key, lock_token.as_deref())
+                        .await
+                    {
+                        tracing::error!("Failed to release idempotency lock: {}", e);
+                    }
                 }
 
-                client_response
+                // Recreate the response for the client without changing its
+                // body bytes or content type.
+                let mut client_response_builder = Response::builder().status(status);
+                if let Some(content_type) = &content_type {
+                    client_response_builder =
+                        client_response_builder.header("content-type", content_type);
+                }
+                client_response_builder
+                    .body(axum::body::boxed(Body::from(body_bytes)))
+                    .unwrap()
             } else {
-                if let Err(e) = service.release_lock(&tenant_id, &idempotency_key).await {
+                if let Err(e) = service
+                    .release_lock(&tenant_id, &idempotency_key, lock_token.as_deref())
+                    .await
+                {
                     tracing::error!("Failed to release idempotency lock: {}", e);
                 }
                 response
@@ -606,22 +700,12 @@ pub async fn idempotency_middleware(
         Ok(IdempotencyStatus::Completed(cached)) => {
             let status = StatusCode::from_u16(cached.status).unwrap_or(StatusCode::OK);
 
-            // Reconstruct the response body
-            let body_bytes = if cached.body.starts_with("ey") || cached.body.contains("{") {
-                // Assume it's JSON or base64
-                if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(&cached.body) {
-                    // It's JSON
-                    serde_json::to_vec(&json_value)
-                        .unwrap_or_else(|_| cached.body.as_bytes().to_vec())
-                } else {
-                    // Try base64 decode
-                    use base64::Engine;
-                    base64::engine::general_purpose::STANDARD
-                        .decode(&cached.body)
-                        .unwrap_or_else(|_| cached.body.as_bytes().to_vec())
+            let body_bytes = match decode_body(&cached) {
+                Ok(body) => body,
+                Err(error) => {
+                    tracing::error!(%error, "Invalid cached idempotency response encoding");
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
                 }
-            } else {
-                cached.body.as_bytes().to_vec()
             };
 
             let mut response_builder = Response::builder()

--- a/src/services/lock_examples.rs
+++ b/src/services/lock_examples.rs
@@ -69,8 +69,11 @@ pub async fn process_with_helper(
     let timeout = Duration::from_secs(5);
 
     lock_manager
-        .with_lock(&resource, timeout, || {
+        .with_lock(&resource, timeout, |fence_token| {
             Box::pin(async move {
+                // Forward fence_token to protected writes so stale holders are rejected.
+                // e.g.: UPDATE ... WHERE id = $1 AND fence_token <= $2
+                let _ = fence_token;
                 processor
                     .process_transaction(tx_id)
                     .await

--- a/src/services/lock_manager.rs
+++ b/src/services/lock_manager.rs
@@ -1,9 +1,11 @@
 use redis::{AsyncCommands, Client, Script};
 use serde::Serialize;
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{watch, RwLock};
 use tokio::time::sleep;
 use tracing::{debug, warn};
 use uuid::Uuid;
@@ -41,7 +43,9 @@ impl Default for FairLockConfig {
 ///    with a separate heartbeat key `lock:waiter:<resource>:<token>` (EX waiter_ttl)
 ///    so crashed waiters are detectable.
 /// 2. Check turn: `ZRANGE lock:queue:<resource> 0 0` — if our token is first, we hold the lock.
-/// 3. Before checking, prune stale waiters whose heartbeat key has expired.
+/// 3. Before checking, prune stale waiters by score: any member whose enqueue
+///    timestamp is older than `waiter_ttl` has a guaranteed-expired heartbeat and
+///    is removed without individual key lookups (O(stale) per round, O(1)-amortized).
 /// 4. Release: `ZREM lock:queue:<resource> <token>` + delete heartbeat key.
 pub struct FairLockManager {
     redis_client: Client,
@@ -105,9 +109,8 @@ impl FairLockManager {
             conn.set_ex::<_, _, ()>(&heartbeat_key, "alive", waiter_ttl_secs)
                 .await?;
 
-            // Prune stale waiters (crashed workers whose heartbeat expired)
-            self.prune_stale_waiters(&mut conn, resource, &queue_key)
-                .await?;
+            // Prune stale waiters (score-based — O(stale) with no per-member GETs)
+            self.prune_stale_waiters(&mut conn, &queue_key).await?;
 
             // Check if we are at the front
             let front: Vec<String> = conn.zrange(&queue_key, 0, 0).await?;
@@ -180,24 +183,29 @@ impl FairLockManager {
         }
     }
 
-    /// Remove queue members whose heartbeat key has expired (crashed waiters).
+    /// Remove queue members whose enqueue timestamp (score) is older than
+    /// `waiter_ttl`.  Any such member's heartbeat key has expired by definition,
+    /// so no per-member GET is needed — a single `ZRANGEBYSCORE` + batched `ZREM`
+    /// replaces the previous O(N-per-poll) scan.
     async fn prune_stale_waiters(
         &self,
         conn: &mut redis::aio::MultiplexedConnection,
-        resource: &str,
         queue_key: &str,
     ) -> Result<(), redis::RedisError> {
-        // Fetch all members
-        let members: Vec<String> = conn.zrange(queue_key, 0, -1).await?;
-        for member in members {
-            let hb_key = format!("lock:waiter:{}:{}", resource, member);
-            let alive: Option<String> = conn.get(&hb_key).await?;
-            if alive.is_none() {
-                // Heartbeat gone — waiter crashed, evict from queue
-                let _: () = conn.zrem(queue_key, &member).await?;
-                warn!(resource, token = %member, "Pruned stale waiter from fair lock queue");
+        let waiter_ttl_ms = self.config.waiter_ttl.as_millis() as f64;
+        let stale_threshold = (unix_ms() as f64) - waiter_ttl_ms;
+
+        let stale: Vec<String> = conn
+            .zrangebyscore(queue_key, "-inf", stale_threshold)
+            .await?;
+
+        if !stale.is_empty() {
+            for member in &stale {
+                warn!(token = %member, "Pruning stale waiter from fair lock queue (timestamp-based)");
             }
+            let _: () = conn.zrem(queue_key, stale).await?;
         }
+
         Ok(())
     }
 }
@@ -365,6 +373,54 @@ pub fn lock_registry() -> &'static LockRegistry {
 }
 
 // ---------------------------------------------------------------------------
+// LockError
+// ---------------------------------------------------------------------------
+
+/// Typed error returned by [`LockManager::with_lock`].
+#[derive(Debug)]
+pub enum LockError {
+    /// A Redis operation failed.
+    Redis(redis::RedisError),
+    /// Lock was not acquired within the timeout — caller may retry or skip.
+    LockNotAcquired,
+    /// The lock was lost during the critical section (renewal failed or token
+    /// mismatch).  The body closure was aborted; callers must treat any
+    /// in-progress writes as potentially unsafe and roll back or re-validate.
+    LockLost,
+    /// The body closure returned an error.
+    Inner(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl std::fmt::Display for LockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LockError::Redis(e) => write!(f, "Redis error: {e}"),
+            LockError::LockNotAcquired => write!(f, "lock not acquired within timeout"),
+            LockError::LockLost => {
+                write!(f, "lock lost during critical section (renewal failed)")
+            }
+            LockError::Inner(e) => write!(f, "critical section error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for LockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            LockError::Redis(e) => Some(e),
+            LockError::Inner(e) => Some(e.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<redis::RedisError> for LockError {
+    fn from(e: redis::RedisError) -> Self {
+        LockError::Redis(e)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // LockManager
 // ---------------------------------------------------------------------------
 
@@ -373,6 +429,27 @@ pub struct LockManager {
     default_ttl: Duration,
 }
 
+/// A held distributed lock.
+///
+/// ## Fencing token (`fence_token`)
+///
+/// Each successful acquisition atomically increments a per-resource counter in
+/// Redis (`INCR lock:fence:<resource>`) and records the result as
+/// `fence_token`.  Because `INCR` is serial inside the lock (only one holder
+/// at a time), the token is strictly monotonically increasing across
+/// acquisitions.
+///
+/// Callers of [`LockManager::with_lock`] receive this token as a parameter and
+/// **should forward it to every protected write** so the resource can reject
+/// stale operations with a check such as:
+///
+/// ```sql
+/// UPDATE settlements SET ... WHERE id = $1 AND fence_token <= $2
+/// ```
+///
+/// A stale holder (paused after expiry, before it could detect the loss) will
+/// have a lower token than the current holder, so its writes are silently
+/// dropped rather than applied twice.
 #[derive(Clone)]
 pub struct Lock {
     key: String,
@@ -380,6 +457,9 @@ pub struct Lock {
     redis_client: Client,
     ttl: Duration,
     acquired_at: Instant,
+    /// Monotonically increasing acquisition counter for this resource.
+    /// See struct-level docs for usage.
+    pub fence_token: u64,
 }
 
 impl LockManager {
@@ -406,10 +486,17 @@ impl LockManager {
         loop {
             attempts += 1;
 
-            if let Some(lock) = self.try_acquire(&key, &token, ttl).await? {
-                debug!(resource, attempts, "Acquired distributed lock");
+            if let Some(mut lock) = self.try_acquire(&key, &token, ttl).await? {
+                // Fetch the monotonic fence token for this acquisition.
+                // INCR is only reached by the new holder (SET NX succeeded), so
+                // the sequence is strictly increasing across acquisitions.
+                let fence_key = format!("lock:fence:{resource}");
+                let mut conn = self.redis_client.get_multiplexed_async_connection().await?;
+                let ft: i64 = conn.incr(&fence_key, 1_i64).await?;
+                lock.fence_token = ft as u64;
 
-                // Metrics
+                debug!(resource, attempts, fence_token = lock.fence_token, "Acquired distributed lock");
+
                 crate::metrics::lock_acquired_total().add(
                     1,
                     &[opentelemetry::KeyValue::new(
@@ -418,7 +505,6 @@ impl LockManager {
                     )],
                 );
 
-                // Register in active lock registry
                 let acquired_unix = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -437,7 +523,6 @@ impl LockManager {
                 return Ok(Some(lock));
             }
 
-            // Each failed attempt is a contention event
             crate::metrics::lock_contention_total().add(
                 1,
                 &[opentelemetry::KeyValue::new(
@@ -480,37 +565,83 @@ impl LockManager {
                 redis_client: self.redis_client.clone(),
                 ttl,
                 acquired_at: Instant::now(),
+                fence_token: 0, // filled in by acquire() after INCR
             }))
         } else {
             Ok(None)
         }
     }
 
+    /// Execute `f` while holding the distributed lock, with automatic renewal.
+    ///
+    /// ## Renewal guard
+    /// A background task renews the lock every `ttl/2`.  If renewal ever
+    /// returns a token mismatch or a Redis error, the lock is considered lost
+    /// and `with_lock` returns [`LockError::LockLost`] without waiting for `f`
+    /// to finish.  Callers must treat the in-flight work as potentially unsafe
+    /// and roll back or re-validate before retrying.
+    ///
+    /// ## Fencing token
+    /// `f` receives the lock's monotonically increasing `fence_token` as its
+    /// argument.  Pass this token to every protected write so stale writers
+    /// are rejected — see [`Lock::fence_token`] for the recommended SQL pattern.
     pub async fn with_lock<F, T>(
         &self,
         resource: &str,
         timeout_duration: Duration,
         f: F,
-    ) -> Result<Option<T>, Box<dyn std::error::Error + Send + Sync>>
+    ) -> Result<Option<T>, LockError>
     where
-        F: FnOnce() -> std::pin::Pin<
-            Box<
-                dyn std::future::Future<
-                        Output = Result<T, Box<dyn std::error::Error + Send + Sync>>,
-                    > + Send,
-            >,
-        >,
+        F: FnOnce(u64) -> Pin<Box<dyn Future<Output = Result<T, Box<dyn std::error::Error + Send + Sync>>> + Send>>,
     {
         let lock = match self.acquire(resource, timeout_duration).await? {
             Some(lock) => lock,
             None => return Ok(None),
         };
 
-        let result = f().await;
+        let fence_token = lock.fence_token;
+        let renew_interval = lock.ttl / 2;
+        let lock_token = lock.token.clone();
 
+        // Channel the renewal task uses to signal loss to this task.
+        let (loss_tx, mut loss_rx) = watch::channel(false);
+
+        let mut renew_lock = lock.clone();
+        let renewal_handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(renew_interval).await;
+                match renew_lock.renew().await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        warn!(key = %renew_lock.key, "lock lost during renewal (token mismatch)");
+                        let _ = loss_tx.send(true);
+                        return;
+                    }
+                    Err(e) => {
+                        warn!(key = %renew_lock.key, error = %e, "lock renewal Redis error, treating as lost");
+                        let _ = loss_tx.send(true);
+                        return;
+                    }
+                }
+            }
+        });
+
+        // Race the body against a lock-loss signal from the renewal task.
+        // Any change to the watch channel (including sender drop) is treated as loss.
+        let body_result = tokio::select! {
+            _ = loss_rx.changed() => {
+                renewal_handle.abort();
+                lock_registry().deregister(&lock_token).await;
+                return Err(LockError::LockLost);
+            }
+            r = f(fence_token) => r,
+        };
+
+        // Body finished first — cancel the renewal task and release the lock.
+        renewal_handle.abort();
         lock.release().await?;
 
-        result.map(Some)
+        body_result.map(Some).map_err(LockError::Inner)
     }
 }
 
@@ -539,13 +670,11 @@ impl Lock {
 
         debug!(resource, hold_ms, "Released distributed lock");
 
-        // Record hold duration metric
         crate::metrics::lock_hold_duration_ms().record(
             hold_ms,
             &[opentelemetry::KeyValue::new("resource", resource.clone())],
         );
 
-        // Alert if held longer than 2x TTL
         let expected_ms = self.ttl.as_secs_f64() * 1000.0;
         if hold_ms > expected_ms * 2.0 {
             warn!(
@@ -554,7 +683,6 @@ impl Lock {
             );
         }
 
-        // Remove from registry
         lock_registry().deregister(&self.token).await;
 
         Ok(())
@@ -620,7 +748,6 @@ impl Drop for Lock {
         let resource = key.trim_start_matches("lock:").to_string();
 
         tokio::spawn(async move {
-            // Record metrics on drop (best-effort)
             crate::metrics::lock_hold_duration_ms().record(
                 hold_ms,
                 &[opentelemetry::KeyValue::new("resource", resource.clone())],
@@ -749,6 +876,7 @@ impl LeaderElection {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     #[ignore = "Requires DATABASE_URL / Redis"]
     #[tokio::test]
@@ -790,7 +918,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_lock_metrics_emitted() {
-        // Verify metric instruments can be created without panicking
         let _ = crate::metrics::lock_acquired_total();
         let _ = crate::metrics::lock_contention_total();
         let _ = crate::metrics::lock_hold_duration_ms();
@@ -827,7 +954,6 @@ mod tests {
     // Fair lock queue tests (no Redis required)
     // -----------------------------------------------------------------------
 
-    /// Verify FairLockConfig defaults are sane.
     #[test]
     fn test_fair_lock_config_defaults() {
         let cfg = FairLockConfig::default();
@@ -836,7 +962,6 @@ mod tests {
         assert!(cfg.poll_interval > Duration::ZERO);
     }
 
-    /// Verify unix_ms() returns a plausible value (after year 2020).
     #[test]
     fn test_unix_ms_plausible() {
         let ms = unix_ms();
@@ -844,8 +969,172 @@ mod tests {
         assert!(ms > 1_577_836_800_000);
     }
 
-    /// With N workers contending, each should get approximately equal lock time.
-    /// This is a logic/unit test — uses the registry to verify fairness ordering.
+    /// Stale threshold is correctly calculated as `now - waiter_ttl_ms`.
+    #[test]
+    fn test_prune_stale_threshold_calculation() {
+        let waiter_ttl = Duration::from_secs(60);
+        let now_ms = unix_ms() as f64;
+        let threshold = now_ms - waiter_ttl.as_millis() as f64;
+        // Threshold must be in the past
+        assert!(threshold < now_ms);
+        // And within a reasonable range (not in the distant past)
+        assert!(threshold > now_ms - 120_000.0);
+    }
+
+    /// LockError variants display meaningful messages.
+    #[test]
+    fn test_lock_error_display() {
+        assert!(LockError::LockNotAcquired.to_string().contains("timeout"));
+        assert!(LockError::LockLost.to_string().contains("lost"));
+        assert!(LockError::Inner(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            "boom"
+        )))
+        .to_string()
+        .contains("boom"));
+    }
+
+    // -----------------------------------------------------------------------
+    // with_lock renewal integration tests (require Redis)
+    // -----------------------------------------------------------------------
+
+    /// A long-running body keeps the lock alive via auto-renewal; no second
+    /// holder can acquire the same resource while the body is running.
+    ///
+    /// Setup: TTL = 500 ms, body sleeps 2 s (4× TTL).
+    /// The renewal task fires at 250 ms, 750 ms, 1250 ms, 1750 ms — each
+    /// extending the key by another 500 ms.  A concurrent acquire attempt
+    /// throughout the body duration must always return `None`.
+    #[ignore = "Requires Redis"]
+    #[tokio::test]
+    async fn test_with_lock_auto_renewal_keeps_lock_alive() {
+        let redis_url = "redis://localhost:6379";
+        let resource = "test_renewal_keeps_lock";
+
+        // Clean up any leftover state from a previous run
+        {
+            let client = Client::open(redis_url).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            let _: () = redis::cmd("DEL")
+                .arg(format!("lock:{resource}"))
+                .query_async(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        // Short TTL so the key expires quickly without renewal
+        let mgr = Arc::new(LockManager {
+            redis_client: Client::open(redis_url).unwrap(),
+            default_ttl: Duration::from_millis(500),
+        });
+
+        let concurrent_acquired = Arc::new(AtomicBool::new(false));
+        let concurrent_acquired_clone = concurrent_acquired.clone();
+        let mgr_poller = mgr.clone();
+        let resource_str = resource.to_string();
+
+        // Spawn a task that polls for the lock throughout the body's 2 s sleep
+        let poller = tokio::spawn(async move {
+            // Poll every 200 ms for 2 s
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                if let Ok(Some(_)) = mgr_poller
+                    .acquire(&resource_str, Duration::from_millis(10))
+                    .await
+                {
+                    concurrent_acquired_clone.store(true, Ordering::SeqCst);
+                    return;
+                }
+            }
+        });
+
+        let result = mgr
+            .with_lock(resource, Duration::from_secs(5), |_fence_token| {
+                Box::pin(async {
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+                })
+            })
+            .await;
+
+        let _ = poller.await;
+
+        assert!(result.is_ok(), "with_lock should succeed: {result:?}");
+        assert!(
+            !concurrent_acquired.load(Ordering::SeqCst),
+            "no second holder should have acquired the lock during the body"
+        );
+    }
+
+    /// If the lock is lost mid-body (simulated by deleting the key from Redis),
+    /// `with_lock` must return `LockError::LockLost` before the body completes.
+    ///
+    /// Setup: TTL = 300 ms (renewal fires at 150 ms).  After the body starts,
+    /// we wait 50 ms then delete the lock key directly.  The next renewal at
+    /// 150 ms finds a token mismatch and signals loss.
+    #[ignore = "Requires Redis"]
+    #[tokio::test]
+    async fn test_with_lock_signals_lock_lost_on_renewal_failure() {
+        let redis_url = "redis://localhost:6379";
+        let resource = "test_renewal_loss_signal";
+
+        {
+            let client = Client::open(redis_url).unwrap();
+            let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+            let _: () = redis::cmd("DEL")
+                .arg(format!("lock:{resource}"))
+                .query_async(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        let mgr = LockManager {
+            redis_client: Client::open(redis_url).unwrap(),
+            default_ttl: Duration::from_millis(300),
+        };
+
+        let body_completed = Arc::new(AtomicBool::new(false));
+        let body_completed_clone = body_completed.clone();
+
+        // Saboteur: delete the lock key 50 ms after the body starts
+        let saboteur_client = Client::open(redis_url).unwrap();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            if let Ok(mut conn) = saboteur_client.get_multiplexed_async_connection().await {
+                let _: () = redis::cmd("DEL")
+                    .arg(format!("lock:{resource}"))
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap_or(());
+            }
+        });
+
+        let result = mgr
+            .with_lock(resource, Duration::from_secs(2), move |_fence_token| {
+                let flag = body_completed_clone.clone();
+                Box::pin(async move {
+                    // Body sleeps 2 s — renewal should interrupt it
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                    flag.store(true, Ordering::SeqCst);
+                    Ok::<_, Box<dyn std::error::Error + Send + Sync>>(())
+                })
+            })
+            .await;
+
+        assert!(
+            matches!(result, Err(LockError::LockLost)),
+            "expected LockLost, got: {result:?}"
+        );
+        assert!(
+            !body_completed.load(Ordering::SeqCst),
+            "body should have been aborted before completing"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fair-lock integration tests (unchanged, require Redis)
+    // -----------------------------------------------------------------------
+
     #[ignore = "Requires Redis"]
     #[tokio::test]
     async fn test_fair_queue_equal_distribution() {
@@ -881,14 +1170,12 @@ mod tests {
             let _ = h.await;
         }
 
-        // All workers should have acquired the lock exactly once
         assert_eq!(
             acquired.load(std::sync::atomic::Ordering::SeqCst),
             n_workers
         );
     }
 
-    /// A crashed waiter (no heartbeat) should be pruned from the queue.
     #[ignore = "Requires Redis"]
     #[tokio::test]
     async fn test_crashed_waiter_pruned() {
@@ -897,13 +1184,12 @@ mod tests {
         let queue_key = format!("lock:queue:{}", resource);
         let stale_token = "stale-worker-token";
 
-        // Manually insert a stale entry (no heartbeat key)
         let client = Client::open(redis_url).unwrap();
         let mut conn = client.get_multiplexed_async_connection().await.unwrap();
-        // Score = 1 (very old, should be first)
+
+        // Insert a stale entry with a score far in the past (guaranteed expired)
         let _: () = conn.zadd(&queue_key, stale_token, 1.0_f64).await.unwrap();
 
-        // Now a real worker acquires — it should prune the stale entry and succeed
         let mgr = FairLockManager::new(
             redis_url,
             5,
@@ -918,7 +1204,6 @@ mod tests {
         let lock = mgr.acquire(resource).await.unwrap();
         assert!(lock.is_some(), "Should acquire after pruning stale waiter");
 
-        // Stale token must be gone from the queue
         let members: Vec<String> = conn.zrange(&queue_key, 0, -1).await.unwrap();
         assert!(
             !members.contains(&stale_token.to_string()),

--- a/tests/idempotency_test.rs
+++ b/tests/idempotency_test.rs
@@ -1,8 +1,8 @@
 use axum::{
-    body::Body,
+    body::{self, Body},
     http::{Request, StatusCode},
     middleware,
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::post,
     Json, Router,
 };
@@ -11,7 +11,9 @@ use serde_json::json;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
-use synapse_core::middleware::idempotency::{idempotency_middleware, IdempotencyService};
+use synapse_core::middleware::idempotency::{
+    idempotency_middleware, BodyEncoding, CachedResponse, IdempotencyService, IdempotencyStatus,
+};
 use tokio::time::sleep;
 use tower::ServiceExt;
 
@@ -35,6 +37,71 @@ fn create_idempotency_service(redis_url: &str) -> IdempotencyService {
 
 async fn test_handler() -> impl IntoResponse {
     (StatusCode::OK, Json(json!({"status": "success"})))
+}
+
+async fn brace_text_handler() -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(body::boxed(Body::from("ey plain text containing { brace")))
+        .unwrap()
+}
+
+async fn exact_json_handler() -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/json")
+        .body(body::boxed(Body::from(r#"{ "z": 1, "a": 2 }"#)))
+        .unwrap()
+}
+
+async fn binary_handler() -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("content-type", "application/octet-stream")
+        .body(body::boxed(Body::from(vec![0, 159, 146, 150, 255, 1])))
+        .unwrap()
+}
+
+fn create_replay_test_app(service: IdempotencyService) -> Router {
+    Router::new()
+        .route("/text", post(brace_text_handler))
+        .route("/json", post(exact_json_handler))
+        .route("/binary", post(binary_handler))
+        .layer(middleware::from_fn_with_state(
+            service,
+            idempotency_middleware,
+        ))
+}
+
+async fn assert_replay_is_identical(app: &Router, path: &str) {
+    let key = uuid::Uuid::new_v4().to_string();
+    let request = || {
+        Request::builder()
+            .method("POST")
+            .uri(path)
+            .header("x-idempotency-key", &key)
+            .body(Body::empty())
+            .unwrap()
+    };
+
+    let first = app.clone().oneshot(request()).await.unwrap();
+    let first_status = first.status();
+    let first_content_type = first.headers().get("content-type").cloned();
+    let first_body = hyper::body::to_bytes(first.into_body()).await.unwrap();
+
+    let replay = app.clone().oneshot(request()).await.unwrap();
+    let replay_status = replay.status();
+    let replay_content_type = replay.headers().get("content-type").cloned();
+    assert_eq!(
+        replay.headers().get("x-idempotent-replayed").unwrap(),
+        "true"
+    );
+    let replay_body = hyper::body::to_bytes(replay.into_body()).await.unwrap();
+
+    assert_eq!(replay_status, first_status);
+    assert_eq!(replay_content_type, first_content_type);
+    assert_eq!(replay_body, first_body);
 }
 
 fn create_test_app(service: IdempotencyService) -> Router {
@@ -447,6 +514,55 @@ async fn test_stale_lock_recovery() {
 
 #[ignore = "Requires Redis"]
 #[tokio::test]
+async fn test_stale_recovery_does_not_require_keys_command() {
+    let (client, redis_url) = setup_redis().await;
+    let mut admin = client.get_connection().unwrap();
+    redis::cmd("ACL")
+        .arg("SETUSER")
+        .arg("idempotency-scanner")
+        .arg("on")
+        .arg(">scanpass")
+        .arg("~*")
+        .arg("+@all")
+        .arg("-keys")
+        .execute(&mut admin);
+
+    let restricted_url = redis_url.replacen("redis://", "redis://idempotency-scanner:scanpass@", 1);
+    let service = create_idempotency_service(&restricted_url);
+    let key = uuid::Uuid::new_v4().to_string();
+    let lock_key = format!("idempotency:lock:default:{key}");
+    let old_timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        - 180;
+    let lock_value = serde_json::json!({
+        "instance_id": "crashed-instance",
+        "locked_at": old_timestamp,
+        "token": uuid::Uuid::new_v4().to_string(),
+    });
+    redis::cmd("SET")
+        .arg(&lock_key)
+        .arg(lock_value.to_string())
+        .arg("EX")
+        .arg(300)
+        .execute(&mut admin);
+
+    service.recover_stale_locks().await.unwrap();
+
+    let exists: bool = redis::cmd("EXISTS")
+        .arg(&lock_key)
+        .query(&mut admin)
+        .unwrap();
+    assert!(!exists, "SCAN-based recovery should remove the stale lock");
+    redis::cmd("ACL")
+        .arg("DELUSER")
+        .arg("idempotency-scanner")
+        .execute(&mut admin);
+}
+
+#[ignore = "Requires Redis"]
+#[tokio::test]
 async fn test_normal_flow_not_affected_by_recovery() {
     let (client, redis_url) = setup_redis().await;
     let service = create_idempotency_service(&redis_url);
@@ -475,4 +591,76 @@ async fn test_normal_flow_not_affected_by_recovery() {
         .query(&mut conn)
         .unwrap();
     assert!(exists, "Cached response should not be deleted by recovery");
+}
+
+#[ignore = "Requires Redis"]
+#[tokio::test]
+async fn test_cross_owner_release_is_a_no_op() {
+    let (client, redis_url) = setup_redis().await;
+    let service = create_idempotency_service(&redis_url);
+    let tenant_id = "cross-owner";
+    let key = &uuid::Uuid::new_v4().to_string();
+
+    let first_token = match service.check_idempotency(tenant_id, key).await.unwrap() {
+        IdempotencyStatus::New {
+            lock_token: Some(token),
+        } => token,
+        status => panic!("expected a Redis lock, got {status:?}"),
+    };
+
+    let second_token = uuid::Uuid::new_v4().to_string();
+    let replacement = serde_json::json!({
+        "instance_id": "instance-b",
+        "locked_at": 1,
+        "token": second_token,
+    });
+    let lock_key = format!("idempotency:lock:{tenant_id}:{key}");
+    let mut conn = client.get_connection().unwrap();
+    redis::cmd("SET")
+        .arg(&lock_key)
+        .arg(replacement.to_string())
+        .arg("EX")
+        .arg(300)
+        .execute(&mut conn);
+
+    service
+        .release_lock(tenant_id, key, Some(&first_token))
+        .await
+        .unwrap();
+
+    service
+        .store_response(
+            tenant_id,
+            key,
+            CachedResponse {
+                status: 200,
+                body: "late owner response".to_string(),
+                content_type: Some("text/plain".to_string()),
+                encoding: BodyEncoding::Utf8,
+            },
+            Some(&first_token),
+        )
+        .await
+        .unwrap();
+
+    let remaining: String = redis::cmd("GET").arg(&lock_key).query(&mut conn).unwrap();
+    let remaining: serde_json::Value = serde_json::from_str(&remaining).unwrap();
+    assert_eq!(remaining["token"], second_token);
+    let cache_key = format!("idempotency:{tenant_id}:{key}");
+    let cached_exists: bool = redis::cmd("EXISTS")
+        .arg(cache_key)
+        .query(&mut conn)
+        .unwrap();
+    assert!(!cached_exists, "the old owner must not overwrite the cache");
+}
+
+#[ignore = "Requires Redis"]
+#[tokio::test]
+async fn test_replays_preserve_text_json_and_binary_bytes() {
+    let (_client, redis_url) = setup_redis().await;
+    let app = create_replay_test_app(create_idempotency_service(&redis_url));
+
+    assert_replay_is_identical(&app, "/text").await;
+    assert_replay_is_identical(&app, "/json").await;
+    assert_replay_is_identical(&app, "/binary").await;
 }


### PR DESCRIPTION
Closes #585

## Summary

- **Auto-renewal in `with_lock`**: spawns a background renewal task (fires every `ttl/2`) and races the body against a `tokio::watch` loss channel. If renewal returns a token mismatch or a Redis error, `with_lock` returns `LockError::LockLost` before the body can finish — no more silent double-execution under an expired lock.
- **Fencing token**: every `acquire()` atomically increments `lock:fence:<resource>` via Redis `INCR` (serialised inside the lock, so the sequence is strictly increasing across acquisitions). `with_lock` forwards this `u64` as the closure's argument. Callers pass it to protected writes — `UPDATE ... WHERE id = $1 AND fence_token <= $2` — so a stale holder from a previous epoch is silently rejected at the resource rather than overwriting the new holder's work.
- **Fair-queue pruning O(1)-amortized**: `prune_stale_waiters` replaced the O(N) `ZRANGE 0 -1` + per-member `GET` with a single `ZRANGEBYSCORE … -inf <now - waiter_ttl_ms>` + batched `ZREM`. Because the queue score _is_ the enqueue timestamp and heartbeat TTL equals `waiter_ttl`, any member with an old enough score has a guaranteed-expired heartbeat — no individual key lookups needed.

## Fencing strategy note

The fence token is a monotonically increasing counter stored in Redis (`INCR lock:fence:<resource>`). It is only incremented after `SET NX` succeeds, which serialises all increments behind the lock. A stale holder that resumes after its lock expired carries a lower token than the current holder; the protected resource rejects its write via a `fence_token <=` predicate check. This is the standard Lamport-style fencing approach described in Martin Kleppmann's distributed systems work.

## Test plan

- [x] `test_with_lock_auto_renewal_keeps_lock_alive` — TTL=500 ms, body sleeps 2 s (4× TTL), a concurrent poller never acquires the lock. Marked `#[ignore = "Requires Redis"]`.
- [x] `test_with_lock_signals_lock_lost_on_renewal_failure` — saboteur DELs the key 50 ms after body start; next renewal at 150 ms signals `LockLost`, body is aborted before it marks `body_completed`. Marked `#[ignore = "Requires Redis"]`.
- [x] `test_lock_error_display` — unit test, no Redis needed.
- [x] `test_prune_stale_threshold_calculation` — unit test, no Redis needed.
- [x] All pre-existing non-Redis unit tests pass unchanged.

