### PR TITLE
Feature/rust sdk admin reconciliation and settlements docs

### DIFF
--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -150,6 +150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +258,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -306,7 +337,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -384,6 +415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,7 +491,7 @@ dependencies = [
  "http",
  "infer",
  "pin-project-lite",
- "rand",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "serde_qs",
@@ -494,17 +536,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.24.2"
+name = "hyper-tls"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "futures-util",
- "http",
+ "bytes",
  "hyper",
- "rustls",
+ "native-tls",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -689,6 +730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +780,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +820,49 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -799,6 +906,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,9 +961,20 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -854,7 +984,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -867,12 +1007,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -928,15 +1077,15 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -944,13 +1093,12 @@ dependencies = [
  "sync_wrapper",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -961,29 +1109,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
-name = "ring"
-version = "0.17.14"
+name = "rustix"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
+ "bitflags 2.13.0",
+ "errno",
  "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki",
- "sct",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -993,16 +1128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1018,19 +1143,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "security-framework"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "ring",
- "untrusted",
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1169,11 +1316,13 @@ name = "synapse-sdk"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
  "wiremock",
 ]
 
@@ -1201,7 +1350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -1213,6 +1362,19 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand 2.4.1",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1274,12 +1436,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rustls"
-version = "0.24.1"
+name = "tokio-native-tls"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
- "rustls",
+ "native-tls",
  "tokio",
 ]
 
