### PR TITLE
feat: implement PITR backup restore admin API, CLI, and audit trail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,11 @@ services:
       POSTGRES_USER: synapse
       POSTGRES_PASSWORD: synapse
       POSTGRES_DB: synapse
-      POSTGRES_INITDB_ARGS: "-c wal_level=replica -c max_wal_senders=3 -c max_replication_slots=3"
+      # wal_level/max_wal_senders/max_replication_slots make pg_basebackup
+      # streaming possible; archive_mode+archive_command actually populate
+      # postgres_wal so point-in-time recovery has WAL to replay beyond the
+      # latest base backup (see scripts/pitr_restore.sh).
+      POSTGRES_INITDB_ARGS: "-c wal_level=replica -c max_wal_senders=3 -c max_replication_slots=3 -c archive_mode=on -c archive_command='test ! -f /var/lib/postgresql/wal_archive/%f && cp %p /var/lib/postgresql/wal_archive/%f'"
     ports:
       - "5432:5432"
     volumes:
@@ -60,13 +64,25 @@ services:
       VAULT_ROLE_ID: ""
       VAULT_SECRET_ID: ""
       REDIS_URL: redis://redis:6379
+      # PITR restore (see scripts/pitr_restore.sh / src/services/pitr.rs).
+      # The script needs its own connection string because it runs as a
+      # separate process and streams a base backup over the replication
+      # protocol rather than reusing the app's pool.
+      PITR_DATABASE_URL: postgres://synapse:synapse@postgres:5432/synapse
+      WAL_ARCHIVE_DIR: /var/lib/postgresql/wal_archive
+      PITR_WORKSPACE_DIR: /app/pitr_workspace
     ports:
       - "3000:3000"
     volumes:
       - ./migrations:/app/migrations # optional: for live migration updates
+      # Read-only: the app never writes here, it only reads archived WAL
+      # segments during a restore.
+      - postgres_wal:/var/lib/postgresql/wal_archive:ro
+      - pitr_workspace:/app/pitr_workspace
     command: ["/app/synapse-core"]
 
 volumes:
   postgres_data:
   postgres_wal:
   redis_data:
+  pitr_workspace:

--- a/dockerfile
+++ b/dockerfile
@@ -12,9 +12,22 @@ COPY migrations ./migrations
 # Build the application
 RUN cargo build --release
 
-# Runtime stage (unchanged)
+# Runtime stage
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
+# postgresql-14 (client + server binaries) pulled from the PGDG repo, pinned
+# to match the postgres:14-alpine image in docker-compose.yml: PITR restore
+# (scripts/pitr_restore.sh) needs pg_basebackup/pg_ctl/postgres/psql on PATH,
+# and physical-restore tooling should match the source server's major version.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates wget gnupg lsb-release \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && wget -qO /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+      https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update && apt-get install -y --no-install-recommends postgresql-14 \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH="/usr/lib/postgresql/14/bin:${PATH}"
 WORKDIR /app
 COPY --from=builder /app/target/release/synapse-core /app/synapse-core
 COPY --from=builder /app/migrations ./migrations

--- a/migrations/20260721000001_pitr_restore_jobs.down.sql
+++ b/migrations/20260721000001_pitr_restore_jobs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pitr_restore_jobs;

--- a/migrations/20260721000001_pitr_restore_jobs.sql
+++ b/migrations/20260721000001_pitr_restore_jobs.sql
@@ -1,0 +1,20 @@
+-- Tracks point-in-time-recovery (PITR) restore attempts as async jobs so the
+-- CLI/admin API can submit a restore and poll for progress without blocking
+-- the request thread on a long-running, destructive operation.
+CREATE TABLE IF NOT EXISTS pitr_restore_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    target_timestamp TIMESTAMPTZ NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    dry_run BOOLEAN NOT NULL DEFAULT false,
+    requested_by VARCHAR(255) NOT NULL,
+    detail TEXT,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT chk_pitr_restore_jobs_status
+        CHECK (status IN ('pending', 'running', 'succeeded', 'failed'))
+);
+
+CREATE INDEX idx_pitr_restore_jobs_status ON pitr_restore_jobs(status);
+CREATE INDEX idx_pitr_restore_jobs_created_at ON pitr_restore_jobs(created_at DESC);

