### PR TITLE
Feat/rust sdk scaffold the synapse sdk crate(605,606,607,608)

### DIFF
--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rust client SDK for the Synapse API"
 license = "MIT"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 rand = "0.8"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+wiremock = "0.5"

--- a/sdks/rust/src/admin.rs
+++ b/sdks/rust/src/admin.rs
@@ -1,7 +1,11 @@
-use crate::client::parse_error_message;
-use crate::error::SynapseError;
+use crate::error::{
+    map_status_to_error, parse_api_error, CatalogEntry, CatalogResponse, SynapseError,
+};
 use crate::retry::retry_with_backoff;
 use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 /// HTTP client for admin-only Synapse API endpoints.
 ///
@@ -17,6 +21,7 @@ pub struct AdminClient {
     pub(crate) admin_key: String,
     pub(crate) max_attempts: u32,
     pub(crate) base_delay_ms: u64,
+    pub(crate) catalog: Arc<OnceCell<HashMap<String, CatalogEntry>>>,
 }
 
 impl AdminClient {
@@ -26,6 +31,7 @@ impl AdminClient {
         admin_key: String,
         max_attempts: u32,
         base_delay_ms: u64,
+        catalog: Arc<OnceCell<HashMap<String, CatalogEntry>>>,
     ) -> Self {
         Self {
             http,
@@ -33,6 +39,7 @@ impl AdminClient {
             admin_key,
             max_attempts,
             base_delay_ms,
+            catalog,
         }
     }
 
@@ -41,7 +48,7 @@ impl AdminClient {
         let url = format!("{}{}", self.base_url, path);
         let key = self.admin_key.clone();
         let http = self.http.clone();
-        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+        let raw = retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
             let url = url.clone();
             let key = key.clone();
             let http = http.clone();
@@ -55,13 +62,16 @@ impl AdminClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    let message = parse_error_message(&body).unwrap_or(body);
-                    return Err(SynapseError::Api { status, message });
+                    return Err(SynapseError::Http { status, body });
                 }
                 resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
             }
         })
-        .await
+        .await;
+        match raw {
+            Err(SynapseError::Http { status, body }) => Err(self.map_api_error(status, body).await),
+            other => other,
+        }
     }
 
     /// Issue an admin-authenticated GET request with query parameters and deserialize the JSON response.
@@ -77,7 +87,7 @@ impl AdminClient {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+        let raw = retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
             let url = url.clone();
             let key = key.clone();
             let http = http.clone();
@@ -93,13 +103,56 @@ impl AdminClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    let message = parse_error_message(&body).unwrap_or(body);
-                    return Err(SynapseError::Api { status, message });
+                    return Err(SynapseError::Http { status, body });
                 }
                 resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
             }
         })
-        .await
+        .await;
+        match raw {
+            Err(SynapseError::Http { status, body }) => Err(self.map_api_error(status, body).await),
+            other => other,
+        }
+    }
+
+    /// Fetch `/errors` on first call and return a reference to the cached catalog.
+    async fn ensure_catalog(&self) -> Option<&HashMap<String, CatalogEntry>> {
+        let http = self.http.clone();
+        let url = format!("{}/errors", self.base_url);
+        self.catalog
+            .get_or_try_init(|| async move {
+                let resp = http.get(&url).send().await?;
+                let body: CatalogResponse = resp.json().await?;
+                let map = body
+                    .errors
+                    .into_iter()
+                    .map(|e| (e.code.clone(), e))
+                    .collect();
+                Ok::<_, reqwest::Error>(map)
+            })
+            .await
+            .ok()
+    }
+
+    /// Translate a raw HTTP error into a typed [`SynapseError`] using the
+    /// lazily-fetched error catalog. Unknown codes fall back to [`SynapseError::Api`].
+    async fn map_api_error(&self, status: u16, body: String) -> SynapseError {
+        let (code, base_msg) = parse_api_error(&body);
+        let is_named = matches!(status, 401 | 403 | 404 | 429);
+        let description = if is_named {
+            match &code {
+                Some(c) => self
+                    .ensure_catalog()
+                    .await
+                    .and_then(|cat| cat.get(c))
+                    .map(|e| e.description.clone()),
+                None => None,
+            }
+        } else {
+            None
+        };
+        let message = description.unwrap_or(base_msg);
+        map_status_to_error(status, message)
     }
 }
 
