### PR TITLE
feat(sdk): add transactions.search(filters) [Rust SDK]

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -5,4 +5,6 @@ pub mod resources;
 
 pub use client::SynapseClient;
 pub use error::SynapseError;
-pub use models::{ListMeta, ListParams, Transaction, TransactionList};
+pub use models::{
+    ListMeta, ListParams, SearchParams, Transaction, TransactionList, TransactionSearch,
+};

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -34,6 +34,46 @@ pub struct TransactionList {
     pub meta: ListMeta,
 }
 
+/// Filters for [`Transactions::search`].
+///
+/// All fields are optional; omit a field to leave that dimension unfiltered.
+/// A search with no matches returns an empty [`TransactionSearch`] (a page with
+/// `total == 0` and no `results`), never an error.
+#[derive(Debug, Default)]
+pub struct SearchParams {
+    /// Exact transaction status (e.g. `"pending"`, `"completed"`).
+    pub status: Option<String>,
+    /// Exact asset code (e.g. `"USD"`).
+    pub asset_code: Option<String>,
+    /// Inclusive minimum amount, as a decimal string (e.g. `"10.00"`).
+    pub min_amount: Option<String>,
+    /// Inclusive maximum amount, as a decimal string (e.g. `"500.00"`).
+    pub max_amount: Option<String>,
+    /// Inclusive RFC 3339 range start (e.g. `"2024-01-01T00:00:00Z"`).
+    pub from: Option<String>,
+    /// Exclusive RFC 3339 range end (e.g. `"2024-02-01T00:00:00Z"`).
+    pub to: Option<String>,
+    /// Exact Stellar account to filter by.
+    pub stellar_account: Option<String>,
+    /// Opaque pagination cursor from a previous response's `next_cursor`.
+    pub cursor: Option<String>,
+    /// Maximum records per page (server default: 25, max: 100).
+    pub limit: Option<i64>,
+}
+
+/// A single page of transactions returned by [`Transactions::search`].
+#[derive(Debug, Clone, Deserialize)]
+pub struct TransactionSearch {
+    /// Total number of records matching the filters across all pages.
+    pub total: i64,
+    /// Matching transactions for this page (empty when nothing matched).
+    #[serde(default)]
+    pub results: Vec<Transaction>,
+    /// Opaque cursor for the next page, or `None` when this is the last page.
+    #[serde(default)]
+    pub next_cursor: Option<String>,
+}
+
 /// Query parameters for [`Transactions::list`].
 ///
 /// All fields are optional; omit a field to accept the server's default.

--- a/sdks/rust/src/resources/transactions.rs
+++ b/sdks/rust/src/resources/transactions.rs
@@ -1,6 +1,6 @@
 use crate::client::SynapseClient;
 use crate::error::SynapseError;
-use crate::models::{ListParams, Transaction, TransactionList};
+use crate::models::{ListParams, SearchParams, Transaction, TransactionList, TransactionSearch};
 
 pub struct Transactions<'a> {
     pub(crate) client: &'a SynapseClient,
@@ -82,6 +82,87 @@ impl<'a> Transactions<'a> {
         match self
             .client
             .get_query::<TransactionList>("/transactions", &query)
+            .await
+        {
+            Err(SynapseError::Api {
+                status: 400,
+                message,
+            }) if message.contains("cursor") => Err(SynapseError::InvalidCursor(message)),
+            other => other,
+        }
+    }
+
+    /// Search transactions by filter, returning a single page of matches.
+    ///
+    /// Calls `GET /transactions/search` with any of the [`SearchParams`]
+    /// fields supplied; omitted fields leave that dimension unfiltered. Uses
+    /// the standard public client (`X-API-Key`).
+    ///
+    /// A search that matches nothing is **not** an error: it returns a
+    /// [`TransactionSearch`] with `total == 0` and an empty `results` page.
+    /// Use `next_cursor` to page through larger result sets.
+    ///
+    /// # Errors
+    /// - [`SynapseError::InvalidCursor`] – the cursor is malformed or expired (HTTP 400).
+    /// - [`SynapseError::Api`] – server returned another non-success status.
+    /// - [`SynapseError::Http`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use synapse_sdk::{SearchParams, SynapseClient};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = SynapseClient::new("https://api.example.com", "your-api-key");
+    ///
+    /// let filters = SearchParams {
+    ///     status: Some("completed".to_string()),
+    ///     asset_code: Some("USD".to_string()),
+    ///     min_amount: Some("10.00".to_string()),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let page = client.transactions().search(filters).await.unwrap();
+    /// println!("{} total matches, {} on this page", page.total, page.results.len());
+    /// # }
+    /// ```
+    pub async fn search(&self, filters: SearchParams) -> Result<TransactionSearch, SynapseError> {
+        let limit_str = filters.limit.map(|l| l.to_string());
+        let mut query: Vec<(&str, &str)> = Vec::new();
+
+        if let Some(ref v) = filters.status {
+            query.push(("status", v.as_str()));
+        }
+        if let Some(ref v) = filters.asset_code {
+            query.push(("asset_code", v.as_str()));
+        }
+        if let Some(ref v) = filters.min_amount {
+            query.push(("min_amount", v.as_str()));
+        }
+        if let Some(ref v) = filters.max_amount {
+            query.push(("max_amount", v.as_str()));
+        }
+        if let Some(ref v) = filters.from {
+            query.push(("from", v.as_str()));
+        }
+        if let Some(ref v) = filters.to {
+            query.push(("to", v.as_str()));
+        }
+        if let Some(ref v) = filters.stellar_account {
+            query.push(("stellar_account", v.as_str()));
+        }
+        if let Some(ref v) = filters.cursor {
+            query.push(("cursor", v.as_str()));
+        }
+        if let Some(ref v) = limit_str {
+            query.push(("limit", v.as_str()));
+        }
+
+        match self
+            .client
+            .get_query::<TransactionSearch>("/transactions/search", &query)
             .await
         {
             Err(SynapseError::Api {


### PR DESCRIPTION
## Summary
Implements `transactions.search(filters)` for the Rust SDK, wrapping `GET /transactions/search` (`handlers::search::search_transactions_wrapper`) on the standard public client.

- Adds `SearchParams` filters: `status`, `asset_code`, `min_amount`, `max_amount`, `from`, `to`, `stellar_account`, `cursor`, `limit` (param names verified against `SearchQuery` in `src/handlers/search.rs`).
- Adds `TransactionSearch` response model (`total`, `results`, `next_cursor`) matching the handler's JSON.
- Edge case handled: zero matches returns an empty page (`total == 0`, empty `results`), not an error.
- An invalid/expired cursor (400) surfaces as `SynapseError::InvalidCursor`.

Scope: only files under `sdks/rust/`.

> Note: stacks on #724, which introduces the SDK crate and the client/error/model foundation (not yet merged to `main`).

## Validation
- `cargo fmt --check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo build` ✅
- `cargo test` (unit + doctests) ✅

Closes #619