### PR TITLE
Refactor: Remove CLI redefinition of HealthStatus

### DIFF
--- a/cli/synapse-cli/Cargo.toml
+++ b/cli/synapse-cli/Cargo.toml
@@ -28,6 +28,8 @@ futures-util = "0.3"
 # Kept in lockstep with the root crate's tokio-tungstenite version — see the
 # comment there for why (axum 0.6's `ws` feature vendors tokio-tungstenite 0.20).
 tokio-tungstenite = "0.20"
+# Option A: use the canonical API response types directly from the core crate.
+synapse-core = { path = "../.." }
 
 [dev-dependencies]
 assert_cmd = "2"
@@ -36,8 +38,4 @@ predicates = "3"
 regex = "1"
 tempfile = "3"
 wiremock = "0.5"
-# Real-server integration test (tests/events_watch_real_server_test.rs): boots
-# the actual synapse-core axum app in-process and drives the real `synapse`
-# CLI binary against its /ws endpoint.
-synapse-core = { path = "../.." }
 axum = "0.6"

--- a/cli/synapse-cli/src/commands/health.rs
+++ b/cli/synapse-cli/src/commands/health.rs
@@ -4,6 +4,10 @@ use anyhow::Result;
 use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 
+// Option A: depend on synapse-core so the API handler remains the single source
+// of truth. `pub use` preserves the CLI module's existing public type path.
+pub use synapse_core::handlers::HealthStatus;
+
 // ── Response types (mirrors src/handlers/mod.rs) ──────────────────────────────
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -15,25 +19,6 @@ pub struct LivenessResponse {
 pub struct ReadinessResponse {
     pub status: String,
     pub draining: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct HealthStatus {
-    pub status: String,
-    pub version: String,
-    pub db: String,
-    pub db_pool: DbPoolStats,
-    pub pending_queue_depth: u64,
-    pub current_batch_size: u64,
-    pub ws_connection_count: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DbPoolStats {
-    pub active_connections: u32,
-    pub idle_connections: u32,
-    pub max_connections: u32,
-    pub usage_percent: f32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
# Pull Request

## Description

Removes the duplicate `HealthStatus` definition from the Synapse CLI and reuses the canonical API response type from `synapse-core`.

This implements Option A from the issue. The CLI now depends directly on `synapse-core` and publicly re-exports `synapse_core::handlers::HealthStatus`, preserving the existing CLI module path for downstream callers.

The separate auth-specific `HealthStatus` in `src/auth/health.rs` remains unchanged.

## Related Issue

Closes #803

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

- Promoted `synapse-core` from a CLI development dependency to a normal dependency.
- Removed the duplicate CLI definitions of `HealthStatus` and `DbPoolStats`.
- Re-exported `synapse_core::handlers::HealthStatus` from the CLI health module to preserve its existing public path.
- Documented the selection of Option A in the manifest and health command source.
- Left the intentionally different auth-specific health status type unchanged.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] All existing tests pass

Commands used:

```bash
cargo fmt --all -- --check
cargo test -p synapse-cli --lib commands::health::tests
cargo test -p synapse-cli