### PR TITLE
feat: wire sdks/rust + cli/synapse-cli into workspace, add CI and changelog docs

### DIFF
--- a/.github/workflows/sdk-cli-workspace-ci.yml
+++ b/.github/workflows/sdk-cli-workspace-ci.yml
@@ -1,0 +1,49 @@
+name: Workspace CI (sdk + cli)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'sdks/rust/**'
+      - 'cli/synapse-cli/**'
+      - 'src/**'
+      - '.github/workflows/sdk-cli-workspace-ci.yml'
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'sdks/rust/**'
+      - 'cli/synapse-cli/**'
+      - 'src/**'
+      - '.github/workflows/sdk-cli-workspace-ci.yml'
+
+jobs:
+  workspace-check:
+    name: cargo build + test (workspace)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-workspace-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-workspace-
+
+      - name: Build entire workspace
+        run: cargo build --workspace
+
+      - name: Run workspace lib tests
+        run: cargo test --workspace --lib

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = [".", "cli/synapse-cli"]
+members = [".", "sdks/rust", "cli/synapse-cli"]
 
 [package]
 name = "synapse-core"

--- a/cli/synapse-cli/CHANGELOG.md
+++ b/cli/synapse-cli/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to `synapse-cli` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows the policy described in [VERSIONING.md](./VERSIONING.md).
+
+## [Unreleased]
+
+### Added
+
+- Initial crate scaffold: `Cargo.toml`, `src/main.rs`, `src/lib.rs`.
+- `clap`-based CLI entry point with top-level subcommand dispatch.
+- `synapse workspace` command group: `list`, `get`, `create`, `delete`.
+- `synapse event` command group: `list`, `get`, `publish`.
+- `synapse subscription` command group: `list`, `get`, `create`, `cancel`.
+- `synapse admin reconciliation` command group: `list`, `get`, `trigger`.
+- Output formatters: `--output table` (default), `--output json`, `--output csv`.
+- Global flags: `--api-url`, `--token` (env: `SYNAPSE_TOKEN`), `--verbose`.
+- Exit-code contract: 0 success, 1 API error, 2 usage/config error.
+- Integration tests using `assert_cmd` and `predicates`.
+- Wired into the root workspace (`Cargo.toml` `[workspace] members`).
+- Scoped CI workflow (`.github/workflows/cli-synapse-ci.yml`): fmt, clippy, tests.

--- a/cli/synapse-cli/VERSIONING.md
+++ b/cli/synapse-cli/VERSIONING.md
@@ -1,0 +1,44 @@
+# Versioning Policy — synapse-cli
+
+## Current stability: 0.x pre-release
+
+`synapse-cli` is currently versioned in the **0.x** range. The command interface
+and output formats are still being shaped and may change as the Synapse platform
+and underlying SDK evolve.
+
+## Semver rules while `< 1.0`
+
+| Version component | Meaning |
+|-------------------|---------|
+| **PATCH** (`0.x.Y`) | Backwards-compatible bug fixes, typo corrections, and help-text improvements. |
+| **MINOR** (`0.X.0`) | New subcommands/flags **and** breaking changes to existing commands or output formats. Until 1.0 is declared, a minor bump is the signal that scripts using the CLI may need updating. |
+| **MAJOR** (`X.0.0`) | Reserved for declaring CLI stability (i.e., the 1.0 release). |
+
+## What counts as a breaking change
+
+- Removing or renaming a subcommand or flag that was previously documented/shipped.
+- Changing the meaning of positional arguments for any existing subcommand.
+- Altering the machine-readable output format (JSON keys, CSV column order/names) in a backwards-incompatible way.
+- Changing the exit-code contract (e.g., re-mapping what exit codes mean).
+- Raising the minimum supported Rust edition or MSRV in a way that prevents compilation on the previous toolchain.
+
+## What does NOT count as a breaking change
+
+- Adding new subcommands, flags, or output fields (additive changes).
+- Reformatting human-readable table output (column widths, headers) — scripts should use `--output json`.
+- Internal refactoring with no observable change to CLI behaviour.
+- Dependency version bumps that do not affect CLI behaviour.
+
+## Relationship to synapse-sdk versioning
+
+`synapse-cli` depends on `synapse-sdk`. A breaking SDK release will trigger at
+minimum a minor-version bump in `synapse-cli`. The two crates are versioned
+independently; see [sdks/rust/VERSIONING.md](../../sdks/rust/VERSIONING.md).
+
+## Path to 1.0
+
+A 1.0 release will be cut once:
+
+1. All core Synapse resources are reachable via stable subcommands.
+2. The JSON output schema is considered stable and documented.
+3. At least one external team has adopted the CLI in a scripted/automated workflow for 30 days without a breaking-change request.

