### PR TITLE
docs(sdk): document transactions_search with rustdoc and example

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -21,12 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,26 +31,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -66,15 +44,15 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -131,19 +109,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -156,21 +135,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "deadpool"
-version = "0.9.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
- "retain_mut",
  "tokio",
 ]
 
@@ -217,19 +189,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -242,6 +205,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -301,21 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,12 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,24 +320,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -394,7 +351,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -426,35 +402,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.12",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "http-types"
-version = "2.12.0"
+name = "http-body"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "anyhow",
- "async-channel",
- "base64 0.13.1",
- "futures-lite",
- "http",
- "infer",
+ "bytes",
+ "http 1.4.2",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
- "rand",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -479,9 +467,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -494,17 +482,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
- "futures-util",
- "http",
- "hyper",
- "rustls",
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
  "tokio",
- "tokio-rustls",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -645,21 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,10 +691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -728,8 +748,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -758,10 +795,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "parking"
-version = "2.2.1"
+name = "openssl"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking_lot"
@@ -797,6 +871,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -835,23 +915,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.7.3"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "getrandom 0.1.16",
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -859,20 +943,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -924,19 +999,19 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -944,46 +1019,26 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
 [[package]]
-name = "retain_mut"
-version = "0.1.9"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
+ "bitflags 2.13.0",
+ "errno",
  "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -993,16 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1018,19 +1063,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1074,17 +1141,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -1169,6 +1225,7 @@ name = "synapse-sdk"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -1201,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1213,6 +1270,19 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1274,12 +1344,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
 ]
 
@@ -1334,12 +1404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,7 +1413,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -1359,10 +1422,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
+name = "vcpkg"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
@@ -1372,12 +1435,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -1449,12 +1506,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "windows-core"
@@ -1675,24 +1726,25 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.5.22"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a3a53eaf34f390dd30d7b1b078287dd05df2aa2e21a589ccb80f5c7253c2e9"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "deadpool",
  "futures",
- "futures-timer",
- "http-types",
- "hyper",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
  "log",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rust client SDK for the Synapse API"
 license = "MIT"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -17,3 +18,4 @@ tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+wiremock = "0.6"

