### PR TITLE
fix: idempotent callback ingestion on anchor_transaction_id

### DIFF
--- a/migrations/20260621000000_callback_idempotency.down.sql
+++ b/migrations/20260621000000_callback_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS anchor_transaction_dedup;

--- a/migrations/20260621000000_callback_idempotency.sql
+++ b/migrations/20260621000000_callback_idempotency.sql
@@ -1,0 +1,24 @@
+-- Idempotency guard for anchor platform callbacks.
+--
+-- The transactions table is partitioned by created_at, so PostgreSQL cannot
+-- enforce a cross-partition unique constraint on anchor_transaction_id alone.
+-- This table acts as the uniqueness arbiter: whichever delivery inserts here
+-- first owns the anchor_transaction_id; all later deliveries of the same key
+-- are redirected to the existing transaction row.
+CREATE TABLE IF NOT EXISTS anchor_transaction_dedup (
+    anchor_transaction_id TEXT        NOT NULL,
+    transaction_id        UUID        NOT NULL,
+    transaction_created_at TIMESTAMPTZ NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT anchor_transaction_dedup_pkey PRIMARY KEY (anchor_transaction_id)
+);
+
+COMMENT ON TABLE anchor_transaction_dedup IS
+    'Cross-partition uniqueness guard for anchor_transaction_id. '
+    'One row per inbound anchor callback key; maps to the canonical transaction row.';
+
+COMMENT ON COLUMN anchor_transaction_dedup.transaction_id IS
+    'UUID of the winning transaction row in the partitioned transactions table.';
+
+COMMENT ON COLUMN anchor_transaction_dedup.transaction_created_at IS
+    'created_at of the winning row - needed to locate it on the correct partition.';

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -338,7 +338,7 @@ mod tests {
             None,
             None,
         );
-        let inserted = crate::db::queries::insert_transaction(&pool, &tx)
+        let (inserted, _) = crate::db::queries::insert_transaction(&pool, &tx)
             .await
             .unwrap();
         assert_eq!(inserted.stellar_account, tx.stellar_account);
@@ -359,7 +359,7 @@ mod tests {
             None,
             None,
         );
-        let inserted = crate::db::queries::insert_transaction(&pool, &tx)
+        let (inserted, _) = crate::db::queries::insert_transaction(&pool, &tx)
             .await
             .unwrap();
         let fetched = crate::db::queries::get_transaction(&pool, inserted.id)
@@ -386,7 +386,8 @@ mod tests {
             );
             crate::db::queries::insert_transaction(&pool, &tx)
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
         }
         let transactions = crate::db::queries::list_transactions(&pool, 5, None, false)
             .await

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -420,36 +420,94 @@ where
 /// row instead of inserting a duplicate or double-writing the audit log.
 /// Coordinates with the `anchor_transaction_id` idempotency guard so the
 /// same inbound Anchor callback can't be persisted twice either.
-pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<Transaction> {
+/// Returns `(transaction, is_new)`.
+/// `is_new = true` means this delivery created a fresh row.
+/// `is_new = false` means a prior delivery already owns the `anchor_transaction_id`
+/// and the returned transaction is that existing row - no new row was written.
+pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<(Transaction, bool)> {
     with_timeout(
         QueryTier::Write,
         "INSERT INTO transactions ... RETURNING *",
         crate::utils::retry::retry_with_backoff("insert_transaction", 3, 100, || async {
             let mut db_tx = pool.begin().await?;
 
-            let (result, inserted) = persist_transaction(&mut db_tx, tx).await?;
-            if inserted {
+            let (result, is_new) = persist_transaction(&mut db_tx, tx).await?;
+            if is_new {
                 audit_transaction_creation(&mut db_tx, &result).await?;
             }
 
             db_tx.commit().await?;
 
-            // Invalidate cache after successful commit
-            invalidate_transaction_caches(&result.asset_code).await;
+            if is_new {
+                invalidate_transaction_caches(&result.asset_code).await;
+            }
 
-            Ok(result)
+            Ok((result, is_new))
         }),
     )
     .await
 }
 
-/// Inserts `tx`, returning the persisted row and whether this call actually
-/// performed the insert (`true`) or found it already committed by an earlier
-/// retry attempt (`false`).
+/// Inserts `tx`, returning `(row, is_new)`.
+///
+/// `is_new = true`  - this call wrote the row (first delivery or first successful retry).
+/// `is_new = false` - a prior delivery already owns `anchor_transaction_id`; the
+///                    returned row is that existing transaction. No second row is written.
+///
+/// Idempotency strategy:
+/// - When `anchor_transaction_id` is `Some`, we first attempt to claim it in
+///   `anchor_transaction_dedup`, a non-partitioned table whose PRIMARY KEY enforces
+///   cross-partition uniqueness. The claim and the transaction INSERT share the same
+///   DB transaction so they are atomic.
+/// - When `anchor_transaction_id` is `None`, no cross-delivery dedup is possible;
+///   each delivery creates a new row. The PK `(id, created_at)` guard still protects
+///   against retry-duplicates of the same `tx` object.
 async fn persist_transaction(
     db_tx: &mut SqlxTransaction<'_, Postgres>,
     tx: &Transaction,
 ) -> Result<(Transaction, bool)> {
+    // === Anchor-ID dedup guard (cross-partition uniqueness)
+    if let Some(ref anchor_id) = tx.anchor_transaction_id {
+        let claimed = sqlx::query(
+            r#"
+            INSERT INTO anchor_transaction_dedup
+                (anchor_transaction_id, transaction_id, transaction_created_at)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (anchor_transaction_id) DO NOTHING
+            "#,
+        )
+        .bind(anchor_id)
+        .bind(tx.id)
+        .bind(tx.created_at)
+        .execute(&mut **db_tx)
+        .await?;
+
+        if claimed.rows_affected() == 0 {
+            // Another delivery (or a previously committed retry) already owns this key.
+            let row = sqlx::query(
+                "SELECT transaction_id, transaction_created_at \
+                 FROM anchor_transaction_dedup WHERE anchor_transaction_id = $1",
+            )
+            .bind(anchor_id)
+            .fetch_one(&mut **db_tx)
+            .await?;
+
+            let existing_id: Uuid = row.get("transaction_id");
+            let existing_created_at: chrono::DateTime<Utc> = row.get("transaction_created_at");
+
+            let existing = sqlx::query_as::<_, Transaction>(
+                "SELECT * FROM transactions WHERE id = $1 AND created_at = $2",
+            )
+            .bind(existing_id)
+            .bind(existing_created_at)
+            .fetch_one(&mut **db_tx)
+            .await?;
+
+            return Ok((existing, false));
+        }
+    }
+
+    // === Main insert (PK guard for retry safety)
     let inserted = sqlx::query_as::<_, Transaction>(
         r#"
         INSERT INTO transactions (
@@ -457,8 +515,7 @@ async fn persist_transaction(
             created_at, updated_at, anchor_transaction_id, callback_type, callback_status,
             settlement_id, memo, memo_type, metadata
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-        -- The table is partitioned by created_at, so the primary key (and the
-        -- only conflict target Postgres accepts here) is (id, created_at).
+        -- Partitioned by created_at; only (id, created_at) is a valid conflict target.
         ON CONFLICT (id, created_at) DO NOTHING
         RETURNING *
         "#,
@@ -483,6 +540,7 @@ async fn persist_transaction(
     match inserted {
         Some(row) => Ok((row, true)),
         None => {
+            // PK conflict: an earlier retry already committed this exact row.
             let row = sqlx::query_as::<_, Transaction>(
                 "SELECT * FROM transactions WHERE id = $1 AND created_at = $2",
             )
@@ -1729,6 +1787,98 @@ mod integration_tests {
             .expect("Failed to load migrations");
         migrator.run(&pool).await.expect("Failed to run migrations");
         pool
+    }
+
+    // === Idempotency tests
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_duplicate_anchor_id_returns_same_row() {
+        let pool = setup_test_db().await;
+        let anchor_id = format!("anchor-{}", uuid::Uuid::new_v4());
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx1 = crate::db::models::Transaction::new(
+            stellar.clone(),
+            sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(),
+            Some(anchor_id.clone()),
+            None, None, None, None, None,
+        );
+        let (t1, is_new1) = insert_transaction(&pool, &tx1).await.unwrap();
+        assert!(is_new1, "first delivery must be new");
+
+        // Second delivery with same anchor_transaction_id but different tx object
+        let tx2 = crate::db::models::Transaction::new(
+            stellar.clone(),
+            sqlx::types::BigDecimal::from(200u32),
+            "EUR".to_string(),
+            Some(anchor_id.clone()),
+            None, None, None, None, None,
+        );
+        let (t2, is_new2) = insert_transaction(&pool, &tx2).await.unwrap();
+        assert!(!is_new2, "duplicate delivery must not be new");
+        assert_eq!(t1.id, t2.id, "both deliveries must return the same transaction id");
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM transactions WHERE anchor_transaction_id = $1",
+        )
+        .bind(&anchor_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1, "exactly one row must exist in the DB");
+    }
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_null_anchor_id_always_inserts() {
+        let pool = setup_test_db().await;
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx1 = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(), None, None, None, None, None, None,
+        );
+        let tx2 = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(), None, None, None, None, None, None,
+        );
+
+        let (_, is_new1) = insert_transaction(&pool, &tx1).await.unwrap();
+        let (_, is_new2) = insert_transaction(&pool, &tx2).await.unwrap();
+        assert!(is_new1, "first null-key delivery must be new");
+        assert!(is_new2, "second null-key delivery must also be new (different tx)");
+    }
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_retry_after_commit_no_duplicate() {
+        let pool = setup_test_db().await;
+        let anchor_id = format!("retry-{}", uuid::Uuid::new_v4());
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(50u32),
+            "USD".to_string(), Some(anchor_id.clone()), None, None, None, None, None,
+        );
+
+        let (t1, is_new1) = insert_transaction(&pool, &tx).await.unwrap();
+        assert!(is_new1);
+
+        // Simulate retry: same tx object, same id, same anchor_transaction_id
+        let (t2, is_new2) = insert_transaction(&pool, &tx).await.unwrap();
+        assert!(!is_new2, "retry must not create a new row");
+        assert_eq!(t1.id, t2.id);
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM transactions WHERE id = $1",
+        )
+        .bind(t1.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1, "retry must not produce a duplicate row");
     }
 
     #[ignore = "Requires DATABASE_URL"]

--- a/src/handlers/webhook.rs
+++ b/src/handlers/webhook.rs
@@ -129,20 +129,19 @@ fn validate_webhook_payload(
 /// Process a raw transaction callback from an external anchor.
 ///
 /// Validates and sanitizes all fields before inserting the transaction into the
-/// database. Returns `201 Created` with the new transaction ID and initial status.
+/// database. Idempotent on `anchor_transaction_id`: a duplicate delivery returns
+/// `200 OK` with the existing transaction rather than creating a second row.
 ///
 /// # Errors
 /// - `400 Bad Request` – validation fails (invalid address, amount, field length, etc.)
 /// - `500 Internal Server Error` – database insertion fails
 #[instrument(name = "webhook.transaction_callback", skip(state, payload))]
 pub async fn transaction_callback(
-    State(state): State<AppState>,
+    State(state): State<ApiState>,
     Json(payload): Json<WebhookTransactionRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Validate and sanitize all inputs before any DB interaction.
     let payload = validate_webhook_payload(payload)?;
 
-    // Extract trace context from the current OpenTelemetry context.
     let trace_id = opentelemetry::global::get_text_map_propagator(|propagator| {
         let mut carrier = std::collections::HashMap::new();
         propagator.inject_context(&opentelemetry::Context::current(), &mut carrier);
@@ -162,13 +161,19 @@ pub async fn transaction_callback(
     )
     .with_trace_id(trace_id);
 
-    let inserted = queries::insert_transaction(&state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.app_state.db, &tx).await?;
+
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
 
     Ok((
-        StatusCode::CREATED,
+        status,
         Json(WebhookTransactionResponse {
-            id: inserted.id.to_string(),
-            status: inserted.status,
+            id: result.id.to_string(),
+            status: result.status,
         }),
     ))
 }
@@ -392,9 +397,15 @@ pub async fn callback(
         payload.metadata,
     );
 
-    let inserted = queries::insert_transaction(&state.app_state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.app_state.db, &tx).await?;
 
-    Ok((StatusCode::CREATED, Json(inserted)).into_response())
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+
+    Ok((status, Json(result)).into_response())
 }
 
 /// Generic webhook receiver for event-driven integrations.

--- a/src/handlers/webhook_refactored.rs
+++ b/src/handlers/webhook_refactored.rs
@@ -166,13 +166,19 @@ pub async fn transaction_callback(
         None, // metadata
     );
 
-    let inserted = queries::insert_transaction(&state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.db, &tx).await?;
+
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
 
     Ok((
-        StatusCode::CREATED,
+        status,
         Json(WebhookTransactionResponse {
-            id: inserted.id.to_string(),
-            status: inserted.status,
+            id: result.id.to_string(),
+            status: result.status,
         }),
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn create_app(app_state: AppState) -> Router {
     // Callback routes: signature verification + api_key_auth + validation + quota
     let mut callback_routes = Router::new()
         .route("/callback", post(handlers::webhook::callback))
-        .route("/callback/transaction", post(handlers::webhook::callback))
+        .route("/callback/transaction", post(handlers::webhook::transaction_callback))
         .layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             crate::middleware::quota::rate_limit_middleware,


### PR DESCRIPTION
PR summary in markdown:

---
## Summary

Anchor platforms retry callbacks on timeout, which was causing duplicate transaction rows and double-settlement risk. Three bugs combined to produce this:

1. **No dedup on `anchor_transaction_id`** - two deliveries of the same callback created two rows, each eligible for settlement.
2. **Retry-safe insert was not anchor-key-safe** - `ON CONFLICT (id, created_at)` only guards retries of the exact same `tx` object; a second HTTP delivery gets a different UUID and bypasses it entirely.
3. **Route misconfiguration** - `/callback/transaction` was wired to the lenient `callback` handler instead of `transaction_callback` (strict field validation), so the validated handler was never reachable.

## Changes

- **Migration** (`20260621000000_callback_idempotency.sql`) - adds `anchor_transaction_dedup`, a non-partitioned table with `PRIMARY KEY (anchor_transaction_id)`. This is the correct approach because the `transactions` table is partitioned by `created_at`, so PostgreSQL cannot enforce a cross-partition unique constraint on `anchor_transaction_id` alone.
- **`src/db/queries.rs`** - `persist_transaction` now atomically claims the dedup slot before inserting. If the slot is already owned (concurrent or duplicate delivery), it returns the existing row without writing a second one. `insert_transaction` return type changed to `(Transaction, bool)` where `bool = true` means new insert.
- **`src/handlers/webhook.rs`** - both `callback` and `transaction_callback` return `201 Created` for new inserts and `200 OK` for duplicate deliveries. `transaction_callback` state changed from `AppState` to `ApiState` so it can be mounted on the shared router.
- **`src/lib.rs`** - `/callback/transaction` now routes to `transaction_callback` (strict validation) instead of `callback`.
- **`src/db/models.rs`**, **`src/handlers/webhook_refactored.rs`** - updated callers of `insert_transaction` to handle the new return type.

## Null `anchor_transaction_id` behavior

When `anchor_transaction_id` is absent, no cross-delivery dedup is applied - each delivery creates a new row (unchanged behavior). The PK guard `(id, created_at)` still protects against retries of the same `tx` object.

## Tests

Three integration tests added in `src/db/queries.rs` (require `DATABASE_URL`, marked `#[ignore]`):

- `test_duplicate_anchor_id_returns_same_row` - two deliveries of the same key produce exactly one row and the same transaction id.
- `test_null_anchor_id_always_inserts` - null key bypasses dedup; two deliveries create two rows.
- `test_retry_after_commit_no_duplicate` - retrying the same `tx` object after a committed insert returns the existing row without a duplicate.

## Closes
Closes #581 