--- a/sdks/rust/CHANGELOG.md
+++ b/sdks/rust/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to `synapse-sdk` (Rust) will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows the policy described in [VERSIONING.md](./VERSIONING.md).
+
+## [Unreleased]
+
+### Added
+
+- Initial crate scaffold: `Cargo.toml`, `src/lib.rs`, public module layout.
+- HTTP client wrapper (`SynapseClient`) with configurable base URL and auth token.
+- Core domain models (`synapse`, `event`, `subscription`) with `serde` derive support.
+- `AdminClient` for reconciliation-report endpoints (list, get, trigger reconcile).
+- `ReconciliationReport` and `ReconciliationStatus` types matching the REST contract.
+- Pagination helpers (`PageParams`, `PagedResponse<T>`).
+- Retry / back-off logic via `tokio::time` for transient 5xx responses.
+- Integration test harness using `wiremock` for HTTP mocking.
+- `examples/` directory with a minimal end-to-end usage example.
+- Wired into the root workspace (`Cargo.toml` `[workspace] members`).
+- Scoped CI workflow (`.github/workflows/sdk-rust-ci.yml`): fmt, clippy, tests.

--- a/sdks/rust/VERSIONING.md
+++ b/sdks/rust/VERSIONING.md
@@ -1,0 +1,38 @@
+# Versioning Policy — synapse-sdk (Rust)
+
+## Current stability: 0.x pre-release
+
+`synapse-sdk` is currently versioned in the **0.x** range. The API surface is
+still being established and may change as the Synapse REST API evolves.
+
+## Semver rules while `< 1.0`
+
+| Version component | Meaning |
+|-------------------|---------|
+| **PATCH** (`0.x.Y`) | Backwards-compatible bug fixes and documentation updates. |
+| **MINOR** (`0.X.0`) | New features **and** breaking changes. Until 1.0 is declared, a minor bump is the signal that callers may need to update their code. |
+| **MAJOR** (`X.0.0`) | Reserved for declaring API stability (i.e., the 1.0 release). |
+
+## What counts as a breaking change
+
+- Removing or renaming any public type, field, function, method, or trait impl.
+- Changing the signature of a public function or method (parameters, return type, generics).
+- Removing a variant from a public `enum` that consumers are expected to match exhaustively.
+- Changing the serialised JSON shape of any type that is sent over the wire.
+- Raising the minimum supported Rust edition or MSRV in a way that prevents compilation on the previous toolchain.
+- Removing a feature flag that was previously stable.
+
+## What does NOT count as a breaking change
+
+- Adding new public items (types, methods, fields with `#[non_exhaustive]`).
+- Adding new optional feature flags.
+- Internal refactoring with no change to the public API.
+- Dependency version bumps that do not affect the public API.
+
+## Path to 1.0
+
+A 1.0 release will be cut once:
+
+1. All core Synapse resources (workspaces, events, subscriptions, reconciliation reports) are covered by a stable client API.
+2. The REST contract is considered stable by the Synapse platform team.
+3. At least one production integration has been running against the SDK for 30 days without a breaking-change requirement.


### PR DESCRIPTION
## Summary

- **#717** — Adds `sdks/rust` to the root `Cargo.toml` `[workspace] members` array (one-line change) so `cargo build --workspace` picks up both new crates. Only `Cargo.toml` is touched; nothing under `src/`.
- **#720** — Adds `.github/workflows/sdk-cli-workspace-ci.yml` as a consolidated required status check running `cargo build --workspace` and `cargo test --workspace --lib`. Complements the existing per-crate scoped workflows without duplicating or replacing them.
- **#721** — Adds `CHANGELOG.md` and `VERSIONING.md` to `sdks/rust/` and `cli/synapse-cli/`. Both changelogs follow Keep a Changelog format with an `[Unreleased]` section listing every resource merged so far. `VERSIONING.md` defines the `0.x` semver policy (breaking changes permitted in minor bumps until `1.0`) and enumerates what constitutes a breaking change for each crate.

## Files changed

| File | Issue |
|------|-------|
| `Cargo.toml` | #717 |
| `.github/workflows/sdk-cli-workspace-ci.yml` | #720 |
| `sdks/rust/CHANGELOG.md` | #721 |
| `sdks/rust/VERSIONING.md` | #721 |
| `cli/synapse-cli/CHANGELOG.md` | #721 |
| `cli/synapse-cli/VERSIONING.md` | #721 |

## Test plan

- [ ] `cargo build --workspace` passes locally with the updated members list.
- [ ] New CI workflow triggers on PRs that touch `sdks/rust/**`, `cli/synapse-cli/**`, or `Cargo.toml`.
- [ ] Existing per-crate CI workflows (`sdk-rust-ci.yml`, `cli-synapse-ci.yml`) are unchanged.
- [ ] Both `CHANGELOG.md` files open with an `[Unreleased]` section.
- [ ] Both `VERSIONING.md` files clearly state 0.x policy and breaking-change definition.

Closes #717
Closes #720
Closes #721

