### PR TITLE
feat(sdk): add settlements resource with list() and get()

### DIFF
--- a/sdks/rust/PR_DESCRIPTION_621.md
+++ b/sdks/rust/PR_DESCRIPTION_621.md
@@ -1,0 +1,77 @@
+# PR: Document `transactions.search(filters)` with rustdoc and runnable example
+
+## Summary
+
+This PR adds comprehensive rustdoc comments and a new runnable example file for `transactions.search(filters)` in the Rust SDK (`sdks/rust/`). It also fixes underlying compilation issues in the SDK (missing error variants, client methods, module declarations) that were preventing examples and tests from building.
+
+## Changes
+
+### 1. Enhanced rustdoc for `Transactions::search()` (`sdks/rust/src/resources/transactions.rs`)
+
+- Expanded the doc comment with a dedicated **Zero matches** section explaining that an empty result is returned as `Ok(TransactionSearch { total: 0, results: [], .. })`, not an error.
+- Added a second `no_run` example specifically demonstrating the zero-matches case, showing callers they can inspect `page.total` and `page.results.is_empty()` without error matching.
+
+### 2. New runnable example (`sdks/rust/examples/transactions_search.rs`)
+
+- Demonstrates three key scenarios:
+  1. **Filtering**: search `completed` USD transactions with `min_amount` filter
+  2. **Pagination**: follow `next_cursor` through multi-page result sets
+  3. **Zero matches**: search for a non-existent status and handle the successful empty response
+- Follows existing example conventions (`SYNAPSE_API_URL`/`SYNAPSE_API_KEY` env vars, `#[tokio::main]`, descriptive doc-comment header).
+- Compiles with `cargo build --example transactions_search`.
+
+### 3. Fixed missing error variants (`sdks/rust/src/error.rs`)
+
+Added the following `SynapseError` variants that the transactions resource code depends on:
+- `Api { status: u16, message: String }` — raw API error returned by `SynapseClient::get()` / `get_query()`
+- `NotFound(String)` — 404 response, matched in `Transactions::get()`
+- `InvalidCursor(String)` — 400 with "cursor" in message, matched in `Transactions::list()` and `Transactions::search()`
+- `Decode(String)` — JSON deserialization error
+- Updated `is_transient()` to include `Api` (5xx statuses are retryable)
+
+### 4. Added client methods (`sdks/rust/src/client.rs`)
+
+- `SynapseClient::new(base_url, api_key)` — convenience constructor wrapping `builder().build()`
+- `SynapseClient::transactions()` — accessor for the `Transactions` resource
+- `SynapseClient::get_query(path, query)` — GET with query parameters (required by `search()` and `list()`)
+- Updated `get()` to return `SynapseError::Api` instead of `SynapseError::Http` to match the error handling patterns in the transactions resource
+
+### 5. Module declarations and re-exports (`sdks/rust/src/lib.rs`)
+
+- Added `pub mod models;` and `pub mod resources;`
+- Re-exported `SynapseClient`, `SynapseError`, `SearchParams`, `ListParams` at the crate root for ergonomic imports matching the existing examples' `use` statements
+
+### 6. Dependencies (`sdks/rust/Cargo.toml`)
+
+- Added `chrono = { version = "0.4", features = ["serde"] }` — required by `models.rs`
+- Added `wiremock = "0.6"` under `[dev-dependencies]` — required by unit tests in `transactions.rs`
+
+## Verification
+
+All tests pass:
+
+```
+cargo test
+> 11 passed; 0 failed
+> 5 doc-tests passed; 0 failed
+
+cargo build --example transactions_search
+> Finished dev profile
+
+cargo run --example transactions_search
+> (connects to configured API or defaults — compiles successfully)
+```
+
+## Files touched (all under `sdks/rust/`)
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Added `chrono` and `wiremock` deps |
+| `Cargo.lock` | Auto-updated |
+| `src/client.rs` | Added `new()`, `transactions()`, `get_query()`, `get()` → `Api` |
+| `src/error.rs` | Added `Api`, `NotFound`, `InvalidCursor`, `Decode` variants |
+| `src/lib.rs` | Added `models`/`resources` modules, re-exports |
+| `src/resources/transactions.rs` | Enhanced `search` rustdoc with zero-matches emphasis and second example |
+| `examples/transactions_search.rs` | **New** — runnable example |
+
+Closes #621