--- a/scripts/pitr_restore.sh
+++ b/scripts/pitr_restore.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Point-in-time-recovery (PITR) restore.
+#
+# Invoked by ShellPitrExecutor (src/services/pitr.rs) as a background job, so
+# stdout/stderr and the exit code are the only channel back to the app:
+#   - exit 0  -> stdout (trimmed) is recorded as the job's `detail`
+#   - exit !0 -> stderr (trimmed) is recorded as the job's `error_message`
+#
+# Usage:
+#   pitr_restore.sh <target_timestamp_rfc3339> <database_url> <workspace_dir> <wal_archive_dir>
+#
+# What this does — and deliberately does NOT do:
+#   1. Streams a fresh physical base backup from the live server via
+#      pg_basebackup (uses the replication protocol; this is what
+#      wal_level=replica / max_wal_senders in docker-compose.yml exist for).
+#   2. Configures recovery to replay archived WAL up to the target timestamp
+#      (recovery_target_time), reading segments from <wal_archive_dir>.
+#   3. Starts the recovered data directory as a standalone Postgres instance
+#      on a separate port and waits for recovery to complete.
+#
+#   It intentionally stops there rather than replacing the live primary.
+#   Swapping a running production database out from under its connection
+#   pool is a distinct, high-blast-radius action that deserves an explicit,
+#   separate promotion step by an operator who has verified the recovered
+#   data — not something a background job should do unattended. The job's
+#   `detail` message on success reports where the recovered instance lives
+#   so that verification/promotion can happen next.
+#
+# Requirements: pg_basebackup, pg_ctl, postgres, pg_isready, psql on PATH,
+# network access to the source database, and read access to the WAL
+# archive directory. None of these are available inside the default
+# `synapse-core` app container by default — this script is meant to run in
+# an environment that has them (e.g. a dedicated restore/ops container with
+# the matching Postgres major version installed).
+set -euo pipefail
+
+log() { echo "[pitr_restore] $*" >&2; }
+fail() { echo "$*" >&2; exit 1; }
+
+TARGET_TIMESTAMP="${1:?Usage: $0 <target_timestamp_rfc3339> <database_url> <workspace_dir> <wal_archive_dir>}"
+DATABASE_URL="${2:?database_url is required}"
+WORKSPACE_DIR="${3:?workspace_dir is required}"
+WAL_ARCHIVE_DIR="${4:?wal_archive_dir is required}"
+
+for bin in pg_basebackup pg_ctl postgres pg_isready psql; do
+  command -v "$bin" >/dev/null 2>&1 || fail \
+    "required binary '$bin' not found on PATH; this environment is missing Postgres server tooling needed for PITR restore"
+done
+
+[ -d "$WAL_ARCHIVE_DIR" ] || fail "WAL archive directory not found or not accessible: $WAL_ARCHIVE_DIR"
+
+RESTORE_PORT="${PITR_RESTORE_PORT:-55432}"
+DATA_DIR="$WORKSPACE_DIR/restore_$(date -u +%Y%m%dT%H%M%SZ)"
+
+mkdir -p "$DATA_DIR"
+log "streaming base backup into $DATA_DIR"
+pg_basebackup --dbname="$DATABASE_URL" --pgdata="$DATA_DIR" --format=plain --write-recovery-conf --checkpoint=fast \
+  || fail "pg_basebackup failed"
+
+# Postgres >= 12: recovery is driven by standby.signal + postgresql.auto.conf.
+touch "$DATA_DIR/standby.signal"
+{
+  echo "restore_command = 'cp \"$WAL_ARCHIVE_DIR/%f\" \"%p\"'"
+  echo "recovery_target_time = '$TARGET_TIMESTAMP'"
+  echo "recovery_target_action = 'promote'"
+  echo "recovery_target_inclusive = true"
+} >> "$DATA_DIR/postgresql.auto.conf"
+
+log "starting recovered instance on port $RESTORE_PORT"
+pg_ctl start -D "$DATA_DIR" -o "-p $RESTORE_PORT -c listen_addresses=127.0.0.1" -l "$DATA_DIR/recovery.log" \
+  || fail "failed to start recovered instance; see $DATA_DIR/recovery.log"
+
+# Wait for recovery to finish: pg_isready succeeds once the server is
+# accepting connections, whether still in recovery or already promoted.
+ATTEMPTS=0
+MAX_ATTEMPTS="${PITR_RESTORE_WAIT_ATTEMPTS:-120}"
+until pg_isready -h 127.0.0.1 -p "$RESTORE_PORT" >/dev/null 2>&1; do
+  ATTEMPTS=$((ATTEMPTS + 1))
+  if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+    pg_ctl stop -D "$DATA_DIR" -m immediate >/dev/null 2>&1 || true
+    fail "recovered instance did not become ready within ${MAX_ATTEMPTS}s; see $DATA_DIR/recovery.log"
+  fi
+  sleep 1
+done
+
+# Confirm recovery actually reached the target rather than just starting up.
+IN_RECOVERY=$(psql -h 127.0.0.1 -p "$RESTORE_PORT" -U "$(whoami)" -d postgres -tAc "SELECT pg_is_in_recovery();" 2>/dev/null || echo "unknown")
+
+echo "recovered instance ready at 127.0.0.1:$RESTORE_PORT (data dir: $DATA_DIR, target: $TARGET_TIMESTAMP, in_recovery: $IN_RECOVERY) — verify the data, then promote/cut over manually; it is left running for inspection"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -246,10 +246,33 @@ pub enum BackupCommands {
     },
 
     /// Restore to a specific point in time
+    ///
+    /// Submits a point-in-time-recovery (PITR) restore to the running
+    /// server's admin API and polls until it completes. This is a
+    /// destructive, data-loss-capable operation: the live database is
+    /// replaced with its state as of TIMESTAMP.
+    ///
+    /// Examples:
+    ///   # Check whether a timestamp is restorable without touching anything
+    ///   synapse-core backup restore-pitr --timestamp 2026-01-15T10:30:00Z --dry-run
+    ///
+    ///   # Actually perform the restore (requires explicit confirmation)
+    ///   synapse-core backup restore-pitr --timestamp 2026-01-15T10:30:00Z --yes
     RestorePitr {
         /// Target timestamp (ISO 8601 format, e.g., 2026-01-15T10:30:00Z)
         #[arg(long)]
         timestamp: String,
+
+        /// Validate the target timestamp and record the attempt without
+        /// performing the restore.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Confirm that you intend to run a live (non-dry-run) restore.
+        /// Required unless --dry-run is set; the command refuses to submit
+        /// a destructive restore without it.
+        #[arg(long)]
+        yes: bool,
     },
 
     /// Apply retention policy to clean old backups
@@ -904,12 +927,164 @@ pub async fn handle_tx_reconcile(
     Ok(())
 }
 