@@ -1334,12 +1496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,6 +1513,24 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "waker-fn"
@@ -1449,12 +1623,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "windows-core"

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -14,6 +14,9 @@ serde_json = "1"
 thiserror = "1"
 rand = "0.8"
 tokio = { version = "1", features = ["time"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
+wiremock = "0.5"

--- a/sdks/rust/examples/admin_reconciliation.rs
+++ b/sdks/rust/examples/admin_reconciliation.rs
@@ -1,0 +1,175 @@
+//! Example: Admin Reconciliation Operations
+//!
+//! This example demonstrates how to:
+//! - List reconciliation reports with pagination
+//! - Retrieve details of a specific report
+//! - Run a new reconciliation
+//!
+//! The example shows both successful operations and error handling,
+//! including how to interpret discrepancy reports.
+
+use synapse_sdk::models::ListReportsParams;
+use synapse_sdk::AdminSynapseClient;
+
+#[tokio::main]
+async fn main() {
+    // Initialize the admin client
+    let admin = AdminSynapseClient::builder(
+        "https://api.example.com", // Replace with your actual base URL
+        "your-admin-api-key",      // Replace with your admin key
+    )
+    .build();
+
+    let reconciliation = admin.reconciliation();
+
+    // Example 1: List reconciliation reports
+    println!("=== Listing Reconciliation Reports ===");
+    match reconciliation
+        .list_reports(ListReportsParams {
+            limit: Some(10),
+            offset: Some(0),
+        })
+        .await
+    {
+        Ok(reports) => {
+            println!("Found {} total reports", reports.total);
+            for (i, report) in reports.reports.iter().enumerate() {
+                println!(
+                    "  {}. Report ID: {} (generated: {})",
+                    i + 1,
+                    report.id,
+                    report.generated_at
+                );
+                println!(
+                    "     Discrepancies: missing={}, orphaned={}, amount_mismatches={}",
+                    report.missing_on_chain_count,
+                    report.orphaned_payments_count,
+                    report.amount_mismatches_count
+                );
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to list reports: {}", e);
+            return;
+        }
+    }
+
+    // Example 2: Get details of a specific report
+    println!("\n=== Getting Report Details ===");
+    // Replace with an actual report ID from your system
+    let example_report_id = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")
+        .expect("invalid UUID");
+
+    match reconciliation.get_report(example_report_id).await {
+        Ok(report) => {
+            println!("Report ID: {}", report.id);
+            println!("Period: {} to {}", report.period_start, report.period_end);
+            println!("\nSummary:");
+            println!("  Total DB transactions: {}", report.summary.total_db_transactions);
+            println!(
+                "  Total chain payments: {}",
+                report.summary.total_chain_payments
+            );
+            println!(
+                "  Missing on chain: {}",
+                report.summary.missing_on_chain_count
+            );
+            println!(
+                "  Orphaned payments: {}",
+                report.summary.orphaned_payments_count
+            );
+            println!(
+                "  Amount mismatches: {}",
+                report.summary.amount_mismatches_count
+            );
+            println!(
+                "  Has discrepancies: {}",
+                report.summary.has_discrepancies
+            );
+
+            // Show details of discrepancies
+            if !report.missing_on_chain.is_empty() {
+                println!("\nMissing on chain transactions:");
+                for tx in &report.missing_on_chain {
+                    println!(
+                        "  - ID: {}, Amount: {}, Account: {}",
+                        tx.id, tx.amount, tx.stellar_account
+                    );
+                }
+            }
+
+            if !report.orphaned_payments.is_empty() {
+                println!("\nOrphaned payments:");
+                for payment in &report.orphaned_payments {
+                    println!(
+                        "  - ID: {}, Amount: {}, From: {} To: {}",
+                        payment.payment_id, payment.amount, payment.from, payment.to
+                    );
+                }
+            }
+
+            if !report.amount_mismatches.is_empty() {
+                println!("\nAmount mismatches:");
+                for mismatch in &report.amount_mismatches {
+                    println!(
+                        "  - TX: {}, DB: {}, Chain: {}",
+                        mismatch.transaction_id, mismatch.db_amount, mismatch.chain_amount
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to get report: {}", e);
+        }
+    }
+
+    // Example 3: Run a new reconciliation
+    println!("\n=== Running Reconciliation ===");
+    let stellar_account = "GABC1234567890123456789012345678901234567890123456789012";
+    let period_hours = 24;
+
+    match reconciliation
+        .run(stellar_account, Some(period_hours))
+        .await
+    {
+        Ok(response) => {
+            println!("{}", response.message);
+            println!("Report Summary:");
+            println!("  ID: {}", response.report.id);
+            println!("  Generated: {}", response.report.generated_at);
+            println!(
+                "  DB Transactions: {}",
+                response.report.total_db_transactions
+            );
+            println!(
+                "  Chain Payments: {}",
+                response.report.total_chain_payments
+            );
+
+            if response.report.has_discrepancies {
+                println!(
+                    "\n⚠️  Discrepancies detected! Missing: {}, Orphaned: {}, Mismatches: {}",
+                    response.report.missing_on_chain_count,
+                    response.report.orphaned_payments_count,
+                    response.report.amount_mismatches_count
+                );
+            } else {
+                println!("\n✓ No discrepancies found!");
+            }
+        }
+        Err(e) => {
+            eprintln!("Reconciliation failed: {}", e);
+            // Handle errors like invalid account or server issues
+            match e {
+                synapse_sdk::SynapseError::Api { status, message } => {
+                    if status == 400 {
+                        eprintln!("Invalid account format or parameters: {}", message);
+                    } else {
+                        eprintln!("API error ({status}): {message}");
+                    }
+                }
+                _ => eprintln!("Network or other error: {}", e),
+            }
+        }
+    }
+}

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,5 +1,7 @@
 use crate::error::SynapseError;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
+use crate::resources::admin::AdminReconciliation;
+use crate::resources::transactions::Transactions;
 use serde::de::DeserializeOwned;
 
 /// HTTP client for the Synapse public API.
@@ -24,6 +26,13 @@ pub struct SynapseClientBuilder {
 }
 
 impl SynapseClient {
+    /// Create a new [`SynapseClient`] with default retry settings.
+    ///
+    /// This is a convenience method equivalent to `SynapseClient::builder(url, key).build()`.
+    pub fn new(base_url: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self::builder(base_url, api_key).build()
+    }
+
     /// Return a builder for constructing a [`SynapseClient`].
     pub fn builder(
         base_url: impl Into<String>,
@@ -59,12 +68,105 @@ impl SynapseClient {
                 let status = resp.status().as_u16();
                 if status >= 400 {
                     let body = resp.text().await.unwrap_or_default();
-                    return Err(SynapseError::Http { status, body });
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
                 }
                 resp.json::<T>().await.map_err(SynapseError::Network)
             }
         })
         .await
+    }
+
+    /// Issue an authenticated GET request with query parameters.
+    pub async fn get_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.api_key.clone();
+        let http = self.http.clone();
+        let query = query.to_vec();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let query = query.clone();
+            async move {
+                let mut req = http.get(&url).header("X-API-Key", &key);
+                for (k, v) in query.iter() {
+                    req = req.query(&[(k, v)]);
+                }
+                let resp = req.send().await.map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Issue an authenticated POST request with JSON body and deserialize the JSON response.
+    pub async fn post<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.api_key.clone();
+        let http = self.http.clone();
+        let body_json = serde_json::to_string(body)?;
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let body_json = body_json.clone();
+            async move {
+                let resp = http
+                    .post(&url)
+                    .header("X-API-Key", &key)
+                    .header("Content-Type", "application/json")
+                    .body(body_json)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Access transaction operations.
+    pub fn transactions(&self) -> Transactions {
+        Transactions::new(self)
     }
 }
 
@@ -97,6 +199,197 @@ impl SynapseClientBuilder {
             http: reqwest::Client::new(),
             base_url: self.base_url,
             api_key: self.api_key,
+            max_attempts: self.max_attempts,
+            base_delay_ms: self.base_delay_ms,
+        }
+    }
+}
+
+// ============================================================================
+// Admin API Client
+// ============================================================================
+
+/// HTTP client for the Synapse admin API.
+///
+/// Construct via [`AdminSynapseClient::builder`]. All requests are issued with the
+/// configured admin API key and are retried automatically on transient failures.
+#[derive(Clone)]
+pub struct AdminSynapseClient {
+    pub(crate) http: reqwest::Client,
+    pub(crate) base_url: String,
+    pub(crate) admin_key: String,
+    pub(crate) max_attempts: u32,
+    pub(crate) base_delay_ms: u64,
+}
+
+/// Builder for [`AdminSynapseClient`].
+pub struct AdminSynapseClientBuilder {
+    base_url: String,
+    admin_key: String,
+    max_attempts: u32,
+    base_delay_ms: u64,
+}
+
+impl AdminSynapseClient {
+    /// Return a builder for constructing an [`AdminSynapseClient`].
+    pub fn builder(
+        base_url: impl Into<String>,
+        admin_key: impl Into<String>,
+    ) -> AdminSynapseClientBuilder {
+        AdminSynapseClientBuilder {
+            base_url: base_url.into(),
+            admin_key: admin_key.into(),
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+            base_delay_ms: DEFAULT_BASE_DELAY_MS,
+        }
+    }
+
+    /// Issue an authenticated GET request to `path` and deserialize the JSON response.
+    pub async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.admin_key.clone();
+        let http = self.http.clone();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            async move {
+                let resp = http
+                    .get(&url)
+                    .header("X-Admin-Key", &key)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Issue an authenticated GET request with query parameters.
+    pub async fn get_query<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, &str)],
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.admin_key.clone();
+        let http = self.http.clone();
+        let query = query.to_vec();
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let query = query.clone();
+            async move {
+                let mut req = http.get(&url).header("X-Admin-Key", &key);
+                for (k, v) in query.iter() {
+                    req = req.query(&[(k, v)]);
+                }
+                let resp = req.send().await.map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Issue an authenticated POST request with JSON body and deserialize the JSON response.
+    pub async fn post<B: serde::Serialize, T: DeserializeOwned>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T, SynapseError> {
+        let url = format!("{}{}", self.base_url, path);
+        let key = self.admin_key.clone();
+        let http = self.http.clone();
+        let body_json = serde_json::to_string(body)?;
+        retry_with_backoff(self.max_attempts, self.base_delay_ms, || {
+            let url = url.clone();
+            let key = key.clone();
+            let http = http.clone();
+            let body_json = body_json.clone();
+            async move {
+                let resp = http
+                    .post(&url)
+                    .header("X-Admin-Key", &key)
+                    .header("Content-Type", "application/json")
+                    .body(body_json)
+                    .send()
+                    .await
+                    .map_err(SynapseError::Network)?;
+                let status = resp.status().as_u16();
+                if status >= 400 {
+                    let body = resp.text().await.unwrap_or_default();
+                    return if status >= 500 {
+                        Err(SynapseError::Http { status, body })
+                    } else {
+                        Err(SynapseError::Api {
+                            status,
+                            message: body,
+                        })
+                    };
+                }
+                resp.json::<T>().await.map_err(SynapseError::Network)
+            }
+        })
+        .await
+    }
+
+    /// Access admin reconciliation operations.
+    pub fn reconciliation(&self) -> AdminReconciliation {
+        AdminReconciliation::new(self)
+    }
+}
+
+impl AdminSynapseClientBuilder {
+    /// Set the maximum total number of attempts, including the first (default: 3).
+    pub fn max_attempts(mut self, n: u32) -> Self {
+        self.max_attempts = n.max(1);
+        self
+    }
+
+    /// Disable retry behaviour. The first failure is returned immediately.
+    pub fn disable_retries(mut self) -> Self {
+        self.max_attempts = 1;
+        self
+    }
+
+    /// Set the base delay in milliseconds for exponential backoff (default: 200).
+    pub fn base_delay_ms(mut self, ms: u64) -> Self {
+        self.base_delay_ms = ms;
+        self
+    }
+
+    /// Build the [`AdminSynapseClient`].
+    pub fn build(self) -> AdminSynapseClient {
+        AdminSynapseClient {
+            http: reqwest::Client::new(),
+            base_url: self.base_url,
+            admin_key: self.admin_key,
             max_attempts: self.max_attempts,
             base_delay_ms: self.base_delay_ms,
         }

--- a/sdks/rust/src/client.rs
+++ b/sdks/rust/src/client.rs
@@ -1,6 +1,6 @@
 use crate::error::SynapseError;
 use crate::retry::{retry_with_backoff, DEFAULT_BASE_DELAY_MS, DEFAULT_MAX_ATTEMPTS};
-use crate::resources::admin::AdminReconciliation;
+use crate::resources::admin::{AdminReconciliation, AdminSettlements};
 use crate::resources::transactions::Transactions;
 use serde::de::DeserializeOwned;
 
@@ -362,6 +362,11 @@ impl AdminSynapseClient {
     /// Access admin reconciliation operations.
     pub fn reconciliation(&self) -> AdminReconciliation {
         AdminReconciliation::new(self)
+    }
+
+    /// Access admin settlement operations.
+    pub fn settlements(&self) -> AdminSettlements {
+        AdminSettlements::new(self)
     }
 }
 

--- a/sdks/rust/src/error.rs
+++ b/sdks/rust/src/error.rs
@@ -10,9 +10,25 @@ pub enum SynapseError {
     #[error("HTTP {status}: {body}")]
     Http { status: u16, body: String },
 
+    /// A 4xx API error with parsed message.
+    #[error("API error {status}: {message}")]
+    Api { status: u16, message: String },
+
+    /// Resource not found (HTTP 404).
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    /// Invalid pagination cursor (malformed or expired).
+    #[error("invalid cursor: {0}")]
+    InvalidCursor(String),
+
     /// A network-level failure occurred before a response was received.
     #[error("network error: {0}")]
     Network(#[from] reqwest::Error),
+
+    /// Failed to decode response JSON.
+    #[error("failed to decode response: {0}")]
+    Decode(#[from] serde_json::Error),
 }
 
 impl SynapseError {
@@ -24,6 +40,8 @@ impl SynapseError {
         match self {
             SynapseError::Network(_) => true,
             SynapseError::Http { status, .. } => *status >= 500,
+            SynapseError::Api { status, .. } => *status >= 500,
+            _ => false,
         }
     }
 }

--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -1,4 +1,10 @@
 pub mod client;
 pub mod error;
+pub mod models;
 pub mod pagination;
+pub mod resources;
 pub mod retry;
+
+pub use client::{AdminSynapseClient, SynapseClient};
+pub use error::SynapseError;
+pub use models::*;

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// A single transaction returned by the API.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -89,4 +90,112 @@ pub struct ListParams {
     pub from_date: Option<String>,
     /// Exclusive ISO 8601 range end (e.g. `"2024-02-01T00:00:00Z"`).
     pub to_date: Option<String>,
+}
+
+// ============================================================================
+// Admin: Reconciliation Models
+// ============================================================================
+
+/// A reconciliation report summary returned by list or run operations.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReconciliationReportSummary {
+    pub id: Uuid,
+    pub generated_at: DateTime<Utc>,
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub total_db_transactions: i32,
+    pub total_chain_payments: i32,
+    pub missing_on_chain_count: i32,
+    pub orphaned_payments_count: i32,
+    pub amount_mismatches_count: i32,
+    pub has_discrepancies: bool,
+}
+
+/// Paginated list of reconciliation reports.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListReconciliationReports {
+    pub reports: Vec<ReconciliationReportSummary>,
+    pub total: i64,
+    pub limit: i32,
+    pub offset: i32,
+}
+
+/// Query parameters for listing reconciliation reports.
+#[derive(Debug, Default)]
+pub struct ListReportsParams {
+    /// Maximum records per page (server default: 20).
+    pub limit: Option<i32>,
+    /// Number of records to skip.
+    pub offset: Option<i32>,
+}
+
+/// A missing transaction detail in a reconciliation report.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MissingTransaction {
+    pub id: Uuid,
+    pub stellar_account: String,
+    pub amount: String,
+    pub asset_code: String,
+    pub memo: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// An orphaned payment detail in a reconciliation report.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OrphanedPayment {
+    pub payment_id: String,
+    pub from: String,
+    pub to: String,
+    pub amount: String,
+    pub asset_code: String,
+    pub memo: Option<String>,
+}
+
+/// An amount mismatch detail in a reconciliation report.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AmountMismatch {
+    pub transaction_id: Uuid,
+    pub payment_id: String,
+    pub db_amount: String,
+    pub chain_amount: String,
+    pub memo: Option<String>,
+}
+
+/// Full reconciliation report details.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReconciliationReportDetail {
+    pub id: Uuid,
+    pub generated_at: DateTime<Utc>,
+    pub period_start: DateTime<Utc>,
+    pub period_end: DateTime<Utc>,
+    pub summary: ReconciliationSummary,
+    pub missing_on_chain: Vec<MissingTransaction>,
+    pub orphaned_payments: Vec<OrphanedPayment>,
+    pub amount_mismatches: Vec<AmountMismatch>,
+}
+
+/// Summary statistics in a full reconciliation report.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ReconciliationSummary {
+    pub total_db_transactions: usize,
+    pub total_chain_payments: usize,
+    pub missing_on_chain_count: i32,
+    pub orphaned_payments_count: i32,
+    pub amount_mismatches_count: i32,
+    pub has_discrepancies: bool,
+}
+
+/// Response from running a reconciliation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RunReconciliationResponse {
+    pub message: String,
+    pub report: ReconciliationReportSummary,
+}
+
+/// Request to run a reconciliation.
+#[derive(Debug, Serialize)]
+pub struct RunReconciliationRequest {
+    pub account: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub period_hours: Option<i32>,
 }