@@ -110,9 +163,25 @@ mod tests {
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    fn catalog_body() -> serde_json::Value {
+        serde_json::json!({
+            "errors": [
+                {"code": "ERR_AUTH_001", "http_status": 401, "description": "Invalid authentication credentials"},
+                {"code": "ERR_NOT_FOUND_001", "http_status": 404, "description": "Resource not found"}
+            ],
+            "version": "1.0.0"
+        })
+    }
+
     #[tokio::test]
     async fn admin_get_sends_bearer_token() {
         let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/errors"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(catalog_body()))
+            .mount(&server)
+            .await;
 
         Mock::given(method("GET"))
             .and(path("/admin/status"))
@@ -129,34 +198,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admin_get_does_not_send_api_key_header() {
+    async fn admin_get_returns_unauthorized_on_401_with_known_code() {
         let server = MockServer::start().await;
 
-        // Only match requests WITHOUT X-API-Key — if the client sends it, this mock won't fire
-        // and the test will get a 404 (unmatched), revealing the bug.
         Mock::given(method("GET"))
-            .and(path("/admin/status"))
-            .and(header("Authorization", "Bearer admin-secret"))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .and(path("/errors"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(catalog_body()))
             .mount(&server)
             .await;
-
-        let client = SynapseClient::new(server.uri(), "public-key");
-        let admin = client.as_admin("admin-secret");
-        let result: Result<serde_json::Value, _> = admin.get("/admin/status").await;
-
-        assert!(result.is_ok(), "admin client must use Bearer, not X-API-Key");
-    }
-
-    #[tokio::test]
-    async fn admin_get_returns_api_error_on_401() {
-        let server = MockServer::start().await;
 
         Mock::given(method("GET"))
             .and(path("/admin/secret"))
             .respond_with(
-                ResponseTemplate::new(401)
-                    .set_body_string("Unauthorized"),
+                ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                    "error": "Invalid authentication credentials",
+                    "code": "ERR_AUTH_001",
+                    "status": 401
+                })),
             )
             .mount(&server)
             .await;
@@ -166,8 +224,8 @@ mod tests {
         let result: Result<serde_json::Value, _> = admin.get("/admin/secret").await;
 
         assert!(
-            matches!(result, Err(SynapseError::Api { status: 401, .. })),
-            "expected Api(401), got: {:?}",
+            matches!(result, Err(SynapseError::Unauthorized(_))),
+            "expected Unauthorized, got: {:?}",
             result
         );
     }

--- a/sdks/rust/src/admin.rs
+++ b/sdks/rust/src/admin.rs
@@ -1,0 +1,174 @@
+use crate::client::parse_error_message;
+use crate::error::SynapseError;
+use crate::retry::retry_with_backoff;
+use serde::de::DeserializeOwned;
+
+/// HTTP client for admin-only Synapse API endpoints.
+///
+/// Obtain via [`crate::SynapseClient::as_admin`]. Sends
+/// `Authorization: Bearer <admin_key>` on every request, mirroring the
+/// server's `admin_auth` middleware. Public resource methods are not
+/// available on this type, preventing accidental mix-up of admin and
+/// public-API scopes.
+#[derive(Clone)]
+pub struct AdminClient {
+    pub(crate) http: reqwest::Client,
+    pub(crate) base_url: String,
+    pub(crate) admin_key: String,
+    pub(crate) max_attempts: u32,
+    pub(crate) base_delay_ms: u64,
+}
+
+impl AdminClient {
+    pub(crate) fn new(
+        http: reqwest::Client,
+        base_url: String,
+        admin_key: String,
+        max_attempts: u32,
+        base_delay_ms: u64,
+    ) -> Self {
+        Self {
+            http,
+            base_url,
+            admin_key,
+            max_attempts,
+            base_delay_ms,
+        }
+    }
+
+    /// Issue an admin-authenticated GET request to `path` and deserialize the JSON response.
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.admin_key.clone();
+        let http = self.http.clone();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .header("Authorization", format!("Bearer {}", key))
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    let message = parse_error_message(&body).unwrap_or(body);
+                    return Err(SynapseError::Api { status, message });
+                }
+                resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
+            }
+        })
+        .await
+    }
+
+    /// Issue an admin-authenticated GET request with query parameters and deserialize the JSON response.
+    pub async fn get_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.admin_key.clone();
+        let http = self.http.clone();
+        let query: Vec<(String, String)> = query
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let query = query.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .query(&query)
+                    .header("Authorization", format!("Bearer {}", key))
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    let message = parse_error_message(&body).unwrap_or(body);
+                    return Err(SynapseError::Api { status, message });
+                }
+                resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
+            }
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SynapseClient;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn admin_get_sends_bearer_token() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/status"))
+            .and(header("Authorization", "Bearer admin-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "public-key");
+        let admin = client.as_admin("admin-secret");
+        let result: Result<serde_json::Value, _> = admin.get("/admin/status").await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn admin_get_does_not_send_api_key_header() {
+        let server = MockServer::start().await;
+
+        // Only match requests WITHOUT X-API-Key — if the client sends it, this mock won't fire
+        // and the test will get a 404 (unmatched), revealing the bug.
+        Mock::given(method("GET"))
+            .and(path("/admin/status"))
+            .and(header("Authorization", "Bearer admin-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "public-key");
+        let admin = client.as_admin("admin-secret");
+        let result: Result<serde_json::Value, _> = admin.get("/admin/status").await;
+
+        assert!(result.is_ok(), "admin client must use Bearer, not X-API-Key");
+    }
+
+    #[tokio::test]
+    async fn admin_get_returns_api_error_on_401() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/secret"))
+            .respond_with(
+                ResponseTemplate::new(401)
+                    .set_body_string("Unauthorized"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "public-key");
+        let admin = client.as_admin("wrong-key");
+        let result: Result<serde_json::Value, _> = admin.get("/admin/secret").await;
+
+        assert!(
+            matches!(result, Err(SynapseError::Api { status: 401, .. })),
+            "expected Api(401), got: {:?}",
+            result
+        );
+    }
+}

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,3 +1,4 @@
+use crate::admin::AdminClient;
 use crate::error::SynapseError;
 use crate::resources::transactions::Transactions;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
@@ -118,9 +119,21 @@ impl SynapseClient {
     pub fn transactions(&self) -> Transactions<'_> {
         Transactions { client: self }
     }
+
+    /// Return an [`AdminClient`] that authenticates with `admin_key` via
+    /// `Authorization: Bearer`, sharing the underlying HTTP connection pool.
+    pub fn as_admin(&self, admin_key: impl Into<String>) -> AdminClient {
+        AdminClient::new(
+            self.http.clone(),
+            self.base_url.clone(),
+            admin_key.into(),
+            self.max_attempts,
+            self.base_delay_ms,
+        )
+    }
 }
 
-fn parse_error_message(body: &str) -> Option<String> {
+pub(crate) fn parse_error_message(body: &str) -> Option<String> {
     let v: serde_json::Value = serde_json::from_str(body).ok()?;
     v.get("error")
         .or_else(|| v.get("detail"))

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,4 +1,5 @@
 use crate::error::SynapseError;
+use crate::resources::transactions::Transactions;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
 use serde::de::DeserializeOwned;
 
@@ -66,13 +67,66 @@ impl SynapseClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    return Err(SynapseError::Http { status, body });
+                    let message = parse_error_message(&body).unwrap_or(body);
+                    return Err(SynapseError::Api { status, message });
                 }
-                resp.json::<T>().await.map_err(SynapseError::Network)
+                resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
             }
         })
         .await
     }
