### PR TITLE
Feat/rust sdk retry with backoff for transient failures

### DIFF
--- a/.github/workflows/sdk-rust-ci.yml
+++ b/.github/workflows/sdk-rust-ci.yml
@@ -1,0 +1,46 @@
+name: Rust SDK CI
+
+on:
+  push:
+    paths:
+      - 'sdks/rust/**'
+  pull_request:
+    paths:
+      - 'sdks/rust/**'
+
+jobs:
+  ci:
+    name: clippy, fmt, test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdks/rust
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            sdks/rust/target/
+          key: ${{ runner.os }}-rust-sdk-${{ hashFiles('sdks/rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-sdk-
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "synapse-sdk"
+version = "0.1.0"
+edition = "2021"
+description = "Rust client SDK for the Synapse API"
+license = "MIT"
+
+[dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+rand = "0.8"
+tokio = { version = "1", features = ["time"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "synapse-sdk"
 version = "0.1.0"

--- a/sdks/rust/README.md
+++ b/sdks/rust/README.md
@@ -1,0 +1,186 @@
+# synapse-sdk
+
+Rust client SDK for the [Synapse API](https://github.com/Synapse-bridgez/synapse-core).
+
+## Installation
+
+Add the crate to your `Cargo.toml`:
+
+```toml
+[dependencies]
+synapse-sdk = { path = "../sdks/rust" }   # until published to crates.io
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+## Authentication
+
+Synapse uses API-key authentication. Two key types are issued:
+
+| Key type  | Header       | Use case                         |
+|-----------|--------------|----------------------------------|
+| Public    | `X-API-Key`  | Standard integrator requests     |
+| Admin     | `X-API-Key`  | Privileged operations (higher-trust endpoints) |
+
+Pass whichever key your endpoint requires to `SynapseClient::builder`:
+
+```rust,no_run
+use synapse_sdk::client::SynapseClient;
+
+// Public API key
+let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+    .build();
+
+// Admin API key — same builder, different key value
+let admin_client = SynapseClient::builder("https://api.example.com", "sk_admin_...")
+    .build();
+```
+
+## Quickstart
+
+### Building a client
+
+```rust,no_run
+use synapse_sdk::client::SynapseClient;
+
+#[tokio::main]
+async fn main() {
+    let client = SynapseClient::builder(
+        "https://api.example.com",
+        std::env::var("SYNAPSE_API_KEY").expect("SYNAPSE_API_KEY not set"),
+    )
+    .build();
+}
+```
+
+### Retry configuration
+
+All requests are retried automatically on transient failures (network errors and
+5xx responses). 4xx responses are returned immediately without retrying.
+
+```rust,no_run
+use synapse_sdk::client::SynapseClient;
+
+// Custom retry settings: up to 5 attempts, 100 ms base delay.
+let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+    .max_attempts(5)
+    .base_delay_ms(100)
+    .build();
+
+// Disable retries entirely (useful when you manage your own retry loop).
+let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+    .disable_retries()
+    .build();
+```
+
+Delays use decorrelated jitter — each retry draws a random value in
+`[base_delay, prev_delay * 3]`, capped at 10 s — so concurrent callers spread
+their retries instead of retrying in lockstep.
+
+### Fetching a resource
+
+Use `client.get::<T>(path)` for any endpoint that returns JSON:
+
+```rust,no_run
+use serde::Deserialize;
+use synapse_sdk::client::SynapseClient;
+
+#[derive(Deserialize)]
+struct Transaction {
+    id: String,
+    amount: String,
+    status: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+        .build();
+
+    let tx: Transaction = client.get("/v1/transactions/txn_abc123").await?;
+    println!("Transaction {}: {} ({})", tx.id, tx.amount, tx.status);
+    Ok(())
+}
+```
+
+### Cursor pagination
+
+List endpoints return a page of items plus an optional `next_cursor`. Use
+[`PageIter`](src/pagination.rs) to iterate lazily — each call to `next_page`
+issues exactly one request:
+
+```rust,no_run
+use serde::Deserialize;
+use synapse_sdk::client::SynapseClient;
+use synapse_sdk::pagination::PageIter;
+
+#[derive(Deserialize)]
+struct Transaction {
+    id: String,
+    amount: String,
+}
+
+#[derive(Deserialize)]
+struct TransactionPage {
+    transactions: Vec<Transaction>,
+    next_cursor: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+        .build();
+
+    let mut iter = PageIter::new(|cursor| {
+        let client = client.clone();
+        async move {
+            let path = match cursor {
+                Some(c) => format!("/v1/transactions?cursor={c}&limit=50"),
+                None    => "/v1/transactions?limit=50".to_string(),
+            };
+            let page: TransactionPage = client.get(&path).await?;
+            Ok((page.transactions, page.next_cursor))
+        }
+    });
+
+    while let Some(page) = iter.next_page().await {
+        for tx in page? {
+            println!("{}: {}", tx.id, tx.amount);
+        }
+    }
+    Ok(())
+}
+```
+
+### Error handling
+
+```rust,no_run
+use synapse_sdk::client::SynapseClient;
+use synapse_sdk::error::SynapseError;
+
+#[tokio::main]
+async fn main() {
+    let client = SynapseClient::builder("https://api.example.com", "pk_live_...")
+        .build();
+
+    match client.get::<serde_json::Value>("/v1/transactions/missing").await {
+        Ok(body)  => println!("got: {body}"),
+        Err(SynapseError::Http { status: 404, .. }) => println!("not found"),
+        Err(SynapseError::Http { status, body })    => println!("HTTP {status}: {body}"),
+        Err(SynapseError::Network(e))               => println!("network: {e}"),
+    }
+}
+```
+
+## Module overview
+
+| Module                      | Contents                                      |
+|-----------------------------|-----------------------------------------------|
+| `synapse_sdk::client`       | `SynapseClient` and `SynapseClientBuilder`    |
+| `synapse_sdk::error`        | `SynapseError` enum                           |
+| `synapse_sdk::retry`        | `retry_with_backoff` (used internally)        |
+| `synapse_sdk::pagination`   | `PageIter` lazy cursor-pagination iterator    |
+
+## License
+
+MIT

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,0 +1,104 @@
+use crate::error::SynapseError;
+use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
+use serde::de::DeserializeOwned;
+
+/// HTTP client for the Synapse public API.
+///
+/// Construct via [`SynapseClient::builder`]. All requests are issued with the
+/// configured API key and are retried automatically on transient failures.
+#[derive(Clone)]
+pub struct SynapseClient {
+    pub(crate) http: reqwest::Client,
+    pub(crate) base_url: String,
+    pub(crate) api_key: String,
+    pub(crate) max_attempts: u32,
+    pub(crate) base_delay_ms: u64,
+}
+
+/// Builder for [`SynapseClient`].
+pub struct SynapseClientBuilder {
+    base_url: String,
+    api_key: String,
+    max_attempts: u32,
+    base_delay_ms: u64,
+}
+
+impl SynapseClient {
+    /// Return a builder for constructing a [`SynapseClient`].
+    pub fn builder(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+    ) -> SynapseClientBuilder {
+        SynapseClientBuilder {
+            base_url: base_url.into(),
+            api_key: api_key.into(),
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            base_delay_ms: DEFAULT_BASE_DELAY_MS,
+        }
+    }
+
+    /// Issue an authenticated GET request to `path` and deserialize the JSON response.
+    ///
+    /// The request is retried automatically according to the client's retry
+    /// configuration. 4xx responses are returned immediately without retrying.
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.api_key.clone();
+        let http = self.http.clone();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .header("X-API-Key", &key)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(SynapseError::Http { status, body });
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+}
+
+impl SynapseClientBuilder {
+    /// Set the maximum total number of attempts, including the first (default: 3).
+    ///
+    /// Values below 1 are treated as 1 (no retries).
+    pub fn max_attempts(mut self, n: u32) -> Self {
+        self.max_attempts = n.max(1);
+        self
+    }
+
+    /// Disable retry behaviour. The first failure is returned immediately.
+    ///
+    /// Use this when the caller manages its own retry loop.
+    pub fn disable_retries(mut self) -> Self {
+        self.max_attempts = 1;
+        self
+    }
+
+    /// Set the base delay in milliseconds for exponential backoff (default: 200).
+    pub fn base_delay_ms(mut self, ms: u64) -> Self {
+        self.base_delay_ms = ms;
+        self
+    }
+
+    /// Build the [`SynapseClient`].
+    pub fn build(self) -> SynapseClient {
+        SynapseClient {
+            http: reqwest::Client::new(),
+            base_url: self.base_url,
+            api_key: self.api_key,
+            max_attempts: self.max_attempts,
+            base_delay_ms: self.base_delay_ms,
+        }
+    }
+}

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+/// Errors returned by the Synapse SDK.
+#[derive(Debug, Error)]
+pub enum SynapseError {
+    /// The server returned an HTTP error status.
+    ///
+    /// 5xx responses are transient (retryable). 4xx responses are permanent
+    /// caller mistakes and are never retried.
+    #[error("HTTP {status}: {body}")]
+    Http { status: u16, body: String },
+
+    /// A network-level failure occurred before a response was received.
+    #[error("network error: {0}")]
+    Network(#[from] reqwest::Error),
+}
+
+impl SynapseError {
+    /// Returns `true` if this error may resolve on a subsequent attempt.
+    ///
+    /// Network errors and 5xx HTTP responses are transient. 4xx responses are
+    /// permanent (they represent a caller mistake) and must not be retried.
+    pub fn is_transient(&self) -> bool {
+        match self {
+            SynapseError::Network(_) => true,
+            SynapseError::Http { status, .. } => *status >= 500,
+        }
+    }
+}

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod error;
+pub mod retry;

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod client;
 pub mod error;
+pub mod pagination;
 pub mod retry;

--- a/sdks/rust/src/pagination.rs
+++ b/sdks/rust/src/pagination.rs
@@ -120,11 +120,10 @@ mod tests {
     async fn passes_cursor_to_each_fetch() {
         let cursors_seen: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
 
-        let responses: Arc<Mutex<Vec<(Vec<u8>, Option<String>)>>> =
-            Arc::new(Mutex::new(vec![
-                (vec![1], Some("tok".to_string())),
-                (vec![2], None),
-            ]));
+        let responses: Arc<Mutex<Vec<(Vec<u8>, Option<String>)>>> = Arc::new(Mutex::new(vec![
+            (vec![1], Some("tok".to_string())),
+            (vec![2], None),
+        ]));
 
         let mut iter = PageIter::new(|cursor| {
             let seen = cursors_seen.clone();
@@ -145,7 +144,11 @@ mod tests {
 
         let seen = cursors_seen.lock().unwrap();
         assert_eq!(seen[0], None, "first call must pass None");
-        assert_eq!(seen[1], Some("tok".to_string()), "second call must pass the cursor from page 1");
+        assert_eq!(
+            seen[1],
+            Some("tok".to_string()),
+            "second call must pass the cursor from page 1"
+        );
     }
 
     #[tokio::test]

--- a/sdks/rust/src/pagination.rs
+++ b/sdks/rust/src/pagination.rs
@@ -1,0 +1,170 @@
+use crate::error::SynapseError;
+use std::future::Future;
+use std::marker::PhantomData;
+
+/// A lazy, page-by-page iterator over a cursor-paginated endpoint.
+///
+/// Each call to [`PageIter::next_page`] issues exactly one network request.
+/// The iterator is exhausted when the server returns `next_cursor: None`; all
+/// subsequent calls return `None` without making further requests.
+///
+/// Build one from any async closure that accepts `Option<String>` (the cursor)
+/// and returns `Result<(Vec<T>, Option<String>), SynapseError>`:
+///
+/// ```no_run
+/// # use synapse_sdk::pagination::PageIter;
+/// # use synapse_sdk::error::SynapseError;
+/// # async fn example() -> Result<(), SynapseError> {
+/// let mut iter = PageIter::new(|cursor| async move {
+///     // replace with a real client.transactions.list(cursor, limit) call
+///     let items: Vec<String> = vec![];
+///     let next_cursor: Option<String> = None;
+///     Ok((items, next_cursor))
+/// });
+///
+/// while let Some(page) = iter.next_page().await {
+///     for item in page? {
+///         println!("{item}");
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+pub struct PageIter<T, F, Fut> {
+    fetch: F,
+    cursor: Option<String>,
+    done: bool,
+    _marker: PhantomData<fn() -> (T, Fut)>,
+}
+
+impl<T, F, Fut> PageIter<T, F, Fut>
+where
+    F: FnMut(Option<String>) -> Fut,
+    Fut: Future<Output = Result<(Vec<T>, Option<String>), SynapseError>>,
+{
+    /// Create a new iterator backed by `fetch`.
+    ///
+    /// `fetch` is called with the current cursor on each page request. Return
+    /// `(items, Some(cursor))` to indicate more pages or `(items, None)` to
+    /// signal the last page.
+    pub fn new(fetch: F) -> Self {
+        Self {
+            fetch,
+            cursor: None,
+            done: false,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Fetch the next page.
+    ///
+    /// Returns `None` once the server has signalled that no more pages exist.
+    /// If the underlying request fails, the iterator is marked done and the
+    /// error is surfaced as `Some(Err(...))` so the caller can handle it; any
+    /// further call returns `None`.
+    pub async fn next_page(&mut self) -> Option<Result<Vec<T>, SynapseError>> {
+        if self.done {
+            return None;
+        }
+        let cursor = self.cursor.take();
+        match (self.fetch)(cursor).await {
+            Ok((items, next_cursor)) => {
+                match next_cursor {
+                    Some(c) => self.cursor = Some(c),
+                    None => self.done = true,
+                }
+                Some(Ok(items))
+            }
+            Err(e) => {
+                self.done = true;
+                Some(Err(e))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn collects_all_pages_and_stops() {
+        let pages = Arc::new(Mutex::new(vec![
+            (vec![1u32, 2], Some("c1".to_string())),
+            (vec![3u32, 4], Some("c2".to_string())),
+            (vec![5u32], None::<String>),
+        ]));
+
+        let mut iter = PageIter::new(|_cursor| {
+            let pages = pages.clone();
+            async move {
+                let entry = {
+                    let mut lock = pages.lock().unwrap();
+                    lock.remove(0)
+                };
+                Ok::<_, SynapseError>(entry)
+            }
+        });
+
+        let mut all = Vec::new();
+        while let Some(page) = iter.next_page().await {
+            all.extend(page.unwrap());
+        }
+        assert_eq!(all, vec![1, 2, 3, 4, 5]);
+        // Exhausted iterator must keep returning None.
+        assert!(iter.next_page().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn passes_cursor_to_each_fetch() {
+        let cursors_seen: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let responses: Arc<Mutex<Vec<(Vec<u8>, Option<String>)>>> =
+            Arc::new(Mutex::new(vec![
+                (vec![1], Some("tok".to_string())),
+                (vec![2], None),
+            ]));
+
+        let mut iter = PageIter::new(|cursor| {
+            let seen = cursors_seen.clone();
+            let responses = responses.clone();
+            async move {
+                seen.lock().unwrap().push(cursor);
+                let entry = {
+                    let mut lock = responses.lock().unwrap();
+                    lock.remove(0)
+                };
+                Ok::<_, SynapseError>(entry)
+            }
+        });
+
+        while let Some(page) = iter.next_page().await {
+            page.unwrap();
+        }
+
+        let seen = cursors_seen.lock().unwrap();
+        assert_eq!(seen[0], None, "first call must pass None");
+        assert_eq!(seen[1], Some("tok".to_string()), "second call must pass the cursor from page 1");
+    }
+
+    #[tokio::test]
+    async fn surfaces_error_and_stops() {
+        let mut iter = PageIter::<u32, _, _>::new(|_cursor| async move {
+            Err::<(Vec<u32>, Option<String>), _>(SynapseError::Http {
+                status: 500,
+                body: "oops".to_string(),
+            })
+        });
+
+        let result = iter.next_page().await;
+        assert!(
+            matches!(result, Some(Err(SynapseError::Http { status: 500, .. }))),
+            "error should be surfaced"
+        );
+        assert!(
+            iter.next_page().await.is_none(),
+            "iterator must stop after an error"
+        );
+    }
+}

--- a/sdks/rust/src/retry.rs
+++ b/sdks/rust/src/retry.rs
@@ -1,0 +1,128 @@
+use crate::error::SynapseError;
+use rand::Rng;
+use std::future::Future;
+use std::time::Duration;
+
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 3;
+pub const DEFAULT_BASE_DELAY_MS: u64 = 200;
+
+const MAX_DELAY_MS: u64 = 10_000;
+
+/// Retry a fallible async operation with exponential backoff and decorrelated jitter.
+///
+/// `max_attempts` is the total number of calls including the first attempt — pass
+/// `1` to effectively disable retries. `base_delay_ms` is the starting delay; each
+/// retry draws a new delay in the range `[base, prev * 3]`, capped at 10 s.
+///
+/// Only [`SynapseError::is_transient`] errors are retried. 4xx responses are
+/// returned immediately on the first attempt.
+pub async fn retry_with_backoff<F, Fut, T>(
+    max_attempts: u32,
+    base_delay_ms: u64,
+    mut f: F,
+) -> Result<T, SynapseError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, SynapseError>>,
+{
+    let mut attempt = 0u32;
+    let mut prev_delay_ms = base_delay_ms;
+    loop {
+        match f().await {
+            Ok(v) => return Ok(v),
+            Err(e) if attempt + 1 < max_attempts && e.is_transient() => {
+                attempt += 1;
+                let delay_ms = {
+                    let upper = prev_delay_ms.saturating_mul(3).max(base_delay_ms);
+                    let d = rand::thread_rng().gen_range(base_delay_ms..=upper);
+                    d.min(MAX_DELAY_MS)
+                };
+                prev_delay_ms = delay_ms;
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    fn http_error(status: u16) -> SynapseError {
+        SynapseError::Http {
+            status,
+            body: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_on_5xx_and_succeeds() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let result: Result<u32, _> = retry_with_backoff(3, 1, || {
+            let c = c.clone();
+            async move {
+                let n = c.fetch_add(1, Ordering::SeqCst);
+                if n < 2 {
+                    Err(http_error(500))
+                } else {
+                    Ok(42)
+                }
+            }
+        })
+        .await;
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_4xx() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let result: Result<u32, _> = retry_with_backoff(3, 1, || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(http_error(400))
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "4xx must not be retried");
+    }
+
+    #[tokio::test]
+    async fn disabled_when_max_attempts_is_one() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let result: Result<u32, _> = retry_with_backoff(1, 1, || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(http_error(503))
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "retries disabled when max_attempts=1");
+    }
+
+    #[tokio::test]
+    async fn exhausts_all_attempts_on_persistent_5xx() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = calls.clone();
+        let result: Result<u32, _> = retry_with_backoff(3, 1, || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Err(http_error(502))
+            }
+        })
+        .await;
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 3, "should try exactly max_attempts times");
+    }
+}

--- a/sdks/rust/src/retry.rs
+++ b/sdks/rust/src/retry.rs
@@ -107,7 +107,11 @@ mod tests {
         })
         .await;
         assert!(result.is_err());
-        assert_eq!(calls.load(Ordering::SeqCst), 1, "retries disabled when max_attempts=1");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "retries disabled when max_attempts=1"
+        );
     }
 
     #[tokio::test]
@@ -123,6 +127,10 @@ mod tests {
         })
         .await;
         assert!(result.is_err());
-        assert_eq!(calls.load(Ordering::SeqCst), 3, "should try exactly max_attempts times");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            3,
+            "should try exactly max_attempts times"
+        );
     }
 }


### PR DESCRIPTION
Rust SDK: retry, cursor pagination, README, and CI
This PR introduces the sdks/rust/ crate (synapse-sdk) and implements four Stellar Wave issues. Each issue is its own commit.

What's included
feat(sdk): add retry-with-backoff wrapper (759a93c)
Scaffolds the synapse-sdk crate and adds retry_with_backoff in src/retry.rs. The function retries only on transient failures (network errors, 5xx). 4xx responses are returned immediately. Max attempts (default 3), base delay, and disable-retries are all configurable via SynapseClient::builder().

feat(sdk): add cursor pagination iterator utility (dce8364)
Adds PageIter<T, F, Fut> in src/pagination.rs. The iterator is lazy — each next_page().await call issues exactly one request. It stops cleanly when next_cursor is None and surfaces the first request error as Some(Err(...)) then halts.

docs(sdk): add README and quickstart examples (cbbe906)
Writes sdks/rust/README.md covering installation, authentication (public vs admin key), retry configuration, client.get, cursor pagination with PageIter, and error handling. All code samples use exact method names from the implementation.

ci(sdk): add scoped clippy/fmt/test workflow (db9792c)
Adds .github/workflows/sdk-rust-ci.yml with a paths: sdks/rust/** filter. The job runs cargo fmt --check, cargo clippy -- -D warnings, and cargo test in sequence; any failure fails the workflow.

Files changed

sdks/rust/Cargo.toml
sdks/rust/src/lib.rs
sdks/rust/src/error.rs
sdks/rust/src/client.rs
sdks/rust/src/retry.rs
sdks/rust/src/pagination.rs
sdks/rust/README.md
.github/workflows/sdk-rust-ci.yml
Closes #609
Closes #610
Closes #611
Closes #612