--- a/sdks/rust/src/models.rs
+++ b/sdks/rust/src/models.rs
@@ -199,3 +199,33 @@ pub struct RunReconciliationRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub period_hours: Option<i32>,
 }
+
+// ============================================================================
+// Admin: Settlement Models
+// ============================================================================
+
+/// A settlement record.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Settlement {
+    pub id: Uuid,
+    pub status: String,
+    pub total_amount: String,
+    pub reason: Option<String>,
+    pub actor: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Request to update a settlement's status.
+#[derive(Debug, Serialize)]
+pub struct UpdateSettlementStatusRequest {
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// New total amount — only meaningful when transitioning to "adjusted".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_total: Option<String>,
+    /// Actor performing the change (defaults to "admin").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actor: Option<String>,
+}

--- a/sdks/rust/src/resources/admin/mod.rs
+++ b/sdks/rust/src/resources/admin/mod.rs
@@ -1,0 +1,3 @@
+pub mod reconciliation;
+
+pub use reconciliation::AdminReconciliation;

--- a/sdks/rust/src/resources/admin/mod.rs
+++ b/sdks/rust/src/resources/admin/mod.rs
@@ -1,3 +1,5 @@
 pub mod reconciliation;
+pub mod settlements;
 
 pub use reconciliation::AdminReconciliation;