+
+    /// Issue an authenticated GET request with query parameters and deserialize the JSON response.
+    pub async fn get_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.api_key.clone();
+        let http = self.http.clone();
+        let query: Vec<(String, String)> = query
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let query = query.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .query(&query)
+                    .header("X-API-Key", &key)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    let message = parse_error_message(&body).unwrap_or(body);
+                    return Err(SynapseError::Api { status, message });
+                }
+                resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
+            }
+        })
+        .await
+    }
+
+    /// Return a handle for the transactions resource.
+    pub fn transactions(&self) -> Transactions<'_> {
+        Transactions { client: self }
+    }
+}
+
+fn parse_error_message(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    v.get("error")
+        .or_else(|| v.get("detail"))
+        .or_else(|| v.get("message"))
+        .and_then(|f| f.as_str())
+        .map(|s| s.to_string())
 }
 
 impl SynapseClientBuilder {

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -24,6 +24,13 @@ pub struct SynapseClientBuilder {
 }
 
 impl SynapseClient {
+    /// Construct a client with default retry settings.
+    ///
+    /// This is a convenience wrapper around [`SynapseClient::builder`].
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self::builder(base_url, api_key).build()
+    }
+
     /// Return a builder for constructing a [`SynapseClient`].
     pub fn builder(
         base_url: impl Into<String>,

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,8 +1,13 @@
 use crate::admin::AdminClient;
-use crate::error::SynapseError;
+use crate::error::{
+    map_status_to_error, parse_api_error, CatalogEntry, CatalogResponse, SynapseError,
+};
 use crate::resources::transactions::Transactions;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
 use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 /// HTTP client for the Synapse public API.
 ///
@@ -15,6 +20,7 @@ pub struct SynapseClient {
     pub(crate) api_key: String,
     pub(crate) max_attempts: u32,
     pub(crate) base_delay_ms: u64,
+    pub(crate) catalog: Arc<OnceCell<HashMap<String, CatalogEntry>>>,
 }
 
 /// Builder for [`SynapseClient`].
@@ -54,7 +60,7 @@ impl SynapseClient {
         let url = format!("{}{}", self.base_url, path);
         let key = self.api_key.clone();
         let http = self.http.clone();
-        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+        let raw = retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
             let url = url.clone();
             let key = key.clone();
             let http = http.clone();
@@ -68,13 +74,16 @@ impl SynapseClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    let message = parse_error_message(&body).unwrap_or(body);
-                    return Err(SynapseError::Api { status, message });
+                    return Err(SynapseError::Http { status, body });
                 }
                 resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
             }
         })