-#[allow(dead_code)]
+/// Submit a point-in-time-recovery restore to the server's admin API and
+/// poll until it completes.
+///
+/// This is destructive and data-loss-capable, so a live (non-dry-run)
+/// restore is refused unless `yes` is set — mirroring the server-side
+/// requirement that every restore attempt (dry-run or not) be recorded in
+/// the audit log with who requested it and what timestamp was targeted.
 pub async fn handle_backup_restore_pitr(
-    _config: &Config,
-    _timestamp_str: &str,
+    config: &Config,
+    timestamp_str: &str,
+    dry_run: bool,
+    yes: bool,
 ) -> anyhow::Result<()> {
-    anyhow::bail!("PITR restore service not yet implemented")
+    let target_timestamp = chrono::DateTime::parse_from_rfc3339(timestamp_str)
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "Invalid --timestamp '{timestamp_str}'. Use ISO 8601 (e.g., 2026-01-15T10:30:00Z)"
+            )
+        })?
+        .with_timezone(&chrono::Utc);
+
+    if !dry_run && !yes {
+        anyhow::bail!(
+            "Refusing to run a live PITR restore without confirmation. \
+             Re-run with --yes to proceed, or --dry-run to validate the target timestamp first \
+             without touching anything."
+        );
+    }
+
+    let admin_key = std::env::var("ADMIN_API_KEY").map_err(|_| {
+        anyhow::anyhow!(
+            "ADMIN_API_KEY is not set. This command calls the server's admin API and needs the \
+             same admin key the server was started with."
+        )
+    })?;
+
+    let actor = std::env::var("SYNAPSE_ACTOR")
+        .or_else(|_| std::env::var("USER"))
+        .or_else(|_| std::env::var("LOGNAME"))
+        .unwrap_or_else(|_| "admin-cli".to_string());
+
+    let base_url = format!("http://localhost:{}", config.server_port);
+    let client = reqwest::Client::new();
+
+    println!(
+        "Submitting PITR restore request: target={target_timestamp}, dry_run={dry_run}, requested_by={actor}"
+    );
+
+    let resp = client
+        .post(format!("{base_url}/admin/backup/restore-pitr"))
+        .header("Authorization", format!("Bearer {admin_key}"))
+        .json(&serde_json::json!({
+            "target_timestamp": target_timestamp.to_rfc3339(),
+            "dry_run": dry_run,
+            "requested_by": actor,
+        }))
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to reach server at {base_url}: {e}"))?;
+
+    let status = resp.status();
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to parse server response: {e}"))?;
+
+    if !status.is_success() {
+        let detail = body
+            .get("detail")
+            .or_else(|| body.get("error"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        anyhow::bail!("Server rejected the PITR restore request (HTTP {status}): {detail}");
+    }
+
+    let job_id = body
+        .get("id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("Server response missing job id: {body}"))?
+        .to_string();
+
+    println!("✓ Restore job submitted: {job_id}");
+    print_pitr_job_status(&body);
+
+    if dry_run {
+        // Dry-run jobs are resolved synchronously by the server.
+        return finish_pitr_job(&body);
+    }
+
+    // Poll until the job reaches a terminal state.
+    let poll_url = format!("{base_url}/admin/backup/restore-pitr/{job_id}");
+    let max_wait = std::time::Duration::from_secs(30 * 60);
+    let poll_interval = std::time::Duration::from_secs(3);
+    let start = std::time::Instant::now();
+
+    loop {
+        if start.elapsed() > max_wait {
+            anyhow::bail!(
+                "Timed out waiting for restore job {job_id} to complete after {}s. \
+                 The restore may still be running server-side — check its status later \
+                 with the same job id.",
+                max_wait.as_secs()
+            );
+        }
+
+        tokio::time::sleep(poll_interval).await;
+
+        let resp = client
+            .get(&poll_url)
+            .header("Authorization", format!("Bearer {admin_key}"))
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to poll restore job status: {e}"))?;
+
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to parse job status response: {e}"))?;
+
+        if !status.is_success() {
+            anyhow::bail!("Server returned HTTP {status} while polling job {job_id}: {body}");
+        }
+
+        let job_status = body.get("status").and_then(|v| v.as_str()).unwrap_or("");
+        println!("  status: {job_status}");
+
+        if job_status == "succeeded" || job_status == "failed" {
+            print_pitr_job_status(&body);
+            return finish_pitr_job(&body);
+        }
+    }
+}
+
+fn print_pitr_job_status(body: &serde_json::Value) {
+    if let Some(detail) = body.get("detail").and_then(|v| v.as_str()) {
+        println!("  detail: {detail}");
+    }
+    if let Some(err) = body.get("error_message").and_then(|v| v.as_str()) {
+        println!("  error: {err}");
+    }
+}
+
+fn finish_pitr_job(body: &serde_json::Value) -> anyhow::Result<()> {
+    match body.get("status").and_then(|v| v.as_str()) {
+        Some("succeeded") => {
+            println!("✓ PITR restore job completed successfully");
+            Ok(())
+        }
+        Some("failed") => {
+            let err = body
+                .get("error_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            anyhow::bail!("PITR restore job failed: {err}")
+        }
+        other => anyhow::bail!("PITR restore job ended in an unexpected state: {other:?}"),
+    }
 }
 
 #[cfg(test)]

--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 /// Entity type constants for audit logs
 pub const ENTITY_TRANSACTION: &str = "transaction";
 pub const ENTITY_SETTLEMENT: &str = "settlement";
+pub const ENTITY_BACKUP: &str = "backup";
 
 /// Represents an audit log entry
 #[derive(Debug, Clone)]

--- a/src/handlers/admin/backup.rs
+++ b/src/handlers/admin/backup.rs
@@ -1,0 +1,88 @@
+//! Admin endpoints for point-in-time-recovery (PITR) backup restores.
+//!
+//! Both routes sit behind the `admin_auth` layer applied to `admin_router`
+//! in `src/lib.rs`. Submitting a restore never blocks on the actual restore
+//! work — see [`crate::services::pitr`] for the async job machinery.
+
+use crate::error::AppError;
+use crate::services::pitr::{PitrService, ShellPitrExecutor};
+use crate::ApiState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub fn backup_routes() -> Router<ApiState> {
+    Router::new()
+        .route("/restore-pitr", post(submit_restore_pitr))
+        .route("/restore-pitr/:job_id", get(get_restore_pitr_job))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RestorePitrRequest {
+    /// The point in time to restore to.
+    pub target_timestamp: DateTime<Utc>,
+    /// When true, only validates the target and records the attempt —
+    /// no restore is performed. Required client-side confirmation (e.g. a
+    /// CLI `--yes` flag) should gate ever sending `dry_run: false`.
+    #[serde(default)]
+    pub dry_run: bool,
+    /// Identity of the operator requesting the restore, recorded in the
+    /// audit log. Falls back to `"admin"` when not provided.
+    pub requested_by: Option<String>,
+}
+
+fn pitr_service(state: &ApiState) -> PitrService {
+    let executor = Arc::new(ShellPitrExecutor::from_env());
+    PitrService::new(state.app_state.db.clone(), executor)
+}
+
+/// POST /admin/backup/restore-pitr
+///
+/// Validates `target_timestamp` against available WAL/backup coverage and,
+/// unless `dry_run` is set, kicks off the restore as a background job.
+/// Returns the created job (id + status) immediately; poll
+/// `GET /admin/backup/restore-pitr/:job_id` for progress.
+pub async fn submit_restore_pitr(
+    State(state): State<ApiState>,
+    Json(req): Json<RestorePitrRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let service = pitr_service(&state);
+    let actor = req.requested_by.as_deref().unwrap_or("admin");
+
+    match service
+        .submit_restore(req.target_timestamp, actor, req.dry_run)
+        .await
+    {
+        Ok(job) => Ok((StatusCode::ACCEPTED, Json(job))),
+        Err(crate::services::pitr::PitrError::InvalidTarget(msg)) => Err(AppError::BadRequest(msg)),
+        Err(crate::services::pitr::PitrError::Database(e)) => {
+            Err(AppError::DatabaseError(e.to_string()))
+        }
+    }
+}
+
+/// GET /admin/backup/restore-pitr/:job_id
+///
+/// Returns the current status of a previously submitted restore job.
+pub async fn get_restore_pitr_job(
+    State(state): State<ApiState>,
+    Path(job_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let service = pitr_service(&state);
+
+    let job = service
+        .get_job(job_id)
+        .await
+        .map_err(|e| AppError::DatabaseError(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound(format!("restore job {job_id} not found")))?;
+
+    Ok((StatusCode::OK, Json(job)))
+}

--- a/src/handlers/admin/mod.rs
+++ b/src/handlers/admin/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod bulk_status;
 pub mod locks;
 pub mod quota;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,8 @@ pub fn create_app(app_state: AppState) -> Router {
             "/admin/reconciliation",
             handlers::admin::reconciliation::reconciliation_routes(),
         )
+        // Admin: point-in-time-recovery backup restores
+        .nest("/admin/backup", handlers::admin::backup::backup_routes())
         .layer(axum_middleware::from_fn(
             crate::middleware::auth::admin_auth,
         ));

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,9 +160,11 @@ async fn main() -> anyhow::Result<()> {
             BackupCommands::Restore { filename } => {
                 cli::handle_backup_restore(&config, &filename).await
             }
-            BackupCommands::RestorePitr { timestamp } => {
-                cli::handle_backup_restore_pitr(&config, &timestamp).await
-            }
+            BackupCommands::RestorePitr {
+                timestamp,
+                dry_run,
+                yes,
+            } => cli::handle_backup_restore_pitr(&config, &timestamp, dry_run, yes).await,
             BackupCommands::Cleanup => cli::handle_backup_cleanup(&config).await,
         },
         Some(Commands::Config) => cli::handle_config_validate(&config),

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod circuit_breaker;
 pub mod compliance;
 pub mod feature_flags;
 pub mod lock_manager;
+pub mod pitr;
 pub mod processor;
 pub mod query_cache;
 pub mod reconciliation;

--- a/src/services/pitr.rs
+++ b/src/services/pitr.rs
@@ -1,0 +1,455 @@
+//! Point-in-time-recovery (PITR) restore orchestration.
+//!
+//! A PITR restore is long-running and destructive, so it is modelled as an
+//! async job persisted in `pitr_restore_jobs`: submitting a restore inserts a
+//! row and (for real, non-dry-run restores) spawns a background task that
+//! drives the row through `pending -> running -> succeeded|failed`. Callers
+//! poll [`PitrService::get_job`] for progress instead of blocking on the
+//! request thread.
+//!
+//! Target-timestamp validity is checked against the coverage window implied
+//! by `backup_verification_logs`: the earliest and latest `latest_timestamp`
+//! among rows with `verification_status = 'verified'` bound the range of
+//! points we can confidently recover to. A target outside that window (or a
+//! target when no backup has ever been verified) is rejected before any job
+//! is spawned.
+
+use crate::db::audit::{AuditLog, ENTITY_BACKUP};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::PgPool;
+use std::path::PathBuf;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub const STATUS_PENDING: &str = "pending";
+pub const STATUS_RUNNING: &str = "running";
+pub const STATUS_SUCCEEDED: &str = "succeeded";
+pub const STATUS_FAILED: &str = "failed";
+
+#[derive(Debug, thiserror::Error)]
+pub enum PitrError {
+    #[error("{0}")]
+    InvalidTarget(String),
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+}
+
+/// The window of timestamps we can currently restore to, derived from
+/// verified backups.
+#[derive(Debug, Clone, Copy)]
+pub struct PitrCoverage {
+    pub earliest: DateTime<Utc>,
+    pub latest: DateTime<Utc>,
+}
+
+/// Compute the current PITR coverage window from `backup_verification_logs`.
+/// Returns `None` when no backup has ever been successfully verified.
+pub async fn get_pitr_coverage(pool: &PgPool) -> Result<Option<PitrCoverage>, sqlx::Error> {
+    let row: (Option<DateTime<Utc>>, Option<DateTime<Utc>>) = sqlx::query_as(
+        "SELECT MIN(latest_timestamp), MAX(latest_timestamp) FROM backup_verification_logs \
+         WHERE verification_status = 'verified' AND latest_timestamp IS NOT NULL",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    Ok(match row {
+        (Some(earliest), Some(latest)) => Some(PitrCoverage { earliest, latest }),
+        _ => None,
+    })
+}
+
+/// Validate a target restore timestamp against the current coverage window.
+/// Returns a specific, actionable error message on rejection rather than
+/// silently clamping to the nearest available point.
+pub fn validate_target_timestamp(
+    target: DateTime<Utc>,
+    now: DateTime<Utc>,
+    coverage: Option<&PitrCoverage>,
+) -> Result<(), String> {
+    if target > now {
+        return Err(format!(
+            "target timestamp {target} is in the future; the latest possible recovery point is now ({now})"
+        ));
+    }
+
+    let coverage = coverage.ok_or_else(|| {
+        "no verified backups are available for point-in-time recovery; run backup verification \
+         before attempting a restore"
+            .to_string()
+    })?;
+
+    if target < coverage.earliest {
+        return Err(format!(
+            "target timestamp {target} is before the earliest available recovery point \
+             ({}); the oldest verified backup only covers data from that point onward",
+            coverage.earliest
+        ));
+    }
+
+    if target > coverage.latest {
+        return Err(format!(
+            "target timestamp {target} is after the latest available recovery point \
+             ({}); WAL/backup coverage does not yet extend that far",
+            coverage.latest
+        ));
+    }
+
+    Ok(())
+}
+
+/// A persisted PITR restore attempt.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+pub struct RestoreJob {
+    pub id: Uuid,
+    pub target_timestamp: DateTime<Utc>,
+    pub status: String,
+    pub dry_run: bool,
+    pub requested_by: String,
+    pub detail: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+const RESTORE_JOB_COLUMNS: &str = "id, target_timestamp, status, dry_run, requested_by, \
+     detail, error_message, created_at, started_at, completed_at";
+
+/// Performs the actual restore mechanics. Kept as a trait so the async job
+/// machinery (validation, persistence, status polling, audit logging) can be
+/// exercised in tests without invoking real `pg_basebackup`/WAL-replay
+/// tooling, which needs a dedicated environment (see `scripts/pitr_restore.sh`).
+#[async_trait]
+pub trait PitrExecutor: Send + Sync {
+    /// Perform the restore to `target_timestamp`. Returns a human-readable
+    /// detail message on success, or a human-readable error on failure.
+    async fn restore(&self, target_timestamp: DateTime<Utc>) -> Result<String, String>;
+}
+
+/// Default executor: shells out to an external restore script. Real
+/// Postgres PITR (pg_basebackup + WAL replay + recovery_target_time) needs
+/// server-side binaries and access to the archived WAL, which live outside
+/// this process's container — see `scripts/pitr_restore.sh` for the
+/// documented contract the script is expected to fulfil.
+pub struct ShellPitrExecutor {
+    script: PathBuf,
+    database_url: String,
+    workspace_dir: PathBuf,
+    wal_archive_dir: PathBuf,
+}
+
+impl ShellPitrExecutor {
+    /// Builds an executor from environment configuration. The restore script
+    /// runs as a separate process, so it needs its own explicit connection
+    /// string rather than reusing the app's already-resolved `PgPool` —
+    /// `PITR_DATABASE_URL` takes precedence, falling back to `DATABASE_URL`
+    /// (matches how the app itself resolves its primary connection string
+    /// outside of Vault-based secret injection).
+    pub fn from_env() -> Self {
+        let database_url = std::env::var("PITR_DATABASE_URL")
+            .or_else(|_| std::env::var("DATABASE_URL"))
+            .unwrap_or_default();
+
+        Self {
+            script: std::env::var("PITR_RESTORE_SCRIPT")
+                .unwrap_or_else(|_| "scripts/pitr_restore.sh".to_string())
+                .into(),
+            database_url,
+            workspace_dir: std::env::var("PITR_WORKSPACE_DIR")
+                .unwrap_or_else(|_| "./pitr_workspace".to_string())
+                .into(),
+            wal_archive_dir: std::env::var("WAL_ARCHIVE_DIR")
+                .unwrap_or_else(|_| "/var/lib/postgresql/wal_archive".to_string())
+                .into(),
+        }
+    }
+}
+
+#[async_trait]
+impl PitrExecutor for ShellPitrExecutor {
+    async fn restore(&self, target_timestamp: DateTime<Utc>) -> Result<String, String> {
+        let output = tokio::process::Command::new(&self.script)
+            .arg(target_timestamp.to_rfc3339())
+            .arg(&self.database_url)
+            .arg(&self.workspace_dir)
+            .arg(&self.wal_archive_dir)
+            .output()
+            .await
+            .map_err(|e| {
+                format!(
+                    "failed to launch PITR restore script {}: {e}",
+                    self.script.display()
+                )
+            })?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            if stderr.is_empty() {
+                Err(format!(
+                    "PITR restore script exited with status {}",
+                    output.status
+                ))
+            } else {
+                Err(stderr)
+            }
+        }
+    }
+}
+
+pub struct PitrService {
+    pool: PgPool,
+    executor: Arc<dyn PitrExecutor>,
+}
+
+impl PitrService {
+    pub fn new(pool: PgPool, executor: Arc<dyn PitrExecutor>) -> Self {
+        Self { pool, executor }
+    }
+
+    /// Validate and record a restore request. For `dry_run` requests the job
+    /// resolves immediately with no destructive action taken. For real
+    /// restores a background task is spawned so this call returns as soon as
+    /// the job is persisted — the caller polls [`Self::get_job`] for
+    /// completion.
+    pub async fn submit_restore(
+        &self,
+        target: DateTime<Utc>,
+        requested_by: &str,
+        dry_run: bool,
+    ) -> Result<RestoreJob, PitrError> {
+        let coverage = get_pitr_coverage(&self.pool).await?;
+        let now = Utc::now();
+        let validation = validate_target_timestamp(target, now, coverage.as_ref());
+
+        let initial_status = if validation.is_err() {
+            STATUS_FAILED
+        } else {
+            STATUS_PENDING
+        };
+        let rejection_reason = validation.as_ref().err().cloned();
+
+        let mut tx = self.pool.begin().await?;
+        let job: RestoreJob = sqlx::query_as(&format!(
+            "INSERT INTO pitr_restore_jobs \
+             (target_timestamp, status, dry_run, requested_by, error_message, completed_at) \
+             VALUES ($1, $2, $3, $4, $5, CASE WHEN $2 = '{STATUS_FAILED}' THEN NOW() ELSE NULL END) \
+             RETURNING {RESTORE_JOB_COLUMNS}"
+        ))
+        .bind(target)
+        .bind(initial_status)
+        .bind(dry_run)
+        .bind(requested_by)
+        .bind(rejection_reason.as_deref())
+        .fetch_one(&mut *tx)
+        .await?;
+
+        AuditLog::log(
+            &mut tx,
+            job.id,
+            ENTITY_BACKUP,
+            if validation.is_err() {
+                "pitr_restore_rejected"
+            } else {
+                "pitr_restore_submitted"
+            },
+            None,
+            Some(json!({
+                "target_timestamp": target,
+                "dry_run": dry_run,
+                "reason": rejection_reason,
+            })),
+            requested_by,
+        )
+        .await?;
+
+        tx.commit().await?;
+
+        if let Err(msg) = validation {
+            return Err(PitrError::InvalidTarget(msg));
+        }
+
+        if dry_run {
+            let coverage = coverage.expect("validated target implies coverage exists");
+            let detail = format!(
+                "dry run: target timestamp {target} is within available recovery coverage \
+                 [{}, {}]; no restore was performed",
+                coverage.earliest, coverage.latest
+            );
+            Self::finish_job(
+                &self.pool,
+                job.id,
+                STATUS_SUCCEEDED,
+                Some(&detail),
+                None,
+                requested_by,
+            )
+            .await?;
+            return Ok(self
+                .get_job(job.id)
+                .await?
+                .expect("job was just inserted and finished"));
+        }
+
+        let pool = self.pool.clone();
+        let executor = self.executor.clone();
+        let job_id = job.id;
+        let actor = requested_by.to_string();
+        tokio::spawn(async move {
+            if sqlx::query(
+                "UPDATE pitr_restore_jobs SET status = $1, started_at = NOW() WHERE id = $2",
+            )
+            .bind(STATUS_RUNNING)
+            .bind(job_id)
+            .execute(&pool)
+            .await
+            .is_err()
+            {
+                tracing::error!(job_id = %job_id, "failed to mark PITR restore job as running");
+                return;
+            }
+
+            let result = executor.restore(target).await;
+            let (status, detail, error) = match &result {
+                Ok(detail) => (STATUS_SUCCEEDED, Some(detail.as_str()), None),
+                Err(err) => (STATUS_FAILED, None, Some(err.as_str())),
+            };
+
+            if let Err(e) = Self::finish_job(&pool, job_id, status, detail, error, &actor).await {
+                tracing::error!(job_id = %job_id, error = %e, "failed to record PITR restore job completion");
+            }
+        });
+
+        Ok(job)
+    }
+
+    pub async fn get_job(&self, id: Uuid) -> Result<Option<RestoreJob>, sqlx::Error> {
+        sqlx::query_as(&format!(
+            "SELECT {RESTORE_JOB_COLUMNS} FROM pitr_restore_jobs WHERE id = $1"
+        ))
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
+    async fn finish_job(
+        pool: &PgPool,
+        job_id: Uuid,
+        status: &str,
+        detail: Option<&str>,
+        error_message: Option<&str>,
+        actor: &str,
+    ) -> Result<(), sqlx::Error> {
+        let mut tx = pool.begin().await?;
+
+        sqlx::query(
+            "UPDATE pitr_restore_jobs SET status = $1, detail = $2, error_message = $3, \
+             completed_at = NOW() WHERE id = $4",
+        )
+        .bind(status)
+        .bind(detail)
+        .bind(error_message)
+        .bind(job_id)
+        .execute(&mut *tx)
+        .await?;
+
+        AuditLog::log(
+            &mut tx,
+            job_id,
+            ENTITY_BACKUP,
+            "pitr_restore_completed",
+            None,
+            Some(json!({
+                "status": status,
+                "detail": detail,
+                "error": error_message,
+            })),
+            actor,
+        )
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, TimeZone};
+
+    fn ts(y: i32, m: u32, d: u32) -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(y, m, d, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn test_validate_rejects_future_timestamp() {
+        let now = ts(2026, 6, 1);
+        let target = now + Duration::days(1);
+        let err = validate_target_timestamp(target, now, None).unwrap_err();
+        assert!(err.contains("in the future"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_validate_rejects_when_no_coverage() {
+        let now = ts(2026, 6, 1);
+        let err = validate_target_timestamp(ts(2026, 5, 1), now, None).unwrap_err();
+        assert!(
+            err.contains("no verified backups"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_before_earliest() {
+        let now = ts(2026, 6, 1);
+        let coverage = PitrCoverage {
+            earliest: ts(2026, 5, 1),
+            latest: ts(2026, 5, 20),
+        };
+        let err = validate_target_timestamp(ts(2026, 4, 1), now, Some(&coverage)).unwrap_err();
+        assert!(
+            err.contains("before the earliest available recovery point"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_after_latest() {
+        let now = ts(2026, 6, 1);
+        let coverage = PitrCoverage {
+            earliest: ts(2026, 5, 1),
+            latest: ts(2026, 5, 20),
+        };
+        let err = validate_target_timestamp(ts(2026, 5, 25), now, Some(&coverage)).unwrap_err();
+        assert!(
+            err.contains("after the latest available recovery point"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_target_within_coverage() {
+        let now = ts(2026, 6, 1);
+        let coverage = PitrCoverage {
+            earliest: ts(2026, 5, 1),
+            latest: ts(2026, 5, 20),
+        };
+        assert!(validate_target_timestamp(ts(2026, 5, 10), now, Some(&coverage)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_accepts_coverage_boundaries_inclusive() {
+        let now = ts(2026, 6, 1);
+        let coverage = PitrCoverage {
+            earliest: ts(2026, 5, 1),
+            latest: ts(2026, 5, 20),
+        };
+        assert!(validate_target_timestamp(coverage.earliest, now, Some(&coverage)).is_ok());
+        assert!(validate_target_timestamp(coverage.latest, now, Some(&coverage)).is_ok());
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -23,7 +23,7 @@ pub use rate_limiting::{
     TelemetryRateLimitConfig, TelemetryRateLimitMetrics, TelemetryRateLimiter,
 };
 pub use reconnection::ReconnectionManager;
-pub use webhook::{TelemetryWebhookHandler, WebhookPayload, WebhookResult};
+pub use webhook::{TelemetryWebhookHandler, WebhookEventPayload, WebhookResult};
 
 // ---------------------------------------------------------------------------
 // OpenTelemetry tracer initialisation.

--- a/src/telemetry/webhook.rs
+++ b/src/telemetry/webhook.rs
@@ -148,7 +148,7 @@ impl TelemetryWebhookHandler {
         self.verify_signature(body, signature)?;
 
         // 3. Deserialize.
-        let payload: WebhookPayload = serde_json::from_slice(body).map_err(|e| {
+        let payload: WebhookEventPayload = serde_json::from_slice(body).map_err(|e| {
             TelemetryError::ValidationError(
                 crate::telemetry::input_validation::ValidationError::InvalidFormat(format!(
                     "invalid JSON: {}",
@@ -248,7 +248,7 @@ impl TelemetryWebhookHandler {
     }
 
     /// Validates all string fields in the payload.
-    fn validate_payload(&self, payload: &WebhookPayload) -> Result<(), TelemetryError> {
+    fn validate_payload(&self, payload: &WebhookEventPayload) -> Result<(), TelemetryError> {
         // source and event_type must be valid identifiers.
         InputValidator::validate_span_name(&payload.source)?;
         InputValidator::validate_span_name(&payload.event_type)?;

--- a/tests/pitr_restore_test.rs
+++ b/tests/pitr_restore_test.rs
@@ -1,0 +1,356 @@
+//! Integration tests for the PITR (point-in-time-recovery) backup restore
+//! admin API: POST /admin/backup/restore-pitr and
+//! GET /admin/backup/restore-pitr/:job_id.
+//!
+//! ## Scope
+//!
+//! These tests exercise the full HTTP stack against a real, testcontainers
+//! Postgres: admin-auth enforcement, target-timestamp validation against
+//! `backup_verification_logs` coverage, job persistence and the async
+//! `tokio::spawn` state machine, status polling, and audit-log writes.
+//!
+//! What they deliberately do **not** exercise is a real `pg_basebackup` +
+//! WAL-replay restore. That needs a second Postgres data directory, the
+//! `postgres`/`pg_ctl`/`pg_basebackup` server binaries, and filesystem
+//! access to an archived WAL directory (see the doc comment at the top of
+//! `scripts/pitr_restore.sh` for the full contract) — none of which a
+//! single testcontainer or this CI environment provides, and actually
+//! invoking it would mean tearing down/rebuilding a Postgres instance per
+//! test run, which is exactly the kind of destructive, slow operation
+//! integration tests shouldn't be doing.
+//!
+//! Instead, the job-lifecycle tests point `PITR_RESTORE_SCRIPT` at a small
+//! stub executable that honors the same contract the real script does
+//! (exit 0 + stdout => success, exit != 0 + stderr => failure). This still
+//! exercises the real `tokio::process::Command` invocation and the entire
+//! orchestration path around it identically to production; only the
+//! restore mechanics inside the script differ.
+
+mod common;
+
+use chrono::{DateTime, Duration, Utc};
+use serde_json::{json, Value};
+use sqlx::{PgPool, Row};
+use std::os::unix::fs::PermissionsExt;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+const ADMIN_KEY: &str = "test-admin-key-for-pitr";
+
+/// `PITR_RESTORE_SCRIPT` is process-global; serialize the tests that touch
+/// it so they don't race each other (mirrors the pattern in
+/// `src/db/audit.rs`'s own env-var tests). An async-aware mutex so it's
+/// safe to hold across the `.await` points in the test bodies below.
+static ENV_LOCK: Mutex<()> = Mutex::const_new(());
+
+async fn seed_verified_backup(pool: &PgPool, filename: &str, latest_timestamp: DateTime<Utc>) {
+    sqlx::query(
+        "INSERT INTO backup_verification_logs \
+         (backup_filename, verification_status, row_count, latest_timestamp) \
+         VALUES ($1, 'verified', 100, $2)",
+    )
+    .bind(filename)
+    .bind(latest_timestamp)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn write_fake_script(dir: &TempDir, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    std::fs::write(&path, body).unwrap();
+    let mut perms = std::fs::metadata(&path).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&path, perms).unwrap();
+    path
+}
+
+async fn poll_job_until_terminal(client: &reqwest::Client, poll_url: &str) -> Value {
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        let resp = client
+            .get(poll_url)
+            .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+            .send()
+            .await
+            .unwrap();
+        let body: Value = resp.json().await.unwrap();
+        let status = body["status"].as_str().unwrap_or("");
+        if status == "succeeded" || status == "failed" {
+            return body;
+        }
+    }
+    panic!("job did not reach a terminal state within the poll window");
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_requires_admin_auth() {
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let app = common::TestApp::new().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .json(&json!({"target_timestamp": Utc::now().to_rfc3339(), "dry_run": true}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 401);
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_rejects_when_no_verified_backups() {
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let app = common::TestApp::new().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({"target_timestamp": Utc::now().to_rfc3339(), "dry_run": true}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    let detail = body["detail"].as_str().unwrap_or_default();
+    assert!(
+        detail.contains("no verified backups"),
+        "unexpected error detail: {detail}"
+    );
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_rejects_out_of_range_timestamps() {
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let app = common::TestApp::new().await;
+
+    let earliest = Utc::now() - Duration::days(10);
+    let latest = Utc::now() - Duration::hours(6);
+    seed_verified_backup(&app.pool, "backup_a.sql.gz", earliest).await;
+    seed_verified_backup(&app.pool, "backup_b.sql.gz", latest).await;
+
+    let client = reqwest::Client::new();
+
+    // Before the earliest verified backup.
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({
+            "target_timestamp": (earliest - Duration::days(5)).to_rfc3339(),
+            "dry_run": true,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["detail"]
+        .as_str()
+        .unwrap()
+        .contains("before the earliest available recovery point"));
+
+    // After the latest verified backup, but still in the past (distinct from
+    // the future-timestamp check).
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({
+            "target_timestamp": (latest + Duration::hours(3)).to_rfc3339(),
+            "dry_run": true,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["detail"]
+        .as_str()
+        .unwrap()
+        .contains("after the latest available recovery point"));
+
+    // Both rejected attempts must still be traceable in the audit log.
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_logs WHERE action = 'pitr_restore_rejected'",
+    )
+    .fetch_one(&app.pool)
+    .await
+    .unwrap();
+    assert_eq!(count, 2);
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_dry_run_succeeds_and_writes_audit_log() {
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let app = common::TestApp::new().await;
+
+    let earliest = Utc::now() - Duration::days(10);
+    let latest = Utc::now() - Duration::hours(1);
+    seed_verified_backup(&app.pool, "backup_a.sql.gz", earliest).await;
+    seed_verified_backup(&app.pool, "backup_b.sql.gz", latest).await;
+
+    let target = earliest + Duration::days(2);
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({
+            "target_timestamp": target.to_rfc3339(),
+            "dry_run": true,
+            "requested_by": "alice",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 202);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "succeeded");
+    assert_eq!(body["dry_run"], true);
+    assert!(body["detail"].as_str().unwrap().contains("dry run"));
+
+    let job_id: Uuid = body["id"].as_str().unwrap().parse().unwrap();
+
+    let rows = sqlx::query(
+        "SELECT actor, action FROM audit_logs WHERE entity_id = $1 ORDER BY timestamp ASC",
+    )
+    .bind(job_id)
+    .fetch_all(&app.pool)
+    .await
+    .unwrap();
+
+    assert!(!rows.is_empty(), "expected at least one audit log entry");
+    assert!(rows.iter().all(|r| r.get::<String, _>("actor") == "alice"));
+    let actions: Vec<String> = rows.iter().map(|r| r.get::<String, _>("action")).collect();
+    assert!(actions.contains(&"pitr_restore_submitted".to_string()));
+    assert!(actions.contains(&"pitr_restore_completed".to_string()));
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_job_lifecycle_succeeds_with_stub_executor() {
+    let _guard = ENV_LOCK.lock().await;
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let script_dir = TempDir::new().unwrap();
+    let script = write_fake_script(
+        &script_dir,
+        "fake_restore_success.sh",
+        "#!/bin/sh\necho 'fake restore completed'\nexit 0\n",
+    );
+    std::env::set_var("PITR_RESTORE_SCRIPT", &script);
+
+    let app = common::TestApp::new().await;
+    let earliest = Utc::now() - Duration::days(10);
+    let latest = Utc::now() - Duration::hours(1);
+    seed_verified_backup(&app.pool, "backup_a.sql.gz", earliest).await;
+    seed_verified_backup(&app.pool, "backup_b.sql.gz", latest).await;
+
+    let target = earliest + Duration::days(1);
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({
+            "target_timestamp": target.to_rfc3339(),
+            "dry_run": false,
+            "requested_by": "bob",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 202);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], "pending");
+    let job_id = body["id"].as_str().unwrap().to_string();
+
+    let poll_url = format!("{}/admin/backup/restore-pitr/{job_id}", app.base_url);
+    let final_body = poll_job_until_terminal(&client, &poll_url).await;
+
+    assert_eq!(final_body["status"], "succeeded");
+    assert_eq!(final_body["detail"], "fake restore completed");
+
+    let completed_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_logs WHERE entity_id = $1 AND action = 'pitr_restore_completed'",
+    )
+    .bind(Uuid::parse_str(&job_id).unwrap())
+    .fetch_one(&app.pool)
+    .await
+    .unwrap();
+    assert_eq!(completed_count, 1);
+
+    std::env::remove_var("PITR_RESTORE_SCRIPT");
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_job_lifecycle_records_failure_with_stub_executor() {
+    let _guard = ENV_LOCK.lock().await;
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let script_dir = TempDir::new().unwrap();
+    let script = write_fake_script(
+        &script_dir,
+        "fake_restore_failure.sh",
+        "#!/bin/sh\necho 'simulated restore failure' >&2\nexit 1\n",
+    );
+    std::env::set_var("PITR_RESTORE_SCRIPT", &script);
+
+    let app = common::TestApp::new().await;
+    let earliest = Utc::now() - Duration::days(10);
+    let latest = Utc::now() - Duration::hours(1);
+    seed_verified_backup(&app.pool, "backup_a.sql.gz", earliest).await;
+    seed_verified_backup(&app.pool, "backup_b.sql.gz", latest).await;
+
+    let target = earliest + Duration::days(1);
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/admin/backup/restore-pitr", app.base_url))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .json(&json!({
+            "target_timestamp": target.to_rfc3339(),
+            "dry_run": false,
+            "requested_by": "carol",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let body: Value = resp.json().await.unwrap();
+    let job_id = body["id"].as_str().unwrap().to_string();
+
+    let poll_url = format!("{}/admin/backup/restore-pitr/{job_id}", app.base_url);
+    let final_body = poll_job_until_terminal(&client, &poll_url).await;
+
+    assert_eq!(final_body["status"], "failed");
+    assert_eq!(final_body["error_message"], "simulated restore failure");
+
+    std::env::remove_var("PITR_RESTORE_SCRIPT");
+}
+
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_restore_pitr_unknown_job_id_returns_404() {
+    std::env::set_var("ADMIN_API_KEY", ADMIN_KEY);
+    let app = common::TestApp::new().await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "{}/admin/backup/restore-pitr/{}",
+            app.base_url,
+            Uuid::new_v4()
+        ))
+        .header("Authorization", format!("Bearer {ADMIN_KEY}"))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 404);
+}


### PR DESCRIPTION


# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #778

## Type of Change
Builds the point-in-time-recovery restore path the handle_backup_restore_pitr stub was scaffolded for:

- POST /admin/backup/restore-pitr validates the target timestamp against coverage derived from backup_verification_logs, rejects out-of-range timestamps with a specific error, and submits the restore as an async job (pitr_restore_jobs table) so the request thread never blocks on a long-running, destructive operation.
- GET /admin/backup/restore-pitr/:job_id polls job status/detail/error.
- Both routes sit behind the existing admin_auth middleware.
- Every attempt (rejected, dry-run, submitted, completed) is written to the audit_logs table with who/when/target timestamp/outcome.
- The actual restore mechanics are delegated to a pluggable PitrExecutor; the default shells out to scripts/pitr_restore.sh, which streams a fresh pg_basebackup and replays archived WAL up to the target time into a separate recovered instance for verification/promotion (deliberately does not auto-cut-over the live primary).
- docker-compose.yml now actually turns on archive_mode/archive_command so the existing postgres_wal volume gets populated, and mounts it read-only into the app service; the runtime image gains matching postgresql-14 client/server binaries for the restore script.
- `synapse-core backup restore-pitr --timestamp <TS> [--dry-run] [--yes]` is wired to submit the request and poll until it completes or fails; a live restore is refused client-side without --yes.
- Removes the #[allow(dead_code)] since the handler is now reachable.
- Integration tests (tests/pitr_restore_test.rs) exercise the full HTTP stack against testcontainers Postgres: auth, coverage validation, the async job state machine (via a stub executor honoring the same exit-code/stdout contract as the real script), status polling, and audit logging.

Also fixes a pre-existing WebhookPayload/WebhookEventPayload naming mismatch in src/telemetry that broke `cargo check` on main.
<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the main changes in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Migration Safety (if applicable)

<!-- For PRs that include database migrations -->

- [ ] Migration safety checker passes (`./scripts/check-migration-safety.sh`)
- [ ] Migration follows safe patterns (see [docs/migration-safety.md](../docs/migration-safety.md))
- [ ] Migration tested with rollback
- [ ] Migration documented in PR description

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the style guidelines ([CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Pre-Submission Checks

<!-- All four checks must pass before submitting -->

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->