+pub use settlements::AdminSettlements;

--- a/sdks/rust/src/resources/admin/reconciliation.rs
+++ b/sdks/rust/src/resources/admin/reconciliation.rs
@@ -303,4 +303,170 @@ mod tests {
 
         assert!(result.is_ok(), "expected Ok, got: {:?}", result);
     }
+
+    #[tokio::test]
+    async fn list_reports_with_pagination() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/reconciliation/reports"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "reports": [],
+                "total": 0,
+                "limit": 10,
+                "offset": 20,
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .list_reports(ListReportsParams {
+                limit: Some(10),
+                offset: Some(20),
+            })
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let page = result.unwrap();
+        assert_eq!(page.limit, 10);
+        assert_eq!(page.offset, 20);
+        assert_eq!(page.total, 0);
+        assert!(page.reports.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_report_with_discrepancies() {
+        let server = MockServer::start().await;
+        let report_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/reconciliation/reports/{}", report_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": report_id,
+                "generated_at": "2024-01-15T10:00:00Z",
+                "period_start": "2024-01-14T10:00:00Z",
+                "period_end": "2024-01-15T10:00:00Z",
+                "summary": {
+                    "total_db_transactions": 105,
+                    "total_chain_payments": 102,
+                    "missing_on_chain_count": 2,
+                    "orphaned_payments_count": 1,
+                    "amount_mismatches_count": 0,
+                    "has_discrepancies": true,
+                },
+                "missing_on_chain": [
+                    {
+                        "id": "d0000000-0000-0000-0000-000000000001",
+                        "stellar_account": "GABC1234567890123456789012345678901234567890123456789012",
+                        "amount": "100.00",
+                        "asset_code": "USD",
+                        "memo": "payment-1",
+                        "created_at": "2024-01-14T12:00:00Z",
+                    }
+                ],
+                "orphaned_payments": [],
+                "amount_mismatches": [],
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .get_report(Uuid::parse_str(report_id).unwrap())
+            .await;
+
+        assert!(result.is_ok());
+        let report = result.unwrap();
+        assert!(report.summary.has_discrepancies);
+        assert_eq!(report.summary.missing_on_chain_count, 2);
+        assert_eq!(report.missing_on_chain.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn run_returns_http_error_on_bad_account() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/admin/reconciliation/run"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_string("invalid account format"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .run("invalid-account", None)
+            .await;
+
+        assert!(result.is_err());
+        match result {
+            Err(SynapseError::Api { status, .. }) => {
+                assert_eq!(status, 400);
+            }
+            other => panic!("expected Api error with 400 status, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_report_returns_not_found_on_404() {
+        let server = MockServer::start().await;
+        let report_id = "00000000-0000-0000-0000-000000000000";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/reconciliation/reports/{}", report_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_string("Report not found"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .get_report(Uuid::parse_str(report_id).unwrap())
+            .await;
+
+        assert!(result.is_err());
+        match result {
+            Err(SynapseError::Api { status, .. }) => {
+                assert_eq!(status, 404);
+            }
+            other => panic!("expected Api error with 404 status, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_reports_uses_admin_key_not_public_key() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/admin/reconciliation/reports"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "reports": [],
+                "total": 0,
+                "limit": 20,
+                "offset": 0,
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .list_reports(ListReportsParams::default())
+            .await;
+
+        // If the test passes, it means X-Admin-Key header was sent, not X-API-Key
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    }
 }

--- a/sdks/rust/src/resources/admin/reconciliation.rs
+++ b/sdks/rust/src/resources/admin/reconciliation.rs
@@ -7,6 +7,45 @@ use crate::models::{
 use uuid::Uuid;
 
 /// Admin operations for reconciliation reports.
+///
+/// Use this to list, retrieve, and run reconciliation reports for a Synapse deployment.
+/// All reconciliation operations are synchronous — the `run()` method blocks until
+/// reconciliation completes and returns the summary report.
+///
+/// # Example
+///
+/// ```no_run
+/// use synapse_sdk::AdminSynapseClient;
+/// use synapse_sdk::models::ListReportsParams;
+/// use uuid::Uuid;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let admin = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+/// let recon = admin.reconciliation();
+///
+/// // List recent reports
+/// let reports = recon.list_reports(ListReportsParams {
+///     limit: Some(50),
+///     offset: Some(0),
+/// }).await.expect("failed to list reports");
+///
+/// println!("Found {} total reports", reports.total);
+///
+/// // Get details of a specific report
+/// if let Some(summary) = reports.reports.first() {
+///     let detail = recon.get_report(summary.id).await.expect("failed to get report");
+///     println!("Report has {} discrepancies", detail.missing_on_chain.len());
+/// }
+///
+/// // Run a new reconciliation
+/// let result = recon.run(
+///     "GABC1234567890123456789012345678901234567890123456789012",
+///     Some(24),  // look back 24 hours
+/// ).await.expect("reconciliation failed");
+/// println!("Reconciliation: {}", result.message);
+/// # }
+/// ```
 pub struct AdminReconciliation<'a> {
     pub(crate) client: &'a AdminSynapseClient,
 }
@@ -14,8 +53,12 @@ pub struct AdminReconciliation<'a> {
 impl<'a> AdminReconciliation<'a> {
     /// List reconciliation reports with optional pagination.
     ///
+    /// Returns a page of reconciliation report summaries. The `limit` and `offset`
+    /// parameters control pagination (server default: limit=20, offset=0).
+    ///
     /// # Errors
-    /// - [`SynapseError::Http`] – server returned an error status.
+    /// - [`SynapseError::Http`] – server returned a 5xx error.
+    /// - [`SynapseError::Api`] – server returned a 4xx error with details.
     /// - [`SynapseError::Network`] – network error.
     /// - [`SynapseError::Decode`] – response body is not valid JSON.
     ///
@@ -28,16 +71,25 @@ impl<'a> AdminReconciliation<'a> {
     /// # #[tokio::main]
     /// # async fn main() {
     /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
-    /// let reconciliation = AdminReconciliation::new(&client);
+    /// let reconciliation = client.reconciliation();
     ///
+    /// // Fetch first 25 reports
     /// let params = ListReportsParams {
-    ///     limit: Some(50),
+    ///     limit: Some(25),
     ///     offset: Some(0),
     /// };
     ///
     /// match reconciliation.list_reports(params).await {
-    ///     Ok(reports) => println!("Total reports: {}", reports.total),
-    ///     Err(e) => eprintln!("Error: {}", e),
+    ///     Ok(page) => {
+    ///         println!("Found {} total reports, showing {} on this page",
+    ///                  page.total, page.reports.len());
+    ///         for report in &page.reports {
+    ///             if report.has_discrepancies {
+    ///                 println!("⚠️  Report {} has discrepancies", report.id);
+    ///             }
+    ///         }
+    ///     }
+    ///     Err(e) => eprintln!("Failed to list reports: {}", e),
     /// }
     /// # }
     /// ```
@@ -68,10 +120,16 @@ impl<'a> AdminReconciliation<'a> {
             .await
     }
 
-    /// Get a single reconciliation report by ID.
+    /// Get a single reconciliation report by ID with full details.
+    ///
+    /// Returns the complete report including all discrepancy details:
+    /// - Missing transactions (in database but not on chain)
+    /// - Orphaned payments (on chain but not in database)
+    /// - Amount mismatches (different amounts in DB vs chain)
     ///
     /// # Errors
-    /// - [`SynapseError::Http`] – server returned an error status (e.g., 404 if not found).
+    /// - [`SynapseError::Api`] with status 404 – report not found.
+    /// - [`SynapseError::Http`] – server returned a 5xx error.
     /// - [`SynapseError::Network`] – network error.
     /// - [`SynapseError::Decode`] – response body is not valid JSON.
     ///
@@ -79,16 +137,27 @@ impl<'a> AdminReconciliation<'a> {
     ///
     /// ```no_run
     /// use synapse_sdk::AdminSynapseClient;
+    /// use synapse_sdk::SynapseError;
     /// use uuid::Uuid;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
-    /// let reconciliation = AdminReconciliation::new(&client);
+    /// let reconciliation = client.reconciliation();
     ///
-    /// let report_id = Uuid::nil();
+    /// let report_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    ///
     /// match reconciliation.get_report(report_id).await {
-    ///     Ok(report) => println!("Report generated at: {}", report.generated_at),
+    ///     Ok(report) => {
+    ///         println!("Report {}", report.id);
+    ///         println!("Missing on chain: {}", report.missing_on_chain.len());
+    ///         for tx in &report.missing_on_chain {
+    ///             println!("  - Amount: {}, Account: {}", tx.amount, tx.stellar_account);
+    ///         }
+    ///     }
+    ///     Err(SynapseError::Api { status: 404, .. }) => {
+    ///         eprintln!("Report not found");
+    ///     }
     ///     Err(e) => eprintln!("Error: {}", e),
     /// }
     /// # }
@@ -101,13 +170,23 @@ impl<'a> AdminReconciliation<'a> {
         self.client.get::<ReconciliationReportDetail>(&path).await
     }
 
-    /// Run a reconciliation for the specified account.
+    /// Run a reconciliation for the specified Stellar account.
     ///
-    /// This method blocks until the reconciliation completes and returns the report summary.
-    /// The `period_hours` parameter controls the lookback window (default: 24 hours).
+    /// This method blocks until the reconciliation completes and returns a report summary.
+    /// For full details of discrepancies, call [`get_report`] with the returned report ID.
+    ///
+    /// # Parameters
+    /// - `account`: Stellar account to reconcile (e.g., `G...`)
+    /// - `period_hours`: Lookback window in hours. If `None`, defaults to 24 hours.
+    ///
+    /// # Semantics
+    /// **This is a synchronous/blocking operation**: the API endpoint runs reconciliation
+    /// immediately and returns the complete report summary. It does not return a task ID
+    /// to poll later.
     ///
     /// # Errors
-    /// - [`SynapseError::Http`] – server returned an error status (e.g., 400 if account is invalid).
+    /// - [`SynapseError::Api`] with status 400 – invalid account format or server validation error.
+    /// - [`SynapseError::Http`] – server returned a 5xx error.
     /// - [`SynapseError::Network`] – network error.
     /// - [`SynapseError::Decode`] – response body is not valid JSON.
     ///
@@ -115,18 +194,39 @@ impl<'a> AdminReconciliation<'a> {
     ///
     /// ```no_run
     /// use synapse_sdk::AdminSynapseClient;
+    /// use synapse_sdk::SynapseError;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
-    /// let reconciliation = AdminReconciliation::new(&client);
+    /// let reconciliation = client.reconciliation();
     ///
-    /// match reconciliation.run("GABC1234567890123456789012345678901234567890123456789012", None).await {
+    /// let account = "GABC1234567890123456789012345678901234567890123456789012";
+    ///
+    /// // Run reconciliation for the past 48 hours
+    /// match reconciliation.run(account, Some(48)).await {
     ///     Ok(response) => {
-    ///         println!("Reconciliation completed: {}", response.message);
-    ///         println!("Report ID: {}", response.report.id);
+    ///         println!("✓ Reconciliation completed: {}", response.message);
+    ///         let report = &response.report;
+    ///
+    ///         if report.has_discrepancies {
+    ///             println!("⚠️  Found discrepancies:");
+    ///             println!("  Missing on chain: {}", report.missing_on_chain_count);
+    ///             println!("  Orphaned payments: {}", report.orphaned_payments_count);
+    ///             println!("  Amount mismatches: {}", report.amount_mismatches_count);
+    ///
+    ///             // Fetch full report for details
+    ///             if let Ok(full) = reconciliation.get_report(report.id).await {
+    ///                 println!("Details available via report ID: {}", full.id);
+    ///             }
+    ///         } else {
+    ///             println!("✓ No discrepancies found");
+    ///         }
     ///     }
-    ///     Err(e) => eprintln!("Error: {}", e),
+    ///     Err(SynapseError::Api { status: 400, message }) => {
+    ///         eprintln!("Invalid account or parameters: {}", message);
+    ///     }
+    ///     Err(e) => eprintln!("Reconciliation error: {}", e),
     /// }
     /// # }
     /// ```

--- a/sdks/rust/src/resources/admin/reconciliation.rs
+++ b/sdks/rust/src/resources/admin/reconciliation.rs
@@ -1,0 +1,306 @@
+use crate::client::AdminSynapseClient;
+use crate::error::SynapseError;
+use crate::models::{
+    ListReconciliationReports, ListReportsParams, ReconciliationReportDetail,
+    RunReconciliationRequest, RunReconciliationResponse,
+};
+use uuid::Uuid;
+
+/// Admin operations for reconciliation reports.
+pub struct AdminReconciliation<'a> {
+    pub(crate) client: &'a AdminSynapseClient,
+}
+
+impl<'a> AdminReconciliation<'a> {
+    /// List reconciliation reports with optional pagination.
+    ///
+    /// # Errors
+    /// - [`SynapseError::Http`] – server returned an error status.
+    /// - [`SynapseError::Network`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    /// use synapse_sdk::models::ListReportsParams;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let reconciliation = AdminReconciliation::new(&client);
+    ///
+    /// let params = ListReportsParams {
+    ///     limit: Some(50),
+    ///     offset: Some(0),
+    /// };
+    ///
+    /// match reconciliation.list_reports(params).await {
+    ///     Ok(reports) => println!("Total reports: {}", reports.total),
+    ///     Err(e) => eprintln!("Error: {}", e),
+    /// }
+    /// # }
+    /// ```
+    pub async fn list_reports(
+        &self,
+        params: ListReportsParams,
+    ) -> Result<ListReconciliationReports, SynapseError> {
+        let mut query: Vec<(&str, String)> = Vec::new();
+        let limit_str;
+        let offset_str;
+
+        if let Some(limit) = params.limit {
+            limit_str = limit.to_string();
+            query.push(("limit", limit_str));
+        }
+        if let Some(offset) = params.offset {
+            offset_str = offset.to_string();
+            query.push(("offset", offset_str));
+        }
+
+        let query_refs: Vec<(&str, &str)> = query
+            .iter()
+            .map(|(k, v)| (*k, v.as_str()))
+            .collect();
+
+        self.client
+            .get_query::<ListReconciliationReports>("/admin/reconciliation/reports", &query_refs)
+            .await
+    }
+
+    /// Get a single reconciliation report by ID.
+    ///
+    /// # Errors
+    /// - [`SynapseError::Http`] – server returned an error status (e.g., 404 if not found).
+    /// - [`SynapseError::Network`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    /// use uuid::Uuid;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let reconciliation = AdminReconciliation::new(&client);
+    ///
+    /// let report_id = Uuid::nil();
+    /// match reconciliation.get_report(report_id).await {
+    ///     Ok(report) => println!("Report generated at: {}", report.generated_at),
+    ///     Err(e) => eprintln!("Error: {}", e),
+    /// }
+    /// # }
+    /// ```
+    pub async fn get_report(
+        &self,
+        id: Uuid,
+    ) -> Result<ReconciliationReportDetail, SynapseError> {
+        let path = format!("/admin/reconciliation/reports/{}", id);
+        self.client.get::<ReconciliationReportDetail>(&path).await
+    }
+
+    /// Run a reconciliation for the specified account.
+    ///
+    /// This method blocks until the reconciliation completes and returns the report summary.
+    /// The `period_hours` parameter controls the lookback window (default: 24 hours).
+    ///
+    /// # Errors
+    /// - [`SynapseError::Http`] – server returned an error status (e.g., 400 if account is invalid).
+    /// - [`SynapseError::Network`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let client = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let reconciliation = AdminReconciliation::new(&client);
+    ///
+    /// match reconciliation.run("GABC1234567890123456789012345678901234567890123456789012", None).await {
+    ///     Ok(response) => {
+    ///         println!("Reconciliation completed: {}", response.message);
+    ///         println!("Report ID: {}", response.report.id);
+    ///     }
+    ///     Err(e) => eprintln!("Error: {}", e),
+    /// }
+    /// # }
+    /// ```
+    pub async fn run(
+        &self,
+        account: &str,
+        period_hours: Option<i32>,
+    ) -> Result<RunReconciliationResponse, SynapseError> {
+        let req = RunReconciliationRequest {
+            account: account.to_string(),
+            period_hours,
+        };
+        self.client
+            .post::<_, RunReconciliationResponse>("/admin/reconciliation/run", &req)
+            .await
+    }
+}
+
+impl<'a> AdminReconciliation<'a> {
+    /// Create a new [`AdminReconciliation`] resource.
+    pub fn new(client: &'a AdminSynapseClient) -> Self {
+        AdminReconciliation { client }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn report_summary_json(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "generated_at": "2024-01-15T10:00:00Z",
+            "period_start": "2024-01-14T10:00:00Z",
+            "period_end": "2024-01-15T10:00:00Z",
+            "total_db_transactions": 100,
+            "total_chain_payments": 100,
+            "missing_on_chain_count": 0,
+            "orphaned_payments_count": 0,
+            "amount_mismatches_count": 0,
+            "has_discrepancies": false,
+        })
+    }
+
+    #[tokio::test]
+    async fn list_reports_returns_reports_on_200() {
+        let server = MockServer::start().await;
+        let report_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("GET"))
+            .and(path("/admin/reconciliation/reports"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "reports": [report_summary_json(report_id)],
+                "total": 1,
+                "limit": 20,
+                "offset": 0,
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .list_reports(ListReportsParams {
+                limit: None,
+                offset: None,
+            })
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let page = result.unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.reports.len(), 1);
+        assert_eq!(page.reports[0].id.to_string(), report_id);
+    }
+
+    #[tokio::test]
+    async fn get_report_returns_report_detail_on_200() {
+        let server = MockServer::start().await;
+        let report_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("GET"))
+            .and(path(format!("/admin/reconciliation/reports/{}", report_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "id": report_id,
+                "generated_at": "2024-01-15T10:00:00Z",
+                "period_start": "2024-01-14T10:00:00Z",
+                "period_end": "2024-01-15T10:00:00Z",
+                "summary": {
+                    "total_db_transactions": 100,
+                    "total_chain_payments": 100,
+                    "missing_on_chain_count": 0,
+                    "orphaned_payments_count": 0,
+                    "amount_mismatches_count": 0,
+                    "has_discrepancies": false,
+                },
+                "missing_on_chain": [],
+                "orphaned_payments": [],
+                "amount_mismatches": [],
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .get_report(Uuid::parse_str(report_id).unwrap())
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let report = result.unwrap();
+        assert_eq!(report.id.to_string(), report_id);
+        assert_eq!(report.summary.total_db_transactions, 100);
+        assert!(!report.summary.has_discrepancies);
+    }
+
+    #[tokio::test]
+    async fn run_returns_report_summary_on_200() {
+        let server = MockServer::start().await;
+        let report_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path("/admin/reconciliation/run"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "message": "Reconciliation completed successfully",
+                "report": report_summary_json(report_id),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .run("GABC1234567890123456789012345678901234567890123456789012", None)
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let response = result.unwrap();
+        assert_eq!(
+            response.message,
+            "Reconciliation completed successfully"
+        );
+        assert_eq!(response.report.id.to_string(), report_id);
+    }
+
+    #[tokio::test]
+    async fn run_with_period_hours_sends_parameter() {
+        let server = MockServer::start().await;
+        let report_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path("/admin/reconciliation/run"))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "message": "Reconciliation completed successfully",
+                "report": report_summary_json(report_id),
+            })))
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let reconciliation = AdminReconciliation::new(&client);
+        let result = reconciliation
+            .run(
+                "GABC1234567890123456789012345678901234567890123456789012",
+                Some(48),
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    }
+}

--- a/sdks/rust/src/resources/admin/settlements.rs
+++ b/sdks/rust/src/resources/admin/settlements.rs
@@ -1,0 +1,391 @@
+use crate::client::AdminSynapseClient;
+use crate::error::SynapseError;
+use crate::models::{Settlement, UpdateSettlementStatusRequest};
+use uuid::Uuid;
+
+/// Admin operations for settlements.
+///
+/// Use this to manage settlement status updates. Valid status transitions depend on
+/// the current status:
+/// - `completed` → `pending_review`, `disputed`
+/// - `pending_review` → `adjusted`, `voided`, `disputed`
+/// - `disputed` → `adjusted`, `voided`, `pending_review`
+///
+/// Invalid transitions will return a server error with a specific validation message
+/// describing the disallowed transition.
+///
+/// # Example
+///
+/// ```no_run
+/// use synapse_sdk::AdminSynapseClient;
+/// use uuid::Uuid;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let admin = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+/// let settlements = admin.settlements();
+///
+/// let settlement_id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+///
+/// // Update status with reason
+/// match settlements.update_status(
+///     settlement_id,
+///     "pending_review",
+///     Some("Manual review requested"),
+///     None,
+///     None,
+/// ).await {
+///     Ok(updated) => println!("Settlement status updated to: {}", updated.status),
+///     Err(e) => eprintln!("Error: {}", e),
+/// }
+/// # }
+/// ```
+pub struct AdminSettlements<'a> {
+    pub(crate) client: &'a AdminSynapseClient,
+}
+
+impl<'a> AdminSettlements<'a> {
+    /// Update a settlement's status.
+    ///
+    /// Transitions between settlement statuses with optional reason and adjustment amount.
+    /// The server enforces valid status transitions; attempting an invalid transition
+    /// returns a 400 error with a specific message describing what transitions are allowed.
+    ///
+    /// # Parameters
+    /// - `id`: Settlement ID to update
+    /// - `new_status`: Target status string (e.g., "pending_review", "adjusted", "disputed", "voided")
+    /// - `reason`: Optional reason for the status change
+    /// - `new_total`: Optional new total amount, only meaningful when transitioning to "adjusted"
+    /// - `actor`: Optional actor name (defaults to "admin" on server side)
+    ///
+    /// # Constraints
+    /// - `new_status`: max 50 characters
+    /// - `reason`: max 255 characters
+    /// - `actor`: max 50 characters
+    /// - `new_total`: valid decimal format (e.g., "1000.00")
+    ///
+    /// # Valid Status Transitions
+    /// - `completed` → `pending_review`, `disputed`
+    /// - `pending_review` → `adjusted`, `voided`, `disputed`
+    /// - `disputed` → `adjusted`, `voided`, `pending_review`
+    ///
+    /// # Errors
+    /// - [`SynapseError::Api`] with status 400 – invalid status transition, constraint violation,
+    ///   or malformed request. The error message includes details about what went wrong.
+    /// - [`SynapseError::Api`] with status 404 – settlement not found.
+    /// - [`SynapseError::Http`] – server returned a 5xx error.
+    /// - [`SynapseError::Network`] – network error.
+    /// - [`SynapseError::Decode`] – response body is not valid JSON.
+    ///
+    /// # Example: Simple Status Change
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    /// use synapse_sdk::SynapseError;
+    /// use uuid::Uuid;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let admin = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let settlements = admin.settlements();
+    ///
+    /// let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    ///
+    /// match settlements.update_status(id, "pending_review", None, None, None).await {
+    ///     Ok(settlement) => {
+    ///         println!("✓ Settlement {} is now {}", settlement.id, settlement.status);
+    ///     }
+    ///     Err(e) => eprintln!("✗ Update failed: {}", e),
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// # Example: Status Change with Reason and Validation Error
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    /// use synapse_sdk::SynapseError;
+    /// use uuid::Uuid;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let admin = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let settlements = admin.settlements();
+    ///
+    /// let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    ///
+    /// // Attempt an invalid transition
+    /// match settlements.update_status(
+    ///     id,
+    ///     "completed",  // Invalid: can only transition FROM completed, not TO it
+    ///     Some("Trying to mark as completed"),
+    ///     None,
+    ///     None,
+    /// ).await {
+    ///     Ok(_) => println!("Unexpectedly succeeded"),
+    ///     Err(SynapseError::Api { status, message }) if status == 400 => {
+    ///         // Server returns specific validation error
+    ///         eprintln!("✗ Invalid transition: {}", message);
+    ///     }
+    ///     Err(e) => eprintln!("✗ Other error: {}", e),
+    /// }
+    /// # }
+    /// ```
+    ///
+    /// # Example: Adjustment with New Total
+    ///
+    /// ```no_run
+    /// use synapse_sdk::AdminSynapseClient;
+    /// use uuid::Uuid;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let admin = AdminSynapseClient::builder("https://api.example.com", "admin-key").build();
+    /// let settlements = admin.settlements();
+    ///
+    /// let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+    ///
+    /// match settlements.update_status(
+    ///     id,
+    ///     "adjusted",
+    ///     Some("Manually adjusted based on discrepancy review"),
+    ///     Some("5000.50".to_string()),  // New total amount
+    ///     Some("reviewer_name"),
+    /// ).await {
+    ///     Ok(updated) => {
+    ///         println!("✓ Adjusted to {} (amount: {})",
+    ///                  updated.status, updated.total_amount);
+    ///     }
+    ///     Err(e) => eprintln!("✗ Adjustment failed: {}", e),
+    /// }
+    /// # }
+    /// ```
+    pub async fn update_status(
+        &self,
+        id: Uuid,
+        new_status: &str,
+        reason: Option<&str>,
+        new_total: Option<String>,
+        actor: Option<&str>,
+    ) -> Result<Settlement, SynapseError> {
+        let path = format!("/admin/settlements/{}/status", id);
+        let req = UpdateSettlementStatusRequest {
+            status: new_status.to_string(),
+            reason: reason.map(|s| s.to_string()),
+            new_total,
+            actor: actor.map(|s| s.to_string()),
+        };
+        self.client
+            .post::<_, Settlement>(&path, &req)
+            .await
+    }
+}
+
+impl<'a> AdminSettlements<'a> {
+    /// Create a new [`AdminSettlements`] resource.
+    pub fn new(client: &'a AdminSynapseClient) -> Self {
+        AdminSettlements { client }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn settlement_json(id: &str, status: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "status": status,
+            "total_amount": "1000.00",
+            "reason": null,
+            "actor": null,
+            "created_at": "2024-01-15T10:00:00Z",
+            "updated_at": "2024-01-15T11:00:00Z",
+        })
+    }
+
+    #[tokio::test]
+    async fn update_status_returns_settlement_on_200() {
+        let server = MockServer::start().await;
+        let settlement_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/settlements/{}/status", settlement_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(settlement_json(settlement_id, "pending_review")),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let settlements = AdminSettlements::new(&client);
+        let result = settlements
+            .update_status(
+                Uuid::parse_str(settlement_id).unwrap(),
+                "pending_review",
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        let settlement = result.unwrap();
+        assert_eq!(settlement.status, "pending_review");
+    }
+
+    #[tokio::test]
+    async fn update_status_with_reason() {
+        let server = MockServer::start().await;
+        let settlement_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/settlements/{}/status", settlement_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": settlement_id,
+                    "status": "disputed",
+                    "total_amount": "1000.00",
+                    "reason": "Manual dispute flag",
+                    "actor": "reviewer",
+                    "created_at": "2024-01-15T10:00:00Z",
+                    "updated_at": "2024-01-15T11:00:00Z",
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let settlements = AdminSettlements::new(&client);
+        let result = settlements
+            .update_status(
+                Uuid::parse_str(settlement_id).unwrap(),
+                "disputed",
+                Some("Manual dispute flag"),
+                None,
+                Some("reviewer"),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        let settlement = result.unwrap();
+        assert_eq!(settlement.status, "disputed");
+        assert_eq!(settlement.reason, Some("Manual dispute flag".to_string()));
+    }
+
+    #[tokio::test]
+    async fn update_status_returns_invalid_transition_error() {
+        let server = MockServer::start().await;
+        let settlement_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/settlements/{}/status", settlement_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_string(
+                    "invalid status transition: cannot transition from pending to completed",
+                ),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let settlements = AdminSettlements::new(&client);
+        let result = settlements
+            .update_status(
+                Uuid::parse_str(settlement_id).unwrap(),
+                "completed",
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result {
+            Err(SynapseError::Api { status, .. }) => {
+                assert_eq!(status, 400);
+            }
+            other => panic!("expected Api error with 400 status, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_status_with_new_total() {
+        let server = MockServer::start().await;
+        let settlement_id = "550e8400-e29b-41d4-a716-446655440000";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/settlements/{}/status", settlement_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "id": settlement_id,
+                    "status": "adjusted",
+                    "total_amount": "1500.75",
+                    "reason": "Adjustment based on review",
+                    "actor": "admin",
+                    "created_at": "2024-01-15T10:00:00Z",
+                    "updated_at": "2024-01-15T12:00:00Z",
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let settlements = AdminSettlements::new(&client);
+        let result = settlements
+            .update_status(
+                Uuid::parse_str(settlement_id).unwrap(),
+                "adjusted",
+                Some("Adjustment based on review"),
+                Some("1500.75".to_string()),
+                None,
+            )
+            .await;
+
+        assert!(result.is_ok());
+        let settlement = result.unwrap();
+        assert_eq!(settlement.status, "adjusted");
+        assert_eq!(settlement.total_amount, "1500.75");
+    }
+
+    #[tokio::test]
+    async fn update_status_returns_not_found_on_404() {
+        let server = MockServer::start().await;
+        let settlement_id = "00000000-0000-0000-0000-000000000000";
+
+        Mock::given(method("POST"))
+            .and(path(format!("/admin/settlements/{}/status", settlement_id)))
+            .and(header("X-Admin-Key", "admin-test-key"))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_string("Settlement not found"),
+            )
+            .mount(&server)
+            .await;
+
+        let client = AdminSynapseClient::builder(server.uri(), "admin-test-key").build();
+        let settlements = AdminSettlements::new(&client);
+        let result = settlements
+            .update_status(
+                Uuid::parse_str(settlement_id).unwrap(),
+                "pending_review",
+                None,
+                None,
+                None,
+            )
+            .await;
+
+        assert!(result.is_err());
+        match result {
+            Err(SynapseError::Api { status, .. }) => {
+                assert_eq!(status, 404);
+            }
+            other => panic!("expected Api error with 404 status, got: {:?}", other),
+        }
+    }
+}

--- a/sdks/rust/src/resources/mod.rs
+++ b/sdks/rust/src/resources/mod.rs
@@ -1,1 +1,2 @@
+pub mod admin;
 pub mod transactions;

--- a/sdks/rust/src/resources/transactions.rs
+++ b/sdks/rust/src/resources/transactions.rs
@@ -7,6 +7,12 @@ pub struct Transactions<'a> {
 }
 
 impl<'a> Transactions<'a> {
+    /// Create a new [`Transactions`] resource.
+    pub fn new(client: &'a SynapseClient) -> Self {
+        Transactions { client }
+    }
+
+
     /// Fetch a single transaction by its UUID.
     ///
     /// Returns [`SynapseError::NotFound`] when the ID does not exist so callers


### PR DESCRIPTION
 Summary
                                                                                                                                                  
  This PR adds comprehensive Rust SDK support for admin reconciliation and settlement operations, including full implementations, test coverage,
  and rustdoc with runnable examples for all endpoints.

  Changes

  #658 — Rust SDK: implement admin.reconciliation.list_reports() / get_report(id) / run()

  - Created AdminSynapseClient for admin-scoped API requests (uses X-Admin-Key header)
  - Added AdminReconciliation resource with three methods:
    - list_reports(params) → GET /admin/reconciliation/reports with pagination
    - get_report(id) → GET /admin/reconciliation/reports/:id with full discrepancy details
    - run(account, period_hours) → POST /admin/reconciliation/run (synchronous/blocking)
  - Added response models: ReconciliationReportSummary, ListReconciliationReports, ReconciliationReportDetail, etc.
  - Updated SynapseClient to add get_query() and post() methods for query params and JSON bodies

  #659 — Rust SDK: test coverage for admin.reconciliation.*

  - Added 9 comprehensive unit tests with mocked HTTP transport (wiremock):
    - Happy path tests for all three methods
    - Edge cases: pagination, discrepancies, error states
    - Verified admin key (X-Admin-Key) is sent, not public key
    - Tests for 400/404 error handling

  #660 — Rust SDK: rustdoc and example for admin.reconciliation.*

  - Enhanced rustdoc on all methods with detailed parameter/error documentation
  - Documented run() blocking semantics explicitly (synchronous operation)
  - Created examples/admin_reconciliation.rs demonstrating:
    - Listing reports with pagination
    - Retrieving report details and interpreting discrepancies
    - Running reconciliation and handling validation errors
  - All doctests pass validation

  #657 — Rust SDK: rustdoc and example for admin.settlements.update_status(id, new_status)

  - Created AdminSettlements resource with update_status() method
  - Full rustdoc showing:
    - Valid status transitions (completed→pending_review/disputed, etc.)
    - How server validates transitions and surfaces error messages
    - Parameters for reason, new_total (for adjustments), and actor
  - Added 5 comprehensive tests covering happy path, transitions, and error cases
  - Included detailed examples for simple updates and adjustment workflows

  Notes

  - Only files under sdks/rust/ were modified
  - run() behavior: Synchronous/blocking — returns complete report summary immediately, not a task ID
  - Introduced AdminSynapseClient for admin-scoped requests; mirrors SynapseClient but uses X-Admin-Key header
  - Enhanced error handling: 4xx errors now return SynapseError::Api with parsed status/message for better error discrimination
  - All 14+ unit tests and 12 doctests pass
  - Dependencies added: chrono, uuid (with serde/v4 features)

  Closes #658, Closes #659, Closes #660, Closes #657