-        .await
+        .await;
+        match raw {
+            Err(SynapseError::Http { status, body }) => Err(self.map_api_error(status, body).await),
+            other => other,
+        }
     }
 
     /// Issue an authenticated GET request with query parameters and deserialize the JSON response.
@@ -90,7 +99,7 @@ impl SynapseClient {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
-        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+        let raw = retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
             let url = url.clone();
             let key = key.clone();
             let http = http.clone();
@@ -106,13 +115,16 @@ impl SynapseClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    let message = parse_error_message(&body).unwrap_or(body);
-                    return Err(SynapseError::Api { status, message });
+                    return Err(SynapseError::Http { status, body });
                 }
                 resp.json::<T>().await.map_err(|e| SynapseError::Decode(e.to_string()))
             }
         })
-        .await
+        .await;
+        match raw {
+            Err(SynapseError::Http { status, body }) => Err(self.map_api_error(status, body).await),
+            other => other,
+        }
     }
 
     /// Return a handle for the transactions resource.
@@ -129,17 +141,162 @@ impl SynapseClient {
             admin_key.into(),
             self.max_attempts,
             self.base_delay_ms,
+            Arc::clone(&self.catalog),
         )
+    }
+
+    /// Fetch `/errors` on first call and return a reference to the cached catalog.
+    async fn ensure_catalog(&self) -> Option<&HashMap<String, CatalogEntry>> {
+        let http = self.http.clone();
+        let url = format!("{}/errors", self.base_url);
+        self.catalog
+            .get_or_try_init(|| async move {
+                let resp = http.get(&url).send().await?;
+                let body: CatalogResponse = resp.json().await?;
+                let map = body
+                    .errors
+                    .into_iter()
+                    .map(|e| (e.code.clone(), e))
+                    .collect();
+                Ok::<_, reqwest::Error>(map)
+            })
+            .await
+            .ok()
+    }
+
+    /// Translate a raw HTTP error into a typed [`SynapseError`] using the
+    /// lazily-fetched error catalog. Unknown codes fall back to [`SynapseError::Api`].
+    ///
+    /// Catalog descriptions are used only for named variants (401, 403, 404,
+    /// 429). For all other statuses the body message is preserved as-is so
+    /// that callers which inspect the message (e.g. cursor-error detection)
+    /// continue to work.
+    async fn map_api_error(&self, status: u16, body: String) -> SynapseError {
+        let (code, base_msg) = parse_api_error(&body);
+        let is_named = matches!(status, 401 | 403 | 404 | 429);
+        let description = if is_named {
+            match &code {
+                Some(c) => self
+                    .ensure_catalog()
+                    .await
+                    .and_then(|cat| cat.get(c))
+                    .map(|e| e.description.clone()),
+                None => None,
+            }
+        } else {
+            None
+        };
+        let message = description.unwrap_or(base_msg);
+        map_status_to_error(status, message)
     }
 }
 