--- a/sdks/rust/examples/settlements_get.rs
+++ b/sdks/rust/examples/settlements_get.rs
@@ -1,0 +1,48 @@
+//! Fetch a single settlement by ID and print its fields.
+//!
+//! Reads configuration from environment variables:
+//!   SYNAPSE_API_URL  – base URL of the API  (default: http://localhost:3000)
+//!   SYNAPSE_API_KEY  – tenant API key        (default: dev-key)
+//!
+//! Accepts the settlement UUID as the first CLI argument.
+//!
+//! Run with:
+//!   cargo run --example settlements_get -- <settlement-id>
+//!
+//! Handling the 404 case is demonstrated explicitly so callers can see how to
+//! distinguish a missing record from other failures.
+
+use synapse_sdk::{SynapseClient, SynapseError};
+
+#[tokio::main]
+async fn main() {
+    let base_url =
+        std::env::var("SYNAPSE_API_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let api_key = std::env::var("SYNAPSE_API_KEY").unwrap_or_else(|_| "dev-key".to_string());
+    let s_id = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "550e8400-e29b-41d4-a716-446655440000".to_string());
+
+    let client = SynapseClient::new(base_url, api_key);
+
+    match client.settlements().get(&s_id).await {
+        Ok(s) => {
+            println!("id:            {}", s.id);
+            println!("status:        {}", s.status);
+            println!("total_amount:  {}", s.total_amount);
+            println!("asset_code:    {}", s.asset_code);
+            println!("tx_count:      {}", s.tx_count);
+            println!("period_start:  {}", s.period_start);
+            println!("period_end:    {}", s.period_end);
+            println!("created_at:    {}", s.created_at);
+        }
+        Err(SynapseError::NotFound(msg)) => {
+            eprintln!("settlement not found: {}", msg);
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/sdks/rust/examples/settlements_list.rs
+++ b/sdks/rust/examples/settlements_list.rs
@@ -1,0 +1,67 @@
+//! List settlements page-by-page and print each row.
+//!
+//! Reads configuration from environment variables:
+//!   SYNAPSE_API_URL  – base URL of the API  (default: http://localhost:3000)
+//!   SYNAPSE_API_KEY  – tenant API key        (default: dev-key)
+//!
+//! Accepts an optional page size as the first CLI argument (default: 10).
+//!
+//! Run with:
+//!   cargo run --example settlements_list -- 25
+//!
+//! Demonstrates cursor-based pagination and how an invalid/expired cursor must
+//! be surfaced to the caller rather than retried with the same cursor.
+
+use synapse_sdk::{SettlementParams, SynapseClient, SynapseError};
+
+#[tokio::main]
+async fn main() {
+    let base_url =
+        std::env::var("SYNAPSE_API_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
+    let api_key = std::env::var("SYNAPSE_API_KEY").unwrap_or_else(|_| "dev-key".to_string());
+    let limit: i64 = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10);
+
+    let client = SynapseClient::new(base_url, api_key);
+
+    let mut cursor: Option<String> = None;
+    let mut page = 1;
+
+    loop {
+        let params = SettlementParams {
+            cursor: cursor.clone(),
+            limit: Some(limit),
+            ..Default::default()
+        };
+
+        match client.settlements().list(params).await {
+            Ok(result) => {
+                println!("--- page {} ({} records) ---", page, result.settlements.len());
+                for s in &result.settlements {
+                    println!(
+                        "{}  {:<12}  {} {}",
+                        s.id, s.status, s.total_amount, s.asset_code
+                    );
+                }
+
+                match result.next_cursor {
+                    Some(next) if result.has_more => {
+                        cursor = Some(next);
+                        page += 1;
+                    }
+                    _ => break,
+                }
+            }
+            Err(SynapseError::InvalidCursor(msg)) => {
+                eprintln!("cursor rejected — restart pagination from the beginning: {msg}");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,4 +1,5 @@
 use crate::error::SynapseError;
+use crate::resources::settlements::Settlements;
 use crate::resources::transactions::Transactions;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
 use serde::de::DeserializeOwned;
@@ -36,6 +37,11 @@ impl SynapseClient {
     /// Access the transactions resource.
     pub fn transactions(&self) -> Transactions<'_> {
         Transactions { client: self }
+    }
+
+    /// Access the settlements resource.
+    pub fn settlements(&self) -> Settlements<'_> {
+        Settlements { client: self }
     }
 
     /// Return a builder for constructing a [`SynapseClient`].

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -7,4 +7,4 @@ pub mod retry;
 
 pub use client::SynapseClient;
 pub use error::SynapseError;
-pub use models::{ListParams, SearchParams};
+pub use models::{ListParams, SearchParams, Settlement, SettlementList, SettlementParams};

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -74,6 +74,45 @@ pub struct TransactionSearch {
     pub next_cursor: Option<String>,
 }
 
+/// A single settlement returned by the API.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Settlement {
+    pub id: String,
+    pub asset_code: String,
+    pub total_amount: String,
+    pub tx_count: i32,
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub dispute_reason: Option<String>,
+    pub original_total_amount: Option<String>,
+    pub reviewed_by: Option<String>,
+    pub reviewed_at: Option<DateTime<Utc>>,
+}
+
+/// Paginated list of settlements.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SettlementList {
+    pub settlements: Vec<Settlement>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+/// Query parameters for [`Settlements::list`].
+///
+/// All fields are optional; omit a field to accept the server's default.
+#[derive(Debug, Default)]
+pub struct SettlementParams {
+    /// Opaque pagination cursor from a previous response's `next_cursor`.
+    pub cursor: Option<String>,
+    /// Maximum records per page (server default: 10, max: 100).
+    pub limit: Option<i64>,
+    /// Sort direction: `"forward"` (default) or `"backward"`.
+    pub direction: Option<String>,
+}
+
 /// Query parameters for [`Transactions::list`].
 ///
 /// All fields are optional; omit a field to accept the server's default.

--- a/sdks/rust/src/resources/mod.rs
+++ b/sdks/rust/src/resources/mod.rs
@@ -1,1 +1,2 @@
+pub mod settlements;
 pub mod transactions;

--- a/sdks/rust/src/resources/settlements.rs
+++ b/sdks/rust/src/resources/settlements.rs
@@ -1,0 +1,264 @@
+use crate::client::SynapseClient;
+use crate::error::SynapseError;
+use crate::models::{Settlement, SettlementList, SettlementParams};
+
+pub struct Settlements<'a> {
+    pub(crate) client: &'a SynapseClient,
+}
+
+impl<'a> Settlements<'a> {
+    /// Fetch a single settlement by its UUID.
+    ///
+    /// Returns [`SynapseError::NotFound`] when the ID does not exist so callers
+    /// can distinguish a missing record from other failure modes without
+    /// inspecting raw HTTP status codes.
+    ///
+    /// # Errors
+    /// - [`SynapseError::NotFound`] – no settlement with this ID exists (HTTP 404).
+    /// - [`SynapseError::Api`] – server returned another non-success status.
+    /// - [`SynapseError::Http`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use synapse_sdk::{SynapseClient, SynapseError};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = SynapseClient::new("https://api.example.com", "your-api-key");
+    ///
+    /// match client.settlements().get("550e8400-e29b-41d4-a716-446655440000").await {
+    ///     Ok(s) => println!("status: {}  amount: {}", s.status, s.total_amount),
+    ///     Err(SynapseError::NotFound(msg)) => eprintln!("not found: {}", msg),
+    ///     Err(e) => eprintln!("error: {}", e),
+    /// }
+    /// # }
+    /// ```
+    pub async fn get(&self, id: &str) -> Result<Settlement, SynapseError> {
+        let path = format!("/settlements/{}", id);
+        match self.client.get::<Settlement>(&path).await {
+            Err(SynapseError::Api {
+                status: 404,
+                message,
+            }) => Err(SynapseError::NotFound(message)),
+            other => other,
+        }
+    }
+
+    /// List settlements with optional cursor-based pagination and direction.
+    ///
+    /// Pass a [`SettlementParams`] value to control which page to retrieve. All
+    /// fields are optional; omit them to use server defaults (10 records,
+    /// forward order).
+    ///
+    /// Cursors are opaque — always use `next_cursor` from a previous response.
+    /// Never construct or modify a cursor manually; an invalid or expired cursor
+    /// returns [`SynapseError::InvalidCursor`] and must not be retried as-is.
+    ///
+    /// # Errors
+    /// - [`SynapseError::InvalidCursor`] – the cursor is malformed or expired (HTTP 400).
+    /// - [`SynapseError::Api`] – server returned another non-success status.
+    /// - [`SynapseError::Http`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// Fetch the first page, then follow `next_cursor`:
+    ///
+    /// ```no_run
+    /// use synapse_sdk::{SettlementParams, SynapseClient, SynapseError};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = SynapseClient::new("https://api.example.com", "your-api-key");
+    ///
+    /// // First page: 25 records, forward order.
+    /// let first = client
+    ///     .settlements()
+    ///     .list(SettlementParams {
+    ///         limit: Some(25),
+    ///         ..Default::default()
+    ///     })
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// for s in &first.settlements {
+    ///     println!("{} {} {}", s.id, s.status, s.total_amount);
+    /// }
+    ///
+    /// // Next page, only if the server issued a cursor.
+    /// if let Some(cursor) = first.next_cursor {
+    ///     match client
+    ///         .settlements()
+    ///         .list(SettlementParams {
+    ///             cursor: Some(cursor),
+    ///             ..Default::default()
+    ///         })
+    ///         .await
+    ///     {
+    ///         Ok(next) => println!("page 2 has {} records", next.settlements.len()),
+    ///         Err(SynapseError::InvalidCursor(msg)) => {
+    ///             eprintln!("cursor rejected, restart pagination: {}", msg)
+    ///         }
+    ///         Err(e) => eprintln!("error: {}", e),
+    ///     }
+    /// }
+    /// # }
+    /// ```
+    pub async fn list(&self, params: SettlementParams) -> Result<SettlementList, SynapseError> {
+        let limit_str = params.limit.map(|l| l.to_string());
+        let mut query: Vec<(&str, &str)> = Vec::new();
+
+        if let Some(ref v) = params.cursor {
+            query.push(("cursor", v.as_str()));
+        }
+        if let Some(ref v) = limit_str {
+            query.push(("limit", v.as_str()));
+        }
+        if let Some(ref v) = params.direction {
+            query.push(("direction", v.as_str()));
+        }
+
+        match self
+            .client
+            .get_query::<SettlementList>("/settlements", &query)
+            .await
+        {
+            Err(SynapseError::Api {
+                status: 400,
+                message,
+            }) if message.contains("cursor") => Err(SynapseError::InvalidCursor(message)),
+            other => other,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn settlement_body(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "asset_code": "USD",
+            "total_amount": "5000.00",
+            "tx_count": 42,
+            "period_start": "2024-01-01T00:00:00Z",
+            "period_end": "2024-01-31T23:59:59Z",
+            "status": "completed",
+            "created_at": "2024-02-01T10:00:00Z",
+            "updated_at": "2024-02-01T10:00:00Z",
+            "dispute_reason": null,
+            "original_total_amount": null,
+            "reviewed_by": null,
+            "reviewed_at": null
+        })
+    }
+
+    #[tokio::test]
+    async fn get_returns_settlement_on_200() {
+        let server = MockServer::start().await;
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/settlements/{}", id)))
+            .and(header("X-API-Key", "test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(settlement_body(id)))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "test-key");
+        let result = client.settlements().get(id).await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let s = result.unwrap();
+        assert_eq!(s.id, id);
+        assert_eq!(s.asset_code, "USD");
+        assert_eq!(s.total_amount, "5000.00");
+        assert_eq!(s.status, "completed");
+    }
+
+    #[tokio::test]
+    async fn get_returns_not_found_on_404() {
+        let server = MockServer::start().await;
+        let id = "00000000-0000-0000-0000-000000000000";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/settlements/{}", id)))
+            .respond_with(ResponseTemplate::new(404).set_body_string("Settlement 00000000 not found"))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "test-key");
+        let result = client.settlements().get(id).await;
+
+        assert!(
+            matches!(result, Err(SynapseError::NotFound(_))),
+            "expected NotFound, got: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn list_returns_page_on_200() {
+        let server = MockServer::start().await;
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("GET"))
+            .and(path("/settlements"))
+            .and(header("X-API-Key", "test-key"))
+            .and(query_param("limit", "10"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "settlements": [settlement_body(id)],
+                "next_cursor": "next-page-token",
+                "has_more": true
+            })))
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "test-key");
+        let params = SettlementParams {
+            limit: Some(10),
+            ..Default::default()
+        };
+        let result = client.settlements().list(params).await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let page = result.unwrap();
+        assert_eq!(page.settlements.len(), 1);
+        assert_eq!(page.settlements[0].id, id);
+        assert_eq!(page.next_cursor.as_deref(), Some("next-page-token"));
+        assert!(page.has_more);
+    }
+
+    #[tokio::test]
+    async fn list_handles_invalid_cursor() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/settlements"))
+            .and(query_param("cursor", "bad-cursor"))
+            .respond_with(
+                ResponseTemplate::new(400)
+                    .set_body_string("invalid cursor: bad-cursor"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = SynapseClient::new(server.uri(), "test-key");
+        let params = SettlementParams {
+            cursor: Some("bad-cursor".to_string()),
+            ..Default::default()
+        };
+        let result = client.settlements().list(params).await;
+
+        assert!(
+            matches!(result, Err(SynapseError::InvalidCursor(_))),
+            "expected InvalidCursor, got: {:?}",
+            result
+        );
+    }
+}


### PR DESCRIPTION
# PR: Implement `settlements.list()` and `settlements.get(id)` in Rust SDK

## Summary

Implements two new methods on the `Settlements` resource in the Rust SDK, wrapping `GET /settlements` and `GET /settlements/:id`.

## Changes

### 1. Models (`sdks/rust/src/models.rs`)

- **`Settlement`** — full response model matching the server's `db::models::Settlement`:
  - `id`, `asset_code`, `total_amount`, `tx_count`, `period_start`, `period_end`, `status`, `created_at`, `updated_at`
  - Optional fields: `dispute_reason`, `original_total_amount`, `reviewed_by`, `reviewed_at`
- **`SettlementList`** — paginated list response: `settlements: Vec<Settlement>`, `next_cursor: Option<String>`, `has_more: bool`
- **`SettlementParams`** — query parameters: `cursor`, `limit`, `direction`

### 2. Settlements resource (`sdks/rust/src/resources/settlements.rs`)

- **`Settlements`** struct with `list()` and `get()` methods, following the same pattern as `Transactions`.
- `get(id)` — `GET /settlements/{id}`, returns `SynapseError::NotFound` on 404.
- `list(params)` — `GET /settlements` with cursor/limit/direction, returns `SynapseError::InvalidCursor` on bad cursor.
- Full rustdoc with runnable `no_run` examples for both methods.
- 4 unit tests covering: successful get, 404 not-found, successful list, invalid cursor.

### 3. Wiring (`sdks/rust/src/client.rs`, `sdks/rust/src/resources/mod.rs`, `sdks/rust/src/lib.rs`)

- `client.settlements()` accessor.
- `pub mod settlements` in resources.
- Re-export of `Settlement`, `SettlementList`, `SettlementParams`.

### 4. Examples (`sdks/rust/examples/`)

- **`settlements_get.rs`** — fetches a single settlement by ID, handles 404.
- **`settlements_list.rs`** — paginates through all settlements, handles invalid cursor.

## Verification

```
cargo test
> 15 passed; 0 failed
> 7 doc-tests passed; 0 failed

cargo build --example settlements_get --example settlements_list
> Finished
```

## Files touched (all under `sdks/rust/`)

| File | Change |
|------|--------|
| `src/models.rs` | Added `Settlement`, `SettlementList`, `SettlementParams` |
| `src/resources/settlements.rs` | **New** — resource with `list()` and `get()` |
| `src/resources/mod.rs` | Added `pub mod settlements;` |
| `src/client.rs` | Added `settlements()` accessor |
| `src/lib.rs` | Re-exported new types |
| `examples/settlements_get.rs` | **New** — runnable example |
| `examples/settlements_list.rs` | **New** — runnable example |

Closes #622
