### PR TITLE
fix: make insert_transaction safe to retry after transient post-commi…

### DIFF
--- a/docs/database-reconnection-logic.md
+++ b/docs/database-reconnection-logic.md
@@ -16,22 +16,42 @@ The helper `crate::utils::retry::is_transient_db_error` marks the following case
 
 - `sqlx::Error::Io(_)`
 - `sqlx::Error::PoolTimedOut`
-- PostgreSQL connection errors such as `connection reset`, `could not connect`, and recognized SQLSTATE codes
-- Deadlock (`40P01`) and serialization failure (`40001`)
+- For `sqlx::Error::Database`, the PostgreSQL SQLSTATE code (`db_err.code()`) is
+  checked first — codes such as `40P01` (deadlock), `40001` (serialization
+  failure), `08000`/`08001`/`08003`/`08004`/`08006` (connection failures),
+  `57P03` (cannot connect now), and `53300` (too many connections) are
+  treated as transient
+- Message-substring matching (`"deadlock detected"`, `"could not connect"`, …)
+  is used **only** as a fallback when the driver doesn't surface a SQLSTATE
+  code, since message text is locale- and version-dependent
 
 Permanent errors such as `RowNotFound` or `PoolClosed` are not retried.
 
-### Exponential backoff
+### Exponential backoff with decorrelated jitter
 
 `crate::utils::retry::retry_with_backoff` provides:
 
 - configurable `max_retries`
 - base delay in milliseconds
-- exponential backoff with a jitter window
+- decorrelated jitter (`min(cap, random(base, prev_delay * 3))`) drawn from a
+  real RNG (`rand::thread_rng()`) per call, instead of a wall-clock-derived
+  offset — this avoids correlated "thundering herd" retries when many
+  callers fail at the same instant (e.g. a primary failover)
 - a hard cap at 10 seconds per retry
 - retry metrics emitted via tracing
 
 This lets database queries recover from brief outages or connection hiccups while preventing hot loops.