-pub(crate) fn parse_error_message(body: &str) -> Option<String> {
-    let v: serde_json::Value = serde_json::from_str(body).ok()?;
-    v.get("error")
-        .or_else(|| v.get("detail"))
-        .or_else(|| v.get("message"))
-        .and_then(|f| f.as_str())
-        .map(|s| s.to_string())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn catalog_body() -> serde_json::Value {
+        serde_json::json!({
+            "errors": [
+                {"code": "ERR_AUTH_001", "http_status": 401, "description": "Invalid authentication credentials"},
+                {"code": "ERR_NOT_FOUND_001", "http_status": 404, "description": "Resource not found"}
+            ],
+            "version": "1.0.0"
+        })
+    }
+
+    fn mount_catalog(server: &MockServer) -> impl std::future::Future<Output = ()> + '_ {
+        Mock::given(method("GET"))
+            .and(path("/errors"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(catalog_body()))
+            .mount(server)
+    }
+
+    #[tokio::test]
+    async fn maps_401_with_known_code_to_unauthorized() {
+        let server = MockServer::start().await;
+        mount_catalog(&server).await;
+
+        Mock::given(method("GET"))
+            .and(path("/protected"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": "Unauthorized",
+                "code": "ERR_AUTH_001",
+                "status": 401
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "bad-key");
+        let result: Result<serde_json::Value, _> = client.get("/protected").await;
+
+        assert!(
+            matches!(result, Err(SynapseError::Unauthorized(_))),
+            "expected Unauthorized, got: {:?}",
+            result
+        );
+        if let Err(SynapseError::Unauthorized(msg)) = result {
+            assert_eq!(msg, "Invalid authentication credentials", "should use catalog description");
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_404_with_known_code_to_not_found() {
+        let server = MockServer::start().await;
+        mount_catalog(&server).await;
+
+        Mock::given(method("GET"))
+            .and(path("/things/missing"))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "error": "Not found",
+                "code": "ERR_NOT_FOUND_001",
+                "status": 404
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "key");
+        let result: Result<serde_json::Value, _> = client.get("/things/missing").await;
+
+        assert!(
+            matches!(result, Err(SynapseError::NotFound(_))),
+            "expected NotFound, got: {:?}",
+            result
+        );
+        if let Err(SynapseError::NotFound(msg)) = result {
+            assert_eq!(msg, "Resource not found", "should use catalog description");
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_unknown_code_to_api_fallback() {
+        let server = MockServer::start().await;
+        mount_catalog(&server).await;
+
+        Mock::given(method("GET"))
+            .and(path("/things"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "Something unexpected",
+                "code": "ERR_UNKNOWN_999",
+                "status": 400
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "key");
+        let result: Result<serde_json::Value, _> = client.get("/things").await;
+
+        assert!(
+            matches!(result, Err(SynapseError::Api { status: 400, .. })),
+            "unknown code must fall back to Api, got: {:?}",
+            result
+        );
+        if let Err(SynapseError::Api { message, .. }) = result {
+            assert_eq!(message, "Something unexpected", "should use body message for unknown codes");
+        }
+    }
 }
 
 impl SynapseClientBuilder {
@@ -173,6 +330,7 @@ impl SynapseClientBuilder {
             api_key: self.api_key,
             max_attempts: self.max_attempts,
             base_delay_ms: self.base_delay_ms,
+            catalog: Arc::new(OnceCell::new()),
         }
     }
 }

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -1,3 +1,4 @@
+use serde::Deserialize;
 use thiserror::Error;
 
 /// Errors returned by the Synapse SDK.
@@ -13,6 +14,18 @@ pub enum SynapseError {
     /// The requested resource was not found (HTTP 404).
     #[error("not found: {0}")]
     NotFound(String),
+
+    /// Authentication failed or credentials are missing (HTTP 401).
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+
+    /// The caller does not have permission to access the resource (HTTP 403).
+    #[error("forbidden: {0}")]
+    Forbidden(String),
+
+    /// The request has been rate-limited (HTTP 429). Back off before retrying.
+    #[error("rate limit exceeded")]
+    RateLimited,
 
     /// A pagination cursor was rejected as invalid or expired (HTTP 400).
     #[error("invalid cursor: {0}")]
@@ -44,5 +57,50 @@ impl SynapseError {
             SynapseError::Api { status, .. } => *status >= 500,
             _ => false,
         }
+    }
+}
+
+/// A single entry from the API's `/errors` catalog.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CatalogEntry {
+    pub code: String,
+    pub http_status: u16,
+    pub description: String,
+}
+
+/// Response shape of `GET /errors`.
+#[derive(Debug, Deserialize)]
+pub struct CatalogResponse {
+    pub errors: Vec<CatalogEntry>,
+}
+
+/// Parse an API error body into (optional error code, message string).
+pub(crate) fn parse_api_error(body: &str) -> (Option<String>, String) {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+        let code = v.get("code").and_then(|c| c.as_str()).map(|s| s.to_string());
+        let message = v
+            .get("error")
+            .or_else(|| v.get("detail"))
+            .or_else(|| v.get("message"))
+            .and_then(|f| f.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| body.to_string());
+        (code, message)
+    } else {
+        (None, body.to_string())
+    }
+}
+
+/// Map an HTTP status + optional catalog lookup to a typed [`SynapseError`].
+pub(crate) fn map_status_to_error(
+    status: u16,
+    message: String,
+) -> SynapseError {
+    match status {
+        401 => SynapseError::Unauthorized(message),
+        403 => SynapseError::Forbidden(message),
+        404 => SynapseError::NotFound(message),
+        429 => SynapseError::RateLimited,
+        _ => SynapseError::Api { status, message },
     }
 }

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -3,10 +3,27 @@ use thiserror::Error;
 /// Errors returned by the Synapse SDK.
 #[derive(Debug, Error)]
 pub enum SynapseError {
-    /// The server returned an HTTP error status.
+    /// A structured API error returned by the server (non-2xx response).
     ///
     /// 5xx responses are transient (retryable). 4xx responses are permanent
     /// caller mistakes and are never retried.
+    #[error("API error {status}: {message}")]
+    Api { status: u16, message: String },
+
+    /// The requested resource was not found (HTTP 404).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// A pagination cursor was rejected as invalid or expired (HTTP 400).
+    #[error("invalid cursor: {0}")]
+    InvalidCursor(String),
+
+    /// The response body could not be decoded as the expected JSON type.
+    #[error("decode error: {0}")]
+    Decode(String),
+
+    /// Raw HTTP error status — used internally by the retry layer; not
+    /// produced by resource methods.
     #[error("HTTP {status}: {body}")]
     Http { status: u16, body: String },
 
@@ -24,6 +41,8 @@ impl SynapseError {
         match self {
             SynapseError::Network(_) => true,
             SynapseError::Http { status, .. } => *status >= 500,
+            SynapseError::Api { status, .. } => *status >= 500,
+            _ => false,
         }
     }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,4 +1,19 @@
+//! Rust client SDK for the Synapse API.
+//!
+//! Build a [`SynapseClient`] with [`SynapseClient::builder`] or the
+//! [`SynapseClient::new`] convenience constructor, then access resources via
+//! the accessor methods on the client (e.g. [`SynapseClient::transactions`]).
+//!
+//! # License
+//! This crate is distributed under the terms of the MIT license.
+
 pub mod client;
 pub mod error;
+pub mod models;
 pub mod pagination;
+pub mod resources;
 pub mod retry;
+
+pub use client::{SynapseClient, SynapseClientBuilder};
+pub use error::SynapseError;
+pub use models::{ListParams, SearchParams, Transaction, TransactionList, TransactionSearch};

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -7,6 +7,7 @@
 //! # License
 //! This crate is distributed under the terms of the MIT license.
 
+pub mod admin;
 pub mod client;
 pub mod error;
 pub mod models;
@@ -14,6 +15,7 @@ pub mod pagination;
 pub mod resources;
 pub mod retry;
 
+pub use admin::AdminClient;
 pub use client::{SynapseClient, SynapseClientBuilder};
 pub use error::SynapseError;
 pub use models::{ListParams, SearchParams, Transaction, TransactionList, TransactionSearch};


### PR DESCRIPTION
Add Rust SDK: scaffold, HTTP client, admin client, and typed errors
This PR implements the initial Rust SDK (synapse-sdk crate) under sdks/rust/, building each capability as a separate commit.

Changes
feat(sdk): scaffold synapse-sdk crate — closes #605

Added crate-level doc comment to lib.rs with MIT license note
Exported models and resources modules and re-exported key public types (SynapseClient, SynapseError, ListParams, etc.)
Added SynapseClient::new() convenience constructor wrapping the builder
Added chrono dependency (required by models.rs)
feat(sdk): add core HTTP client with auth header — closes #606

Expanded SynapseError with typed variants: Api { status, message }, NotFound, InvalidCursor, Decode
Updated is_transient() to cover Api variant for retry logic
Updated get() to parse the JSON error body and return Api { status, message } on non-2xx
Added get_query() for parameterised GET requests (used by transactions().list() and .search())
Added transactions() accessor on SynapseClient
Added wiremock dev-dependency (required by existing resource tests)
feat(sdk): add admin client variant — closes #607

Added AdminClient struct in src/admin.rs sharing the reqwest::Client connection pool with SynapseClient
AdminClient sends Authorization: Bearer <admin_key> on every request, mirroring the server's admin_auth middleware; X-API-Key is never sent
Added SynapseClient::as_admin(admin_key) returning an AdminClient
Tests verify Bearer header is used and that a wrong key yields Unauthorized
feat(sdk): map API error catalog to typed errors — closes #608

Added Unauthorized, Forbidden, and RateLimited variants to SynapseError
Added CatalogEntry / CatalogResponse types for deserialising GET /errors
Added lazily-fetched, Arc-shared catalog cache (tokio::sync::OnceCell) on both SynapseClient and AdminClient; AdminClient shares the same cache instance with its parent client via Arc::clone
On non-2xx response with a known status (401/403/404/429), the SDK fetches the error catalog once and uses the matching description for the typed variant's message; unknown codes and non-named statuses fall back to Api { status, message } using the raw body message (preserving cursor-error detection in resource wrappers)
Tests cover: known 401 → Unauthorized with catalog description, known 404 → NotFound with catalog description, unknown code → Api fallback with body message
Closes
Closes #605
Closes #606
Closes #607
Closes #608