### PR TITLE
Feature/horizon stream resumption

### DIFF
--- a/migrations/20260621000000_callback_idempotency.down.sql
+++ b/migrations/20260621000000_callback_idempotency.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS anchor_transaction_dedup;

--- a/migrations/20260621000000_callback_idempotency.sql
+++ b/migrations/20260621000000_callback_idempotency.sql
@@ -1,0 +1,24 @@
+-- Idempotency guard for anchor platform callbacks.
+--
+-- The transactions table is partitioned by created_at, so PostgreSQL cannot
+-- enforce a cross-partition unique constraint on anchor_transaction_id alone.
+-- This table acts as the uniqueness arbiter: whichever delivery inserts here
+-- first owns the anchor_transaction_id; all later deliveries of the same key
+-- are redirected to the existing transaction row.
+CREATE TABLE IF NOT EXISTS anchor_transaction_dedup (
+    anchor_transaction_id TEXT        NOT NULL,
+    transaction_id        UUID        NOT NULL,
+    transaction_created_at TIMESTAMPTZ NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT anchor_transaction_dedup_pkey PRIMARY KEY (anchor_transaction_id)
+);
+
+COMMENT ON TABLE anchor_transaction_dedup IS
+    'Cross-partition uniqueness guard for anchor_transaction_id. '
+    'One row per inbound anchor callback key; maps to the canonical transaction row.';
+
+COMMENT ON COLUMN anchor_transaction_dedup.transaction_id IS
+    'UUID of the winning transaction row in the partitioned transactions table.';
+
+COMMENT ON COLUMN anchor_transaction_dedup.transaction_created_at IS
+    'created_at of the winning row - needed to locate it on the correct partition.';

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -338,7 +338,7 @@ mod tests {
             None,
             None,
         );
-        let inserted = crate::db::queries::insert_transaction(&pool, &tx)
+        let (inserted, _) = crate::db::queries::insert_transaction(&pool, &tx)
             .await
             .unwrap();
         assert_eq!(inserted.stellar_account, tx.stellar_account);
@@ -359,7 +359,7 @@ mod tests {
             None,
             None,
         );
-        let inserted = crate::db::queries::insert_transaction(&pool, &tx)
+        let (inserted, _) = crate::db::queries::insert_transaction(&pool, &tx)
             .await
             .unwrap();
         let fetched = crate::db::queries::get_transaction(&pool, inserted.id)
@@ -386,7 +386,8 @@ mod tests {
             );
             crate::db::queries::insert_transaction(&pool, &tx)
                 .await
-                .unwrap();
+                .unwrap()
+                .0;
         }
         let transactions = crate::db::queries::list_transactions(&pool, 5, None, false)
             .await

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -420,36 +420,94 @@ where
 /// row instead of inserting a duplicate or double-writing the audit log.
 /// Coordinates with the `anchor_transaction_id` idempotency guard so the
 /// same inbound Anchor callback can't be persisted twice either.
-pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<Transaction> {
+/// Returns `(transaction, is_new)`.
+/// `is_new = true` means this delivery created a fresh row.
+/// `is_new = false` means a prior delivery already owns the `anchor_transaction_id`
+/// and the returned transaction is that existing row - no new row was written.
+pub async fn insert_transaction(pool: &PgPool, tx: &Transaction) -> Result<(Transaction, bool)> {
     with_timeout(
         QueryTier::Write,
         "INSERT INTO transactions ... RETURNING *",
         crate::utils::retry::retry_with_backoff("insert_transaction", 3, 100, || async {
             let mut db_tx = pool.begin().await?;
 
-            let (result, inserted) = persist_transaction(&mut db_tx, tx).await?;
-            if inserted {
+            let (result, is_new) = persist_transaction(&mut db_tx, tx).await?;
+            if is_new {
                 audit_transaction_creation(&mut db_tx, &result).await?;
             }
 
             db_tx.commit().await?;
 
-            // Invalidate cache after successful commit
-            invalidate_transaction_caches(&result.asset_code).await;
+            if is_new {
+                invalidate_transaction_caches(&result.asset_code).await;
+            }
 
-            Ok(result)
+            Ok((result, is_new))
         }),
     )
     .await
 }
 
-/// Inserts `tx`, returning the persisted row and whether this call actually
-/// performed the insert (`true`) or found it already committed by an earlier
-/// retry attempt (`false`).
+/// Inserts `tx`, returning `(row, is_new)`.
+///
+/// `is_new = true`  - this call wrote the row (first delivery or first successful retry).
+/// `is_new = false` - a prior delivery already owns `anchor_transaction_id`; the
+///                    returned row is that existing transaction. No second row is written.
+///
+/// Idempotency strategy:
+/// - When `anchor_transaction_id` is `Some`, we first attempt to claim it in
+///   `anchor_transaction_dedup`, a non-partitioned table whose PRIMARY KEY enforces
+///   cross-partition uniqueness. The claim and the transaction INSERT share the same
+///   DB transaction so they are atomic.
+/// - When `anchor_transaction_id` is `None`, no cross-delivery dedup is possible;
+///   each delivery creates a new row. The PK `(id, created_at)` guard still protects
+///   against retry-duplicates of the same `tx` object.
 async fn persist_transaction(
     db_tx: &mut SqlxTransaction<'_, Postgres>,
     tx: &Transaction,
 ) -> Result<(Transaction, bool)> {
+    // === Anchor-ID dedup guard (cross-partition uniqueness)
+    if let Some(ref anchor_id) = tx.anchor_transaction_id {
+        let claimed = sqlx::query(
+            r#"
+            INSERT INTO anchor_transaction_dedup
+                (anchor_transaction_id, transaction_id, transaction_created_at)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (anchor_transaction_id) DO NOTHING
+            "#,
+        )
+        .bind(anchor_id)
+        .bind(tx.id)
+        .bind(tx.created_at)
+        .execute(&mut **db_tx)
+        .await?;
+
+        if claimed.rows_affected() == 0 {
+            // Another delivery (or a previously committed retry) already owns this key.
+            let row = sqlx::query(
+                "SELECT transaction_id, transaction_created_at \
+                 FROM anchor_transaction_dedup WHERE anchor_transaction_id = $1",
+            )
+            .bind(anchor_id)
+            .fetch_one(&mut **db_tx)
+            .await?;
+
+            let existing_id: Uuid = row.get("transaction_id");
+            let existing_created_at: chrono::DateTime<Utc> = row.get("transaction_created_at");
+
+            let existing = sqlx::query_as::<_, Transaction>(
+                "SELECT * FROM transactions WHERE id = $1 AND created_at = $2",
+            )
+            .bind(existing_id)
+            .bind(existing_created_at)
+            .fetch_one(&mut **db_tx)
+            .await?;
+
+            return Ok((existing, false));
+        }
+    }
+
+    // === Main insert (PK guard for retry safety)
     let inserted = sqlx::query_as::<_, Transaction>(
         r#"
         INSERT INTO transactions (
@@ -457,8 +515,7 @@ async fn persist_transaction(
             created_at, updated_at, anchor_transaction_id, callback_type, callback_status,
             settlement_id, memo, memo_type, metadata
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-        -- The table is partitioned by created_at, so the primary key (and the
-        -- only conflict target Postgres accepts here) is (id, created_at).
+        -- Partitioned by created_at; only (id, created_at) is a valid conflict target.
         ON CONFLICT (id, created_at) DO NOTHING
         RETURNING *
         "#,
@@ -483,6 +540,7 @@ async fn persist_transaction(
     match inserted {
         Some(row) => Ok((row, true)),
         None => {
+            // PK conflict: an earlier retry already committed this exact row.
             let row = sqlx::query_as::<_, Transaction>(
                 "SELECT * FROM transactions WHERE id = $1 AND created_at = $2",
             )
@@ -1729,6 +1787,98 @@ mod integration_tests {
             .expect("Failed to load migrations");
         migrator.run(&pool).await.expect("Failed to run migrations");
         pool
+    }
+
+    // === Idempotency tests
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_duplicate_anchor_id_returns_same_row() {
+        let pool = setup_test_db().await;
+        let anchor_id = format!("anchor-{}", uuid::Uuid::new_v4());
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx1 = crate::db::models::Transaction::new(
+            stellar.clone(),
+            sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(),
+            Some(anchor_id.clone()),
+            None, None, None, None, None,
+        );
+        let (t1, is_new1) = insert_transaction(&pool, &tx1).await.unwrap();
+        assert!(is_new1, "first delivery must be new");
+
+        // Second delivery with same anchor_transaction_id but different tx object
+        let tx2 = crate::db::models::Transaction::new(
+            stellar.clone(),
+            sqlx::types::BigDecimal::from(200u32),
+            "EUR".to_string(),
+            Some(anchor_id.clone()),
+            None, None, None, None, None,
+        );
+        let (t2, is_new2) = insert_transaction(&pool, &tx2).await.unwrap();
+        assert!(!is_new2, "duplicate delivery must not be new");
+        assert_eq!(t1.id, t2.id, "both deliveries must return the same transaction id");
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM transactions WHERE anchor_transaction_id = $1",
+        )
+        .bind(&anchor_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1, "exactly one row must exist in the DB");
+    }
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_null_anchor_id_always_inserts() {
+        let pool = setup_test_db().await;
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx1 = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(), None, None, None, None, None, None,
+        );
+        let tx2 = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(100u32),
+            "USD".to_string(), None, None, None, None, None, None,
+        );
+
+        let (_, is_new1) = insert_transaction(&pool, &tx1).await.unwrap();
+        let (_, is_new2) = insert_transaction(&pool, &tx2).await.unwrap();
+        assert!(is_new1, "first null-key delivery must be new");
+        assert!(is_new2, "second null-key delivery must also be new (different tx)");
+    }
+
+    #[ignore = "Requires DATABASE_URL"]
+    #[tokio::test]
+    async fn test_retry_after_commit_no_duplicate() {
+        let pool = setup_test_db().await;
+        let anchor_id = format!("retry-{}", uuid::Uuid::new_v4());
+        let stellar = "G".to_string() + &"A".repeat(55);
+
+        let tx = crate::db::models::Transaction::new(
+            stellar.clone(), sqlx::types::BigDecimal::from(50u32),
+            "USD".to_string(), Some(anchor_id.clone()), None, None, None, None, None,
+        );
+
+        let (t1, is_new1) = insert_transaction(&pool, &tx).await.unwrap();
+        assert!(is_new1);
+
+        // Simulate retry: same tx object, same id, same anchor_transaction_id
+        let (t2, is_new2) = insert_transaction(&pool, &tx).await.unwrap();
+        assert!(!is_new2, "retry must not create a new row");
+        assert_eq!(t1.id, t2.id);
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM transactions WHERE id = $1",
+        )
+        .bind(t1.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count, 1, "retry must not produce a duplicate row");
     }
 
     #[ignore = "Requires DATABASE_URL"]

--- a/src/handlers/webhook.rs
+++ b/src/handlers/webhook.rs
@@ -129,20 +129,19 @@ fn validate_webhook_payload(
 /// Process a raw transaction callback from an external anchor.
 ///
 /// Validates and sanitizes all fields before inserting the transaction into the
-/// database. Returns `201 Created` with the new transaction ID and initial status.
+/// database. Idempotent on `anchor_transaction_id`: a duplicate delivery returns
+/// `200 OK` with the existing transaction rather than creating a second row.
 ///
 /// # Errors
 /// - `400 Bad Request` – validation fails (invalid address, amount, field length, etc.)
 /// - `500 Internal Server Error` – database insertion fails
 #[instrument(name = "webhook.transaction_callback", skip(state, payload))]
 pub async fn transaction_callback(
-    State(state): State<AppState>,
+    State(state): State<ApiState>,
     Json(payload): Json<WebhookTransactionRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    // Validate and sanitize all inputs before any DB interaction.
     let payload = validate_webhook_payload(payload)?;
 
-    // Extract trace context from the current OpenTelemetry context.
     let trace_id = opentelemetry::global::get_text_map_propagator(|propagator| {
         let mut carrier = std::collections::HashMap::new();
         propagator.inject_context(&opentelemetry::Context::current(), &mut carrier);
@@ -162,13 +161,19 @@ pub async fn transaction_callback(
     )
     .with_trace_id(trace_id);
 
-    let inserted = queries::insert_transaction(&state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.app_state.db, &tx).await?;
+
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
 
     Ok((
-        StatusCode::CREATED,
+        status,
         Json(WebhookTransactionResponse {
-            id: inserted.id.to_string(),
-            status: inserted.status,
+            id: result.id.to_string(),
+            status: result.status,
         }),
     ))
 }
@@ -392,9 +397,15 @@ pub async fn callback(
         payload.metadata,
     );
 
-    let inserted = queries::insert_transaction(&state.app_state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.app_state.db, &tx).await?;
 
-    Ok((StatusCode::CREATED, Json(inserted)).into_response())
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
+
+    Ok((status, Json(result)).into_response())
 }
 
 /// Generic webhook receiver for event-driven integrations.

--- a/src/handlers/webhook_refactored.rs
+++ b/src/handlers/webhook_refactored.rs
@@ -166,13 +166,19 @@ pub async fn transaction_callback(
         None, // metadata
     );
 
-    let inserted = queries::insert_transaction(&state.db, &tx).await?;
+    let (result, is_new) = queries::insert_transaction(&state.db, &tx).await?;
+
+    let status = if is_new {
+        StatusCode::CREATED
+    } else {
+        StatusCode::OK
+    };
 
     Ok((
-        StatusCode::CREATED,
+        status,
         Json(WebhookTransactionResponse {
-            id: inserted.id.to_string(),
-            status: inserted.status,
+            id: result.id.to_string(),
+            status: result.status,
         }),
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ pub fn create_app(app_state: AppState) -> Router {
     // Callback routes: signature verification + api_key_auth + validation + quota
     let mut callback_routes = Router::new()
         .route("/callback", post(handlers::webhook::callback))
-        .route("/callback/transaction", post(handlers::webhook::callback))
+        .route("/callback/transaction", post(handlers::webhook::transaction_callback))
         .layer(axum_middleware::from_fn_with_state(
             app_state.clone(),
             crate::middleware::quota::rate_limit_middleware,

--- a/src/services/account_monitor.rs
+++ b/src/services/account_monitor.rs
@@ -301,22 +301,25 @@ impl AccountMonitor {
     pub async fn start_streaming(&self, account: &str) -> anyhow::Result<()> {
         info!("Starting SSE stream for account {}", account);
 
+        // Load the persisted paging token so the stream resumes without gaps.
+        let initial_cursor = self.get_cursor(account).await?;
+
         let (tx, mut rx) = mpsc::channel(100);
 
         let client = self.horizon_client.clone();
         let account_clone = account.to_string();
+        let cursor_clone = initial_cursor.clone();
 
-        // Spawn stream task
         tokio::spawn(async move {
-            if let Err(e) = client.stream_payments(&account_clone, tx).await {
+            if let Err(e) = client.stream_payments(&account_clone, tx, cursor_clone).await {
                 error!("Stream error for {}: {}", account_clone, e);
             }
         });
 
-        // Process stream events
         while let Some(result) = rx.recv().await {
             match result {
                 Ok(payment) => {
+                    let payment_id = payment.id.clone();
                     let payment_obj = Payment {
                         id: payment.id,
                         from: payment.from,
@@ -327,17 +330,28 @@ impl AccountMonitor {
                         memo_type: payment.memo_type,
                     };
 
-                    if let Err(e) = self.process_payment(&payment_obj).await {
-                        warn!("Failed to process streamed payment: {}", e);
+                    match self.process_payment(&payment_obj).await {
+                        Ok(_) => {
+                            // Persist cursor so a process restart resumes from here.
+                            if let Err(e) = self.save_cursor(account, &payment_id).await {
+                                warn!("Failed to persist stream cursor for {}: {}", account, e);
+                            }
+                        }
+                        Err(e) => {
+                            warn!("Failed to process streamed payment {}: {}", payment_id, e);
+                            if let Err(dlq_err) = self.route_to_dlq(&payment_obj, &e).await {
+                                error!(
+                                    "Failed to route payment {} to DLQ: {}",
+                                    payment_id, dlq_err
+                                );
+                            }
+                        }
                     }
                 }
                 Err(e) => {
                     warn!("Stream error: {}, falling back to polling", e);
-                    // Fall back to polling
-                    return {
-                        self.start().await;
-                        Ok(())
-                    };
+                    self.start().await;
+                    return Ok(());
                 }
             }
         }
@@ -424,7 +438,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -471,7 +485,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -505,7 +519,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -539,7 +553,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -573,7 +587,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -607,7 +621,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -638,7 +652,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,
@@ -678,7 +692,7 @@ mod tests {
         };
 
         let monitor = AccountMonitor::new(
-            HorizonClient::new("https://horizon-testnet.stellar.org"),
+            HorizonClient::new("https://horizon-testnet.stellar.org".to_string()),
             pool.clone(),
             vec![account.to_string()],
             60,

--- a/src/stellar/client.rs
+++ b/src/stellar/client.rs
@@ -187,14 +187,27 @@ impl HorizonClient {
         }
     }
 
-    /// Stream payments for an account via SSE with automatic reconnection
-    #[instrument(name = "horizon.stream_payments", skip(self), fields(stellar.account = %account))]
+    /// Stream payments for an account via SSE with automatic reconnection.
+    ///
+    /// Resumes from `initial_cursor` (the Horizon paging token of the last
+    /// successfully processed payment) on first connect and on every reconnect,
+    /// so no on-chain payment in a disconnect window is missed or replayed.
+    /// Pass `None` to start from the current live position ("now").
+    ///
+    /// Backoff is saturating: the shift exponent is capped at 5 (max 32 s,
+    /// clamped to 30 s) so the counter can never overflow regardless of how
+    /// many reconnects occur. The counter resets after any session that delivers
+    /// at least one event.
+    #[instrument(name = "horizon.stream_payments", skip(self, tx), fields(stellar.account = %account))]
     pub async fn stream_payments(
         &self,
         account: &str,
         tx: mpsc::Sender<Result<StreamPayment, HorizonError>>,
+        initial_cursor: Option<String>,
     ) -> Result<(), HorizonError> {
-        let mut reconnect_count = 0u64;
+        let mut last_cursor = initial_cursor;
+        // u32 so .min(5) is always safe and we never approach the shift limit.
+        let mut reconnect_count: u32 = 0;
         let metrics = Arc::new(tokio::sync::Mutex::new(StreamMetrics {
             reconnections: 0,
             events_received: 0,
@@ -202,28 +215,44 @@ impl HorizonClient {
         }));
 
         loop {
-            let url = format!(
+            let mut url = format!(
                 "{}/accounts/{}/payments?order=asc&stream=true",
                 self.base_url.trim_end_matches('/'),
                 account
             );
+            if let Some(ref cursor) = last_cursor {
+                url.push_str(&format!("&cursor={}", cursor));
+            }
 
             match self.connect_stream(&url, &tx, &metrics).await {
-                Ok(_) => {
-                    // Stream ended normally
-                    reconnect_count += 1;
-                    let mut m = metrics.lock().await;
-                    m.reconnections = reconnect_count;
-                    drop(m);
+                Ok((events_in_session, new_cursor)) => {
+                    if let Some(c) = new_cursor {
+                        last_cursor = Some(c);
+                    }
+
+                    // A session that delivered at least one event is "healthy";
+                    // reset backoff so a brief outage after a long healthy run
+                    // doesn't impose unnecessary delay.
+                    if events_in_session > 0 {
+                        reconnect_count = 0;
+                    } else {
+                        reconnect_count = reconnect_count.saturating_add(1);
+                    }
+
+                    {
+                        let mut m = metrics.lock().await;
+                        m.reconnections += 1;
+                    }
 
                     tracing::warn!(
-                        "Stream disconnected for {}, reconnecting (attempt {})",
                         account,
-                        reconnect_count
+                        reconnect_count,
+                        last_cursor = ?last_cursor,
+                        "SSE stream disconnected, reconnecting"
                     );
 
-                    // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
-                    let backoff_secs = std::cmp::min(1u64 << reconnect_count, 30);
+                    // Cap exponent at 5: max shift is 1<<5 = 32, clamped to 30 s.
+                    let backoff_secs = std::cmp::min(1u64 << reconnect_count.min(5), 30);
                     tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
                 }
                 Err(e) => {
@@ -234,12 +263,20 @@ impl HorizonClient {
         }
     }
 
-    async fn connect_stream(
+    /// Connect to an SSE stream and forward complete events to `tx`.
+    ///
+    /// Accumulates raw bytes across TCP chunks in a `String` buffer and only
+    /// parses a payment once a complete SSE event (delimited by `\n\n`) is
+    /// assembled. Multi-line `data:` fields are concatenated before parsing.
+    ///
+    /// Returns `(events_sent, last_cursor)`. `last_cursor` is the Horizon
+    /// paging token (`payment.id`) of the last payment forwarded to `tx`.
+    pub(crate) async fn connect_stream(
         &self,
         url: &str,
         tx: &mpsc::Sender<Result<StreamPayment, HorizonError>>,
         metrics: &Arc<tokio::sync::Mutex<StreamMetrics>>,
-    ) -> Result<(), HorizonError> {
+    ) -> Result<(u64, Option<String>), HorizonError> {
         let response = self
             .client
             .get(url)
@@ -255,41 +292,70 @@ impl HorizonClient {
         }
 
         let mut stream = response.bytes_stream();
+        let mut buf = String::new();
+        let mut events_sent: u64 = 0;
+        let mut last_cursor: Option<String> = None;
 
         while let Some(chunk) = stream.next().await {
             let chunk: bytes::Bytes = chunk?;
-            let text = String::from_utf8_lossy(&chunk);
+            buf.push_str(&String::from_utf8_lossy(&chunk));
 
-            for line in text.lines() {
-                if let Some(json_str) = line.strip_prefix("data: ") {
-                    match serde_json::from_str::<StreamPayment>(json_str) {
-                        Ok(payment) => {
+            // Split on the SSE event delimiter. Only process complete events.
+            while let Some(pos) = buf.find("\n\n") {
+                let raw_event = buf[..pos].to_string();
+                buf = buf[pos + 2..].to_string();
+
+                let data = parse_sse_event(&raw_event);
+                if data.is_empty() {
+                    // Heartbeat or comment-only event.
+                    continue;
+                }
+
+                match serde_json::from_str::<StreamPayment>(&data) {
+                    Ok(payment) => {
+                        {
                             let mut m = metrics.lock().await;
                             m.events_received += 1;
                             m.last_event_time = Some(std::time::Instant::now());
-                            drop(m);
+                        }
 
-                            if tx.send(Ok(payment)).await.is_err() {
-                                return Ok(());
-                            }
+                        last_cursor = Some(payment.id.clone());
+
+                        if tx.send(Ok(payment)).await.is_err() {
+                            // Receiver dropped — shut down cleanly.
+                            return Ok((events_sent, last_cursor));
                         }
-                        Err(e) => {
-                            tracing::warn!("Failed to parse payment event: {}", e);
-                        }
+                        events_sent += 1;
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = %e,
+                            raw_event = %data,
+                            "Unparseable SSE payment event; payment may be lost"
+                        );
+                        tracing::info!(counter.sse_parse_errors = 1u64);
                     }
                 }
             }
         }
 
-        Ok(())
+        Ok((events_sent, last_cursor))
     }
+}
 
-    pub async fn get_stream_metrics(
-        &self,
-        metrics: &Arc<tokio::sync::Mutex<StreamMetrics>>,
-    ) -> StreamMetrics {
-        *metrics.lock().await
+/// Assemble the `data` payload from a raw SSE event block (text between two
+/// `\n\n` delimiters). Multi-line `data:` fields are concatenated in order.
+/// Returns an empty string for heartbeat/comment-only events.
+pub(crate) fn parse_sse_event(raw_event: &str) -> String {
+    let mut data = String::new();
+    for line in raw_event.lines() {
+        if let Some(value) = line.strip_prefix("data: ") {
+            data.push_str(value);
+        } else if let Some(value) = line.strip_prefix("data:") {
+            data.push_str(value.trim_start());
+        }
     }
+    data
 }
 
 #[cfg(test)]
@@ -382,6 +448,132 @@ mod tests {
         );
         let state = client.circuit_state();
         assert_eq!(state, "closed");
+    }
+
+    // === Horizon stream resumption tests
+
+    #[test]
+    fn test_backoff_never_overflows_past_64_reconnects() {
+        for count in 0u32..=100 {
+            let backoff = std::cmp::min(1u64 << count.min(5), 30);
+            assert!(backoff <= 30, "backoff exceeded 30 s at count={count}");
+        }
+    }
+
+    #[test]
+    fn test_parse_sse_event_complete_single_line() {
+        let raw = r#"data: {"id":"p1","from":"G1","to":"G2","amount":"10","asset_code":"USD","memo":null,"memo_type":null,"created_at":"2024-01-01"}"#;
+        let data = parse_sse_event(raw);
+        assert!(!data.is_empty());
+        let payment = serde_json::from_str::<StreamPayment>(&data).unwrap();
+        assert_eq!(payment.id, "p1");
+    }
+
+    #[test]
+    fn test_parse_sse_event_heartbeat_returns_empty() {
+        assert_eq!(parse_sse_event(": heartbeat"), "");
+        assert_eq!(parse_sse_event(""), "");
+    }
+
+    #[test]
+    fn test_sse_buffer_reassembles_chunk_split_event() {
+        let payment_json = r#"{"id":"split-1","from":"GA","to":"GB","amount":"5","asset_code":"EUR","memo":null,"memo_type":null,"created_at":"2024-06-01"}"#;
+
+        // Split the SSE event across two chunks at an arbitrary byte boundary.
+        let full_event = format!("data: {}\n\n", payment_json);
+        let split_at = full_event.len() / 2;
+        let chunk1 = &full_event[..split_at];
+        let chunk2 = &full_event[split_at..];
+
+        let mut buf = String::new();
+        let mut parsed: Vec<StreamPayment> = Vec::new();
+
+        // Simulate chunk1 arriving: no complete event yet.
+        buf.push_str(chunk1);
+        while let Some(pos) = buf.find("\n\n") {
+            let raw = buf[..pos].to_string();
+            buf = buf[pos + 2..].to_string();
+            let data = parse_sse_event(&raw);
+            if !data.is_empty() {
+                parsed.push(serde_json::from_str(&data).unwrap());
+            }
+        }
+        assert!(parsed.is_empty(), "no complete event after chunk1 alone");
+
+        // Simulate chunk2 completing the event.
+        buf.push_str(chunk2);
+        while let Some(pos) = buf.find("\n\n") {
+            let raw = buf[..pos].to_string();
+            buf = buf[pos + 2..].to_string();
+            let data = parse_sse_event(&raw);
+            if !data.is_empty() {
+                parsed.push(serde_json::from_str(&data).unwrap());
+            }
+        }
+
+        assert_eq!(parsed.len(), 1, "exactly one event after both chunks");
+        assert_eq!(parsed[0].id, "split-1");
+    }
+
+    #[tokio::test]
+    async fn test_stream_resumes_with_cursor_after_disconnect() {
+        let mut server = mockito::Server::new_async().await;
+
+        let p1 = r#"{"id":"cursor-1","from":"GA","to":"GB","amount":"10","asset_code":"USD","memo":null,"memo_type":null,"created_at":"2024-01-01"}"#;
+        let p2 = r#"{"id":"cursor-2","from":"GA","to":"GB","amount":"20","asset_code":"USD","memo":null,"memo_type":null,"created_at":"2024-01-02"}"#;
+
+        // First connection (no cursor): returns p1 then closes.
+        let _mock1 = server
+            .mock("GET", "/accounts/GTEST/payments?order=asc&stream=true")
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(format!("data: {}\n\n", p1))
+            .create_async()
+            .await;
+
+        // Second connection (cursor=cursor-1): returns p2 then closes.
+        let _mock2 = server
+            .mock(
+                "GET",
+                "/accounts/GTEST/payments?order=asc&stream=true&cursor=cursor-1",
+            )
+            .with_status(200)
+            .with_header("content-type", "text/event-stream")
+            .with_body(format!("data: {}\n\n", p2))
+            .create_async()
+            .await;
+
+        let client = HorizonClient::new(server.url());
+        let metrics = Arc::new(tokio::sync::Mutex::new(StreamMetrics {
+            reconnections: 0,
+            events_received: 0,
+            last_event_time: None,
+        }));
+        let (tx, mut rx) = mpsc::channel(10);
+
+        // First session: no cursor.
+        let url1 = format!("{}/accounts/GTEST/payments?order=asc&stream=true", server.url());
+        let (n1, cursor1) = client.connect_stream(&url1, &tx, &metrics).await.unwrap();
+        assert_eq!(n1, 1, "first session must deliver p1");
+        assert_eq!(cursor1.as_deref(), Some("cursor-1"));
+
+        // Second session: resume from cursor-1.
+        let url2 = format!(
+            "{}/accounts/GTEST/payments?order=asc&stream=true&cursor=cursor-1",
+            server.url()
+        );
+        let (n2, cursor2) = client.connect_stream(&url2, &tx, &metrics).await.unwrap();
+        assert_eq!(n2, 1, "second session must deliver p2");
+        assert_eq!(cursor2.as_deref(), Some("cursor-2"));
+
+        drop(tx);
+
+        let mut received_ids: Vec<String> = Vec::new();
+        while let Some(Ok(p)) = rx.recv().await {
+            received_ids.push(p.id.clone());
+        }
+
+        assert_eq!(received_ids, vec!["cursor-1", "cursor-2"], "no gaps, no duplicates");
     }
 
     #[tokio::test]


### PR DESCRIPTION
---
## Summary

`HorizonClient::stream_payments` had three bugs that made the on-chain payment
stream unsafe for money: missed payments on reconnect, a panic after 64
reconnects, and silently dropped events from split TCP chunks.

- **Cursor resumption** - `stream_payments` now accepts an `initial_cursor`
  (the Horizon paging token of the last processed payment) and appends
  `&cursor=<value>` to every connect and reconnect URL. `connect_stream`
  returns the cursor of the last forwarded payment so the loop always knows
  where to resume. `start_streaming` loads the persisted cursor from
  `account_monitor_cursors` before spawning the task and saves it after
  each successfully processed SSE payment, so a process restart also
  resumes without gaps.

- **Overflow-safe backoff** - `reconnect_count` is now `u32` and the shift
  exponent is capped at `reconnect_count.min(5)`, making the maximum
  possible shift `1 << 5 = 32`, clamped to 30 s. The counter resets to 0
  after any session that delivers at least one event. No panic at any
  reconnect count.

- **SSE chunk-boundary buffering** - `connect_stream` now accumulates raw
  bytes in a `String` buffer and splits on `\n\n` (the SSE event delimiter)
  before parsing. Multi-line `data:` fields are concatenated. Events split
  across TCP chunk boundaries are fully reassembled before any
  deserialization attempt. Parse failures are surfaced as `tracing::error!`
  with a `counter.sse_parse_errors` metric instead of a silent `warn!`.

## Tests added (`src/stellar/client.rs`)

- `test_backoff_never_overflows_past_64_reconnects` - asserts backoff <= 30 s
  for reconnect counts 0 to 100.
- `test_parse_sse_event_complete_single_line` / `test_parse_sse_event_heartbeat_returns_empty` -
  unit tests for the SSE event parser.
- `test_sse_buffer_reassembles_chunk_split_event` - feeds a payment event
  split at an arbitrary byte boundary across two chunks and asserts it
  parses correctly with no partial drop.
- `test_stream_resumes_with_cursor_after_disconnect` - mockito-backed test
  that runs two `connect_stream` sessions, verifies the cursor from the
  first is passed to the second, and asserts both payments are received
  with no gaps or duplicates.

## Closes
Closes #582 