+
+### Idempotency requirement
+
+`retry_with_backoff` may invoke the wrapped operation more than once for the
+same logical call, so it must only wrap idempotent operations: SELECTs,
+upserts (`ON CONFLICT DO NOTHING`/`DO UPDATE`), or writes guarded by a stable
+idempotency key. `db::queries::insert_transaction` wraps its INSERT in
+`ON CONFLICT (id, created_at) DO NOTHING` keyed on the caller-generated
+transaction id, and only writes the audit log entry when the row didn't
+already exist — so a retry after a transient post-commit error returns the
+existing row instead of duplicating the write or the audit trail.
 
 ## Connection Pool Behavior
 

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -326,6 +326,16 @@ pub async fn set_tenant_context(
 /// entry in the same SQL transaction, and invalidates aggregate caches only
 /// after commit. Handlers should use this helper instead of issuing their own
 /// INSERT so webhook persistence remains auditable and timeout protected.
+///
+/// This is wrapped in [`crate::utils::retry::retry_with_backoff`], so the
+/// insert is keyed on the caller-generated `tx.id`/`tx.created_at` (the
+/// partitioned table's primary key) and uses
+/// `ON CONFLICT (id, created_at) DO NOTHING`: if an earlier attempt's commit
+/// actually succeeded but the client saw a transient error anyway (e.g. the
+/// connection dropped right after `COMMIT`), the retry observes the existing
+/// row instead of inserting a duplicate or double-writing the audit log.
+/// Coordinates with the `anchor_transaction_id` idempotency guard so the
+/// same inbound Anchor callback can't be persisted twice either.
 pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<Transaction> {
     with_timeout(
         QueryTier::Write,
@@ -333,8 +343,10 @@ pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<Trans
         crate::utils::retry::retry_with_backoff("insert_transaction", 3, 100, || async {
             let mut db_tx = pool.begin().await?;
 
-            let result = persist_transaction(&mut db_tx, tx).await?;
-            audit_transaction_creation(&mut db_tx, &result).await?;
+            let (result, inserted) = persist_transaction(&mut db_tx, tx).await?;
+            if inserted {
+                audit_transaction_creation(&mut db_tx, &result).await?;
+            }
 
             db_tx.commit().await?;
 
@@ -347,17 +359,23 @@ pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<Trans
     .await
 }
 
+/// Inserts `tx`, returning the persisted row and whether this call actually
+/// performed the insert (`true`) or found it already committed by an earlier
+/// retry attempt (`false`).
 async fn persist_transaction(
     db_tx: &mut SqlxTransaction<'_, Postgres>,
     tx: &Transaction,
-) -> Result<Transaction> {
-    sqlx::query_as::<_, Transaction>(
+) -> Result<(Transaction, bool)> {
+    let inserted = sqlx::query_as::<_, Transaction>(
         r#"
         INSERT INTO transactions (
             id, stellar_account, amount, asset_code, status,
             created_at, updated_at, anchor_transaction_id, callback_type, callback_status,
             settlement_id, memo, memo_type, metadata
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+        -- The table is partitioned by created_at, so the primary key (and the
+        -- only conflict target Postgres accepts here) is (id, created_at).
+        ON CONFLICT (id, created_at) DO NOTHING
         RETURNING *
         "#,
     )
@@ -375,8 +393,22 @@ async fn persist_transaction(
     .bind(&tx.memo)
     .bind(&tx.memo_type)
     .bind(&tx.metadata)
-    .fetch_one(&mut **db_tx)
-    .await
+    .fetch_optional(&mut **db_tx)
+    .await?;
+
+    match inserted {
+        Some(row) => Ok((row, true)),
+        None => {
+            let row = sqlx::query_as::<_, Transaction>(
+                "SELECT * FROM transactions WHERE id = $1 AND created_at = $2",
+            )
+            .bind(tx.id)
+            .bind(tx.created_at)
+            .fetch_one(&mut **db_tx)
+            .await?;
+            Ok((row, false))
+        }
+    }
 }
 
 async fn audit_transaction_creation(

--- a/src/utils/retry.rs
+++ b/src/utils/retry.rs
@@ -1,36 +1,92 @@
+use rand::Rng;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, warn};
 
+/// Hard cap on any single retry delay, regardless of attempt count.
+const MAX_DELAY_MS: u64 = 10_000;
+
+/// SQLSTATE codes treated as transient (retryable) DB failures.
+///
+/// - `40P01` deadlock_detected
+/// - `40001` serialization_failure
+/// - `08000` connection_exception
+/// - `08003` connection_does_not_exist
+/// - `08001` sqlclient_unable_to_establish_sqlconnection
+/// - `08004` sqlserver_rejected_establishment_of_sqlconnection
+/// - `08006` connection_failure
+/// - `57P03` cannot_connect_now (e.g. DB still starting up / in recovery)
+/// - `53300` too_many_connections
+fn is_transient_sqlstate(code: &str) -> bool {
+    matches!(
+        code,
+        "40P01" | "40001" | "08000" | "08003" | "08001" | "08004" | "08006" | "57P03" | "53300"
+    )
+}
+
+/// Last-resort classification when the driver/server didn't surface a SQLSTATE
+/// code. Message text is locale- and version-dependent, so this is only
+/// consulted when `db_err.code()` is `None`.
+fn is_transient_by_message(message: &str) -> bool {
+    let msg = message.to_lowercase();
+    msg.contains("deadlock detected")
+        || msg.contains("serialization failure")
+        || msg.contains("connection reset")
+        || msg.contains("could not connect")
+}
+
 /// Classifies whether a sqlx error is transient (retryable) or permanent.
+///
+/// Classification prefers the PostgreSQL SQLSTATE code (`db_err.code()`),
+/// which is stable across locales and server versions. Message-substring
+/// matching is only a fallback for the rare case where no code is available.
 pub fn is_transient_db_error(err: &sqlx::Error) -> bool {
     match err {
         sqlx::Error::Io(_) => true,
         sqlx::Error::PoolTimedOut => true,
         sqlx::Error::PoolClosed => false,
-        sqlx::Error::Database(db_err) => {
-            let msg = db_err.message().to_lowercase();
-            // Deadlock detected (PostgreSQL code 40P01)
-            // Serialization failure (PostgreSQL code 40001)
-            // Connection reset / connection failure
-            msg.contains("deadlock detected")
-                || msg.contains("serialization failure")
-                || msg.contains("connection reset")
-                || msg.contains("could not connect")
-                || db_err.code().is_some_and(|c| {
-                    matches!(c.as_ref(), "40P01" | "40001" | "08006" | "08001" | "08004")
-                })
-        }
+        sqlx::Error::Database(db_err) => match db_err.code() {
+            Some(code) => is_transient_sqlstate(code.as_ref()),
+            None => is_transient_by_message(db_err.message()),
+        },
         _ => false,
     }
 }
 
-/// Retry a fallible async operation with exponential backoff + jitter.
+/// Computes the next decorrelated-jitter delay given the previous delay.
+///
+/// Implements the "decorrelated jitter" formula (`min(cap, random(base, prev * 3))`):
+/// each caller draws its own delay from a real RNG rather than deriving it from
+/// the wall clock, so callers that fail at the same instant (e.g. a primary
+/// failover) spread their retries out instead of retrying in lockstep.
+fn decorrelated_jitter_delay_ms(
+    prev_delay_ms: u64,
+    base_delay_ms: u64,
+    cap_ms: u64,
+    rng: &mut impl Rng,
+) -> u64 {
+    let upper = prev_delay_ms.saturating_mul(3).max(base_delay_ms);
+    let next = rng.gen_range(base_delay_ms..=upper);
+    next.min(cap_ms)
+}
+
+/// Retry a fallible async operation with exponential backoff + decorrelated jitter.
 ///
 /// - `max_retries`: maximum number of retry attempts (not counting the initial try)
 /// - `base_delay_ms`: base delay in milliseconds before the first retry
 /// - Retries only when `is_transient_db_error` returns true
 /// - Tracks `db_retry_total` metric by error type
+///
+/// # Idempotency requirement
+///
+/// `f` may be invoked more than once for the same logical call. Only wrap
+/// operations that are safe to run multiple times — either naturally
+/// idempotent (SELECTs, `ON CONFLICT DO NOTHING`/`UPDATE` upserts) or guarded
+/// by an explicit idempotency key (e.g. a stable primary key checked before
+/// insert). Wrapping a plain, non-idempotent write (such as an unguarded
+/// `INSERT`) risks duplicating it if a transient error occurs *after* the
+/// write already committed (e.g. the connection drops while reading the
+/// commit acknowledgement).
 pub async fn retry_with_backoff<F, Fut, T>(
     operation_name: &str,
     max_retries: u32,
@@ -42,22 +98,24 @@ where
     Fut: std::future::Future<Output = Result<T, sqlx::Error>>,
 {
     let mut attempt = 0u32;
+    let mut prev_delay_ms = base_delay_ms;
     loop {
         match f().await {
             Ok(val) => return Ok(val),
             Err(err) if attempt < max_retries && is_transient_db_error(&err) => {
                 attempt += 1;
-                // Exponential backoff: base * 2^(attempt-1), capped at 10s
-                let exp_delay = base_delay_ms * (1u64 << (attempt - 1).min(6));
-                // Jitter: ±25% of the delay using a simple pseudo-random approach
-                let jitter = (exp_delay / 4).max(1);
-                let jitter_offset = (std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .subsec_nanos() as u64)
-                    % (jitter * 2);
-                let delay_ms = exp_delay.saturating_sub(jitter) + jitter_offset;
-                let delay_ms = delay_ms.min(10_000);
+                // `rand::thread_rng()` is `!Send`, so it's created and dropped
+                // within this synchronous block rather than held across the
+                // `.await` points in this loop (which would make the
+                // resulting future `!Send`, breaking callers that need to
+                // spawn or hold it across threads, e.g. axum handlers).
+                let delay_ms = decorrelated_jitter_delay_ms(
+                    prev_delay_ms,
+                    base_delay_ms,
+                    MAX_DELAY_MS,
+                    &mut rand::thread_rng(),
+                );
+                prev_delay_ms = delay_ms;
 
                 warn!(
                     operation = operation_name,
@@ -94,18 +152,25 @@ fn classify_error_kind(err: &sqlx::Error) -> &'static str {
     match err {
         sqlx::Error::Io(_) => "io",
         sqlx::Error::PoolTimedOut => "pool_timeout",
-        sqlx::Error::Database(db_err) => {
-            let msg = db_err.message().to_lowercase();
-            if msg.contains("deadlock") {
-                "deadlock"
-            } else if msg.contains("serialization") {
-                "serialization_failure"
-            } else if msg.contains("connection reset") || msg.contains("could not connect") {
-                "connection_reset"
-            } else {
-                "database"
+        sqlx::Error::Database(db_err) => match db_err.code().as_deref() {
+            Some("40P01") => "deadlock",
+            Some("40001") => "serialization_failure",
+            Some("08000") | Some("08003") | Some("08001") | Some("08004") | Some("08006")
+            | Some("57P03") => "connection_reset",
+            Some("53300") => "too_many_connections",
+            _ => {
+                let msg = db_err.message().to_lowercase();
+                if msg.contains("deadlock") {
+                    "deadlock"
+                } else if msg.contains("serialization") {
+                    "serialization_failure"
+                } else if msg.contains("connection reset") || msg.contains("could not connect") {
+                    "connection_reset"
+                } else {
+                    "database"
+                }
             }
-        }
+        },
         _ => "other",
     }
 }
@@ -173,5 +238,79 @@ mod tests {
     #[test]
     fn test_is_transient_db_error_pool_closed() {
         assert!(!is_transient_db_error(&sqlx::Error::PoolClosed));
+    }
+
+    #[test]
+    fn test_sqlstate_classification_ignores_misleading_message() {
+        // A message that doesn't mention any known transient keyword, but
+        // carries a recognized deadlock SQLSTATE code, must still be
+        // classified as transient: code wins over message text.
+        assert!(is_transient_sqlstate("40P01"));
+        assert!(is_transient_sqlstate("40001"));
+        assert!(is_transient_sqlstate("08006"));
+        assert!(!is_transient_sqlstate("23505")); // unique_violation: not transient
+        assert!(!is_transient_sqlstate("42601")); // syntax_error: not transient
+    }
+
+    #[test]
+    fn test_message_fallback_only_used_without_code() {
+        // The message fallback is last-resort: it should still recognize the
+        // documented phrases when no SQLSTATE code is available.
+        assert!(is_transient_by_message("FATAL: could not connect to server"));
+        assert!(is_transient_by_message("ERROR: deadlock detected"));
+        assert!(!is_transient_by_message("ERROR: unique constraint violated"));
+    }
+
+    #[test]
+    fn test_jitter_distribution_is_spread_not_clustered() {
+        // Decorrelated jitter draws from a real RNG per call, so repeated
+        // samples should land across a wide spread of values rather than
+        // clustering into a handful of buckets (which is what happened with
+        // the old wall-clock-derived jitter under tight, correlated timing).
+        let mut rng = rand::thread_rng();
+        let base = 100u64;
+        let cap = 10_000u64;
+        let mut prev = base;
+        let mut delays = std::collections::HashSet::new();
+        for _ in 0..500 {
+            let d = decorrelated_jitter_delay_ms(prev, base, cap, &mut rng);
+            assert!(d >= base.min(cap));
+            assert!(d <= cap);
+            prev = d;
+            delays.insert(d);
+        }
+        assert!(
+            delays.len() > 250,
+            "expected a wide spread of jitter values, got {} unique values out of 500",
+            delays.len()
+        );
+    }
+
+    #[test]
+    fn test_concurrent_callers_are_decorrelated() {
+        // Two independent callers that fail at the "same instant" (same
+        // starting state) must not produce identical retry-delay sequences —
+        // otherwise they would retry in lockstep against the DB they're
+        // trying to let recover.
+        let mut rng_a = rand::thread_rng();
+        let mut rng_b = rand::thread_rng();
+        let base = 50u64;
+        let cap = 10_000u64;
+
+        let mut prev_a = base;
+        let mut prev_b = base;
+        let mut seq_a = Vec::new();
+        let mut seq_b = Vec::new();
+        for _ in 0..10 {
+            prev_a = decorrelated_jitter_delay_ms(prev_a, base, cap, &mut rng_a);
+            prev_b = decorrelated_jitter_delay_ms(prev_b, base, cap, &mut rng_b);
+            seq_a.push(prev_a);
+            seq_b.push(prev_b);
+        }
+
+        assert_ne!(
+            seq_a, seq_b,
+            "two independent callers produced identical jitter sequences"
+        );
     }
 }

--- a/tests/insert_transaction_retry_test.rs
+++ b/tests/insert_transaction_retry_test.rs
@@ -1,0 +1,106 @@
+//! Verifies that `db::queries::insert_transaction` is safe to retry.
+//!
+//! `retry_with_backoff` may re-invoke the insert closure after a transient
+//! error that occurs *after* the underlying INSERT already committed (e.g.
+//! the connection drops while the client is reading the commit
+//! acknowledgement). This test simulates that scenario by calling
+//! `insert_transaction` twice with the same `Transaction` (same id +
+//! created_at) and asserts the retry observes the already-committed row
+//! instead of inserting a duplicate or writing a second audit log entry.
+
+use sqlx::{migrate::Migrator, PgPool};
+use std::path::Path;
+use synapse_core::db::queries::insert_transaction;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+#[path = "fixtures.rs"]
+mod fixtures;
+use fixtures::TransactionFixture;
+
+async fn setup_test_db() -> (PgPool, impl std::any::Any) {
+    let container = Postgres::default().start().await.unwrap();
+    let host_port = container.get_host_port_ipv4(5432).await.unwrap();
+    let database_url = format!(
+        "postgres://postgres:postgres@127.0.0.1:{}/postgres",
+        host_port
+    );
+
+    let pool = PgPool::connect(&database_url).await.unwrap();
+    let migrator = Migrator::new(Path::join(
+        Path::new(env!("CARGO_MANIFEST_DIR")),
+        "migrations",
+    ))
+    .await
+    .unwrap();
+    migrator.run(&pool).await.unwrap();
+    sqlx::query(
+        r#"
+        DO $$
+        DECLARE
+            partition_date DATE;
+            partition_name TEXT;
+            start_date TEXT;
+            end_date TEXT;
+        BEGIN
+            partition_date := DATE_TRUNC('month', NOW());
+            partition_name := 'transactions_y' || TO_CHAR(partition_date, 'YYYY') || 'm' || TO_CHAR(partition_date, 'MM');
+            start_date := TO_CHAR(partition_date, 'YYYY-MM-DD');
+            end_date := TO_CHAR(partition_date + INTERVAL '1 month', 'YYYY-MM-DD');
+
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = partition_name) THEN
+                EXECUTE format(
+                    'CREATE TABLE %I PARTITION OF transactions FOR VALUES FROM (%L) TO (%L)',
+                    partition_name, start_date, end_date
+                );
+            END IF;
+        END $$;
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    (pool, container)
+}
+
+#[tokio::test]
+#[ignore = "Requires Docker for testcontainers"]
+async fn test_retried_insert_does_not_duplicate_row_or_audit_log() {
+    let (pool, _container) = setup_test_db().await;
+
+    let tx = TransactionFixture::pending_deposit();
+
+    let first = insert_transaction(&pool, &tx)
+        .await
+        .expect("first insert should succeed");
+    assert_eq!(first.id, tx.id);
+
+    // Simulate a retry: the same caller-generated `tx` (same id + created_at)
+    // is inserted again, as `retry_with_backoff` would do after a transient
+    // post-commit error on the first attempt.
+    let retried = insert_transaction(&pool, &tx)
+        .await
+        .expect("retried insert should be idempotent, not error");
+    assert_eq!(retried.id, tx.id);
+    assert_eq!(retried.stellar_account, first.stellar_account);
+
+    let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM transactions WHERE id = $1")
+        .bind(tx.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row_count, 1, "retry must not duplicate the committed row");
+
+    let audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_logs WHERE entity_id = $1 AND entity_type = 'transaction'",
+    )
+    .bind(tx.id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        audit_count, 1,
+        "retry must not write a second audit log entry for the same insert"
+    );
+}


### PR DESCRIPTION
…t errors

retry_with_backoff can re-invoke its closure after a transient error that occurs after the underlying INSERT already committed (e.g. connection drop while reading the commit ack). insert_transaction now uses ON CONFLICT (id, created_at) DO NOTHING and only writes the audit log entry on the call that actually performed the insert, so a retry observes the existing row instead of duplicating it or its audit trail.

Also switches transient-error classification in retry.rs to prefer the PostgreSQL SQLSTATE code over message-substring matching, and replaces the wall-clock-derived jitter with real decorrelated jitter to avoid correlated thundering-herd retries.

# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses -->

Closes #589 

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the main changes in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Migration Safety (if applicable)

<!-- For PRs that include database migrations -->

- [ ] Migration safety checker passes (`./scripts/check-migration-safety.sh`)
- [ ] Migration follows safe patterns (see [docs/migration-safety.md](../docs/migration-safety.md))
- [ ] Migration tested with rollback
- [ ] Migration documented in PR description

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the style guidelines ([CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Pre-Submission Checks

<!-- All four checks must pass before submitting -->

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->