--- a/sdks/rust/examples/transactions_search.rs
+++ b/sdks/rust/examples/transactions_search.rs
@@ -1,0 +1,104 @@
+//! Search transactions by filter, with support for pagination and empty results.
+//!
+//! Reads configuration from environment variables:
+//!   SYNAPSE_API_URL  – base URL of the API  (default: http://localhost:3000)
+//!   SYNAPSE_API_KEY  – tenant API key        (default: dev-key)
+//!
+//! Run with:
+//!   cargo run --example transactions_search
+//!
+//! Demonstrates:
+//!   - Filtering by status, asset code, and amount range
+//!   - Paginating through multi-page result sets via `next_cursor`
+//!   - Handling a query that matches zero records (empty page, not an error)
+
+use synapse_sdk::{SearchParams, SynapseClient, SynapseError};
+
+#[tokio::main]
+async fn main() {
+    let base_url =
+        std::env::var("SYNAPSE_API_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let api_key = std::env::var("SYNAPSE_API_KEY").unwrap_or_else(|_| "dev-key".to_string());
+
+    let client = SynapseClient::new(base_url, api_key);
+
+    // ── First search: look for completed USD transactions of at least $10 ──
+    println!("--- Search 1: completed USD transactions ≥ $10 ---");
+
+    let filters = SearchParams {
+        status: Some("completed".to_string()),
+        asset_code: Some("USD".to_string()),
+        min_amount: Some("10.00".to_string()),
+        ..Default::default()
+    };
+
+    match client.transactions().search(filters).await {
+        Ok(page) => {
+            println!("total matches across all pages: {}", page.total);
+
+            if page.results.is_empty() {
+                println!("no results on this page");
+            } else {
+                for tx in &page.results {
+                    println!("  {}  {}  {} {}", tx.id, tx.status, tx.amount, tx.asset_code);
+                }
+            }
+
+            // ── Pagination: follow next_cursor until exhausted ──
+            let mut cursor = page.next_cursor;
+            while let Some(token) = cursor {
+                let page = client
+                    .transactions()
+                    .search(SearchParams {
+                        cursor: Some(token),
+                        ..Default::default()
+                    })
+                    .await
+                    .unwrap_or_else(|e| {
+                        eprintln!("pagination error: {e}");
+                        std::process::exit(1);
+                    });
+
+                for tx in &page.results {
+                    println!("  {}  {}  {} {}", tx.id, tx.status, tx.amount, tx.asset_code);
+                }
+                cursor = page.next_cursor;
+            }
+        }
+        Err(e) => {
+            eprintln!("search error: {e}");
+            std::process::exit(1);
+        }
+    }
+
+    // ── Second search: query that matches nothing (not an error) ──
+    println!("\n--- Search 2: nonexistent status (expect zero matches) ---");
+
+    let filters = SearchParams {
+        status: Some("nonexistent_status".to_string()),
+        ..Default::default()
+    };
+
+    match client.transactions().search(filters).await {
+        Ok(page) => {
+            // Zero matches is a successful response with total=0 and empty results.
+            println!("total: {}  results: {}  has_next: {}",
+                page.total,
+                page.results.len(),
+                page.next_cursor.is_some(),
+            );
+
+            if page.total == 0 {
+                println!("(expected: no records matched the filter)");
+            }
+        }
+        Err(SynapseError::InvalidCursor(msg)) => {
+            eprintln!("cursor rejected: {msg}");
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,11 +1,13 @@
 use crate::error::SynapseError;
+use crate::resources::transactions::Transactions;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
 use serde::de::DeserializeOwned;
 
 /// HTTP client for the Synapse public API.
 ///
-/// Construct via [`SynapseClient::builder`]. All requests are issued with the
-/// configured API key and are retried automatically on transient failures.
+/// Construct via [`SynapseClient::new`] or [`SynapseClient::builder`]. All
+/// requests are issued with the configured API key and are retried automatically
+/// on transient failures.
 #[derive(Clone)]
 pub struct SynapseClient {
     pub(crate) http: reqwest::Client,
@@ -24,6 +26,18 @@ pub struct SynapseClientBuilder {
 }
 
 impl SynapseClient {
+    /// Create a new [`SynapseClient`] with default retry settings.
+    ///
+    /// Equivalent to `SynapseClient::builder(base_url, api_key).build()`.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self::builder(base_url, api_key).build()
+    }
+
+    /// Access the transactions resource.
+    pub fn transactions(&self) -> Transactions<'_> {
+        Transactions { client: self }
+    }
+
     /// Return a builder for constructing a [`SynapseClient`].
     pub fn builder(
         base_url: impl Into<String>,
@@ -59,7 +73,44 @@ impl SynapseClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    return Err(SynapseError::Http { status, body });
+                    return Err(SynapseError::Api { status, message: body });
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Issue an authenticated GET request with query parameters and deserialize the JSON response.
+    ///
+    /// The request is retried automatically according to the client's retry
+    /// configuration. 4xx responses are returned immediately without retrying.
+    pub async fn get_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.api_key.clone();
+        let http = self.http.clone();
+        let query = query.to_vec();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let query = query.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .header("X-API-Key", &key)
+                    .query(&query)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(SynapseError::Api { status, message: body });
                 }
                 resp.json::<T>().await.map_err(SynapseError::Network)
             }

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -10,9 +10,25 @@ pub enum SynapseError {
     #[error("HTTP {status}: {body}")]
     Http { status: u16, body: String },
 
+    /// The server returned a non-2xx response for an API request.
+    #[error("API error {status}: {message}")]
+    Api { status: u16, message: String },
+
+    /// The requested resource was not found (HTTP 404).
+    #[error("{0}")]
+    NotFound(String),
+
+    /// The pagination cursor is invalid or expired (HTTP 400 with "cursor").
+    #[error("invalid cursor: {0}")]
+    InvalidCursor(String),
+
     /// A network-level failure occurred before a response was received.
     #[error("network error: {0}")]
     Network(#[from] reqwest::Error),
+
+    /// The response body could not be decoded as valid JSON.
+    #[error("decode error: {0}")]
+    Decode(String),
 }
 
 impl SynapseError {
@@ -24,6 +40,8 @@ impl SynapseError {
         match self {
             SynapseError::Network(_) => true,
             SynapseError::Http { status, .. } => *status >= 500,
+            SynapseError::Api { status, .. } => *status >= 500,
+            _ => false,
         }
     }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,4 +1,10 @@
 pub mod client;
 pub mod error;
+pub mod models;
 pub mod pagination;
+pub mod resources;
 pub mod retry;
+
+pub use client::SynapseClient;
+pub use error::SynapseError;
+pub use models::{ListParams, SearchParams};

--- a/sdks/rust/src/resources/transactions.rs
+++ b/sdks/rust/src/resources/transactions.rs
@@ -144,9 +144,15 @@ impl<'a> Transactions<'a> {
     /// fields supplied; omitted fields leave that dimension unfiltered. Uses
     /// the standard public client (`X-API-Key`).
     ///
-    /// A search that matches nothing is **not** an error: it returns a
-    /// [`TransactionSearch`] with `total == 0` and an empty `results` page.
-    /// Use `next_cursor` to page through larger result sets.
+    /// # Zero matches
+    ///
+    /// A search that matches nothing is **not** an error. The API returns a
+    /// [`TransactionSearch`] with `total == 0`, an empty `results` page, and
+    /// `next_cursor == None`. The SDK surfaces this as a successful `Ok` value
+    /// so callers never need a special error branch for the empty case.
+    ///
+    /// Use `next_cursor` to page through larger result sets; when `next_cursor`
+    /// is `None` the current page is the last one.
     ///
     /// # Errors
     /// - [`SynapseError::InvalidCursor`] – the cursor is malformed or expired (HTTP 400).
@@ -172,6 +178,29 @@ impl<'a> Transactions<'a> {
     ///
     /// let page = client.transactions().search(filters).await.unwrap();
     /// println!("{} total matches, {} on this page", page.total, page.results.len());
+    /// # }
+    /// ```
+    ///
+    /// Check for zero matches by inspecting the returned struct — no error
+    /// matching is required:
+    ///
+    /// ```no_run
+    /// # use synapse_sdk::{SearchParams, SynapseClient};
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// # let client = SynapseClient::new("https://api.example.com", "your-api-key");
+    /// let page = client
+    ///     .transactions()
+    ///     .search(SearchParams {
+    ///         status: Some("nonexistent".to_string()),
+    ///         ..Default::default()
+    ///     })
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// assert_eq!(page.total, 0);
+    /// assert!(page.results.is_empty());
+    /// assert!(page.next_cursor.is_none());
     /// # }
     /// ```
     pub async fn search(&self, filters: SearchParams) -> Result<TransactionSearch, SynapseError> {


### PR DESCRIPTION
# PR: Document `transactions.search(filters)` with rustdoc and runnable example

## Summary

This PR adds comprehensive rustdoc comments and a new runnable example file for `transactions.search(filters)` in the Rust SDK (`sdks/rust/`). It also fixes underlying compilation issues in the SDK (missing error variants, client methods, module declarations) that were preventing examples and tests from building.

## Changes

### 1. Enhanced rustdoc for `Transactions::search()` (`sdks/rust/src/resources/transactions.rs`)

- Expanded the doc comment with a dedicated **Zero matches** section explaining that an empty result is returned as `Ok(TransactionSearch { total: 0, results: [], .. })`, not an error.
- Added a second `no_run` example specifically demonstrating the zero-matches case, showing callers they can inspect `page.total` and `page.results.is_empty()` without error matching.

### 2. New runnable example (`sdks/rust/examples/transactions_search.rs`)

- Demonstrates three key scenarios:
  1. **Filtering**: search `completed` USD transactions with `min_amount` filter
  2. **Pagination**: follow `next_cursor` through multi-page result sets
  3. **Zero matches**: search for a non-existent status and handle the successful empty response
- Follows existing example conventions (`SYNAPSE_API_URL`/`SYNAPSE_API_KEY` env vars, `#[tokio::main]`, descriptive doc-comment header).
- Compiles with `cargo build --example transactions_search`.

### 3. Fixed missing error variants (`sdks/rust/src/error.rs`)

Added the following `SynapseError` variants that the transactions resource code depends on:
- `Api { status: u16, message: String }` — raw API error returned by `SynapseClient::get()` / `get_query()`
- `NotFound(String)` — 404 response, matched in `Transactions::get()`
- `InvalidCursor(String)` — 400 with "cursor" in message, matched in `Transactions::list()` and `Transactions::search()`
- `Decode(String)` — JSON deserialization error
- Updated `is_transient()` to include `Api` (5xx statuses are retryable)

### 4. Added client methods (`sdks/rust/src/client.rs`)

- `SynapseClient::new(base_url, api_key)` — convenience constructor wrapping `builder().build()`
- `SynapseClient::transactions()` — accessor for the `Transactions` resource
- `SynapseClient::get_query(path, query)` — GET with query parameters (required by `search()` and `list()`)
- Updated `get()` to return `SynapseError::Api` instead of `SynapseError::Http` to match the error handling patterns in the transactions resource

### 5. Module declarations and re-exports (`sdks/rust/src/lib.rs`)

- Added `pub mod models;` and `pub mod resources;`
- Re-exported `SynapseClient`, `SynapseError`, `SearchParams`, `ListParams` at the crate root for ergonomic imports matching the existing examples' `use` statements

### 6. Dependencies (`sdks/rust/Cargo.toml`)

- Added `chrono = { version = "0.4", features = ["serde"] }` — required by `models.rs`
- Added `wiremock = "0.6"` under `[dev-dependencies]` — required by unit tests in `transactions.rs`

## Verification

All tests pass:

```
cargo test
> 11 passed; 0 failed
> 5 doc-tests passed; 0 failed

cargo build --example transactions_search
> Finished dev profile

cargo run --example transactions_search
> (connects to configured API or defaults — compiles successfully)
```

## Files touched (all under `sdks/rust/`)

| File | Change |
|------|--------|
| `Cargo.toml` | Added `chrono` and `wiremock` deps |
| `Cargo.lock` | Auto-updated |
| `src/client.rs` | Added `new()`, `transactions()`, `get_query()`, `get()` → `Api` |
| `src/error.rs` | Added `Api`, `NotFound`, `InvalidCursor`, `Decode` variants |
| `src/lib.rs` | Added `models`/`resources` modules, re-exports |
| `src/resources/transactions.rs` | Enhanced `search` rustdoc with zero-matches emphasis and second example |
| `examples/transactions_search.rs` | **New** — runnable example |

Closes #621
