### PR TITLE
Revert "feat:Build a graceful, auto-detecting test infrastructure layer instead of a hard testcontainers dependency"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,21 +108,6 @@ DATABASE_URL=postgres://synapse:synapse@localhost:5432/synapse_test cargo test
 
 NOTE: Some warnings about unused imports or dead code are expected – they correspond to features planned for future issues.
 
-#### Integration tests (`tests/`)
-
-Tests built on `tests/common::TestApp` (health checks, lifecycle, etc.) auto-detect test infra in this order: `TEST_DATABASE_URL`/`TEST_REDIS_URL` env vars pointing at infra you already have running, then a fresh `testcontainers` Postgres if Docker is reachable, then a clear failure message if neither is available.
-
-Reuse the docker-compose stack instead of paying the testcontainer startup cost on every run:
-
-```bash
-docker compose up -d postgres redis
-TEST_DATABASE_URL=postgres://synapse:synapse@localhost:5432/synapse \
-TEST_REDIS_URL=redis://localhost:6379 \
-cargo test
-```
-
-See [docs/setup.md](docs/setup.md#integration-tests-tests) for details and measured before/after timings.
-
 ## 📊 Database Partitioning
 
 The `transactions` table uses time-based partitioning for high-volume scaling:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,24 +6,11 @@ services:
       POSTGRES_USER: synapse
       POSTGRES_PASSWORD: synapse
       POSTGRES_DB: synapse
-    # wal_level/max_wal_senders/max_replication_slots make pg_basebackup
-    # streaming possible; archive_mode+archive_command actually populate
-    # postgres_wal so point-in-time recovery has WAL to replay beyond the
-    # latest base backup (see scripts/pitr_restore.sh). These are PGC_POSTMASTER
-    # settings (server start, not `initdb`), so they're passed as `postgres -c`
-    # flags rather than POSTGRES_INITDB_ARGS — `initdb` doesn't accept `-c`.
-    command:
-      - postgres
-      - -c
-      - wal_level=replica
-      - -c
-      - max_wal_senders=3
-      - -c
-      - max_replication_slots=3
-      - -c
-      - archive_mode=on
-      - -c
-      - archive_command=test ! -f /var/lib/postgresql/wal_archive/%f && cp %p /var/lib/postgresql/wal_archive/%f
+      # wal_level/max_wal_senders/max_replication_slots make pg_basebackup
+      # streaming possible; archive_mode+archive_command actually populate
+      # postgres_wal so point-in-time recovery has WAL to replay beyond the
+      # latest base backup (see scripts/pitr_restore.sh).
+      POSTGRES_INITDB_ARGS: "-c wal_level=replica -c max_wal_senders=3 -c max_replication_slots=3 -c archive_mode=on -c archive_command='test ! -f /var/lib/postgresql/wal_archive/%f && cp %p /var/lib/postgresql/wal_archive/%f'"
     ports:
       - "5432:5432"
     volumes:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -170,34 +170,6 @@ DATABASE_URL=postgres://synapse:synapse@localhost:5432/synapse_test cargo test
 
 > **Note:** Some warnings about unused imports or dead code are expected — they correspond to features planned for future issues.
 
-### Integration Tests (`tests/`)
-
-Integration tests built on `tests/common::TestApp` (health checks, lifecycle, PITR restore, etc.)
-need their own Postgres/Redis. `TestApp::new()` looks for infra in this order:
-
-1. `TEST_DATABASE_URL` / `TEST_REDIS_URL`, if set — reuses whatever you already have running.
-2. A fresh `testcontainers` Postgres, if Docker is reachable (Redis is not auto-started this way —
-   see below).
-3. Otherwise it fails fast with a message naming exactly what's missing and how to fix it.
-
-For iterative local runs, start the stack once and point tests at it instead of paying the
-testcontainer startup cost (container create + Postgres boot) on every test binary:
-
-```bash
-docker compose up -d postgres redis
-
-TEST_DATABASE_URL=postgres://synapse:synapse@localhost:5432/synapse \
-TEST_REDIS_URL=redis://localhost:6379 \
-cargo test
-```
-
-This makes a real difference: each `#[tokio::test]` in `health_check_test.rs` calls
-`TestApp::new()` independently, so on a Docker-only fallback every test pays for its own Postgres
-container. Measured locally, `cargo test --test health_check_test` went from ~61s (fresh
-testcontainer per test) to ~9s (reusing `docker compose up -d postgres redis`). If you don't set
-`TEST_DATABASE_URL`/`TEST_REDIS_URL` and don't have Docker running, tests fail fast with a message
-naming exactly what's missing instead of a raw `testcontainers` or Docker-daemon error.
-
 ### Lint & Format
 
 ```bash

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,63 +12,36 @@
 //!     assert_eq!(res.status(), 200);
 //! }
 //! ```
-//!
-//! # Test infrastructure
-//!
-//! `TestApp::new()` looks for Postgres in this order:
-//!   1. `TEST_DATABASE_URL` — an already-running instance you provisioned yourself
-//!      (e.g. `docker compose up -d postgres`, or a CI service container).
-//!   2. A fresh `testcontainers` Postgres, if Docker is reachable.
-//!   3. Otherwise it panics with a message naming exactly what's missing and how
-//!      to fix it — no raw `testcontainers`/Docker-daemon error should ever reach
-//!      the test output.
-//!
-//! Redis is resolved similarly via `TEST_REDIS_URL`, falling back to the default
-//! `docker-compose.yml` port (`redis://127.0.0.1:6379`) rather than a testcontainer,
-//! since every other integration test in this suite assumes Redis lives at that
-//! fixed address (a random testcontainer port would silently desync from them).
-//!
-//! Reusing already-running infra (`docker compose up -d postgres redis`) avoids
-//! paying the testcontainer startup cost — image pull/start + Postgres boot — on
-//! every test binary, which is where most of the wall-clock savings come from
-//! when running the full `tests/` suite locally or in CI.
 
-use redis::Client as RedisClient;
 use sqlx::{migrate::Migrator, PgPool};
 use std::path::Path;
-use std::time::Duration;
 use synapse_core::{create_app, AppState};
-use testcontainers::core::client::docker_client_instance;
-use testcontainers::{runners::AsyncRunner, ContainerAsync, ImageExt};
+use testcontainers::{runners::AsyncRunner, ImageExt};
 use testcontainers_modules::postgres::Postgres;
-
-const TEST_DATABASE_URL_VAR: &str = "TEST_DATABASE_URL";
-const TEST_REDIS_URL_VAR: &str = "TEST_REDIS_URL";
-const DEFAULT_REDIS_URL: &str = "redis://127.0.0.1:6379";
-const COMPOSE_UP_CMD: &str = "docker compose up -d postgres redis";
-const DOCKER_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Test application with automatic database and HTTP server setup.
 pub struct TestApp {
     pub base_url: String,
     pub pool: PgPool,
-    #[allow(dead_code)]
-    pub redis_url: String,
     pub readiness: synapse_core::ReadinessState,
-    /// `Some` only when we started this container ourselves; `None` when we're
-    /// borrowing infra the caller already had running (nothing to tear down).
-    _postgres_container: Option<ContainerAsync<Postgres>>,
+    _postgres_container: Box<dyn std::any::Any>,
 }
 
 impl TestApp {
     /// Create a new test app with isolated Postgres database, migrations, and HTTP server.
-    ///
-    /// Reuses already-running Postgres/Redis when available (see module docs);
-    /// only falls back to a fresh `testcontainers` Postgres if Docker is reachable
-    /// and no `TEST_DATABASE_URL` was provided.
     pub async fn new() -> Self {
-        let (pool, database_url, postgres_container) = resolve_postgres().await;
-        let redis_url = resolve_redis().await;
+        let container = Postgres::default()
+            .with_tag("14-alpine")
+            .start()
+            .await
+            .unwrap();
+        let host_port = container.get_host_port_ipv4(5432).await.unwrap();
+        let database_url = format!(
+            "postgres://postgres:postgres@127.0.0.1:{}/postgres",
+            host_port
+        );
+
+        let pool = PgPool::connect(&database_url).await.unwrap();
 
         // Run migrations
         let migrator = Migrator::new(Path::join(
@@ -95,11 +68,11 @@ impl TestApp {
             feature_flags: synapse_core::services::feature_flags::FeatureFlagService::new(
                 pool.clone(),
             ),
-            redis_url: redis_url.clone(),
+            redis_url: "redis://localhost:6379".to_string(),
             start_time: std::time::Instant::now(),
             readiness: synapse_core::ReadinessState::new(),
             tx_broadcast,
-            query_cache: synapse_core::services::QueryCache::new(&redis_url)
+            query_cache: synapse_core::services::QueryCache::new("redis://localhost:6379")
                 .await
                 .unwrap(),
             profiling_manager: synapse_core::handlers::profiling::ProfilingManager::new(),
@@ -132,9 +105,8 @@ impl TestApp {
         Self {
             base_url,
             pool,
-            redis_url,
             readiness,
-            _postgres_container: postgres_container,
+            _postgres_container: Box::new(container),
         }
     }
 
@@ -173,7 +145,7 @@ impl TestApp {
                 partition_name := 'transactions_y' || TO_CHAR(partition_date, 'YYYY') || 'm' || TO_CHAR(partition_date, 'MM');
                 start_date := TO_CHAR(partition_date, 'YYYY-MM-DD');
                 end_date := TO_CHAR(partition_date + INTERVAL '1 month', 'YYYY-MM-DD');
-
+                
                 IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = partition_name) THEN
                     EXECUTE format(
                         'CREATE TABLE %I PARTITION OF transactions FOR VALUES FROM (%L) TO (%L)',
@@ -186,127 +158,4 @@ impl TestApp {
         .execute(pool)
         .await;
     }
-}
-
-/// Resolve a Postgres connection for tests, in priority order:
-/// 1. `TEST_DATABASE_URL`, if set — assumed to be caller-provisioned infra.
-/// 2. A fresh `testcontainers` Postgres, if Docker is reachable.
-/// 3. Panic with a specific, actionable message.
-async fn resolve_postgres() -> (PgPool, String, Option<ContainerAsync<Postgres>>) {
-    if let Ok(url) = std::env::var(TEST_DATABASE_URL_VAR) {
-        let pool = PgPool::connect(&url).await.unwrap_or_else(|err| {
-            panic!(
-                "{TEST_DATABASE_URL_VAR} is set to `{url}` but a connection could not be \
-                 established ({err}).\n\nFix: make sure that Postgres instance is running and \
-                 reachable, e.g.\n  {COMPOSE_UP_CMD}"
-            )
-        });
-        return (pool, url, None);
-    }
-
-    if !docker_available().await {
-        panic!(
-            "TestApp::new() needs Postgres for integration tests and found none.\n\n\
-             Checked, in order:\n  \
-             1. ${TEST_DATABASE_URL_VAR} — not set\n  \
-             2. Docker — daemon not reachable, so a Postgres testcontainer could not be started\n\n\
-             Fix one of:\n  \
-             - Start Docker, then re-run `cargo test`, or\n  \
-             - Reuse the Postgres from docker-compose.yml instead of paying the testcontainer \
-             startup cost on every run:\n      \
-             {COMPOSE_UP_CMD}\n      \
-             export {TEST_DATABASE_URL_VAR}=postgres://synapse:synapse@localhost:5432/synapse\n      \
-             cargo test"
-        );
-    }
-
-    let container = Postgres::default()
-        .with_tag("14-alpine")
-        .start()
-        .await
-        .unwrap_or_else(|err| {
-            panic!(
-                "Docker is reachable but starting a Postgres testcontainer failed ({err}).\n\n\
-                 Fix: point tests at a Postgres you already have running instead:\n  \
-                 {COMPOSE_UP_CMD}\n  \
-                 export {TEST_DATABASE_URL_VAR}=postgres://synapse:synapse@localhost:5432/synapse"
-            )
-        });
-    let host_port = container.get_host_port_ipv4(5432).await.unwrap();
-    let url = format!(
-        "postgres://postgres:postgres@127.0.0.1:{}/postgres",
-        host_port
-    );
-    let pool = PgPool::connect(&url).await.unwrap();
-    (pool, url, Some(container))
-}
-
-/// Resolve a Redis connection for tests, in priority order:
-/// 1. `TEST_REDIS_URL`, if set — assumed to be caller-provisioned infra.
-/// 2. The default docker-compose port (`redis://127.0.0.1:6379`), if something
-///    answers PING there.
-/// 3. Panic with a specific, actionable message.
-///
-/// Unlike Postgres, this does not fall back to a `testcontainers` Redis: every
-/// other integration test in this suite hardcodes `redis://127.0.0.1:6379`, so a
-/// container on a random port would silently desync from them rather than fail
-/// loudly.
-async fn resolve_redis() -> String {
-    if let Ok(url) = std::env::var(TEST_REDIS_URL_VAR) {
-        if let Err(err) = ping_redis(&url).await {
-            panic!(
-                "{TEST_REDIS_URL_VAR} is set to `{url}` but a connection could not be \
-                 established ({err}).\n\nFix: make sure Redis is running and reachable, e.g.\n  \
-                 {COMPOSE_UP_CMD}"
-            );
-        }
-        return url;
-    }
-
-    if ping_redis(DEFAULT_REDIS_URL).await.is_ok() {
-        return DEFAULT_REDIS_URL.to_string();
-    }
-
-    panic!(
-        "TestApp::new() needs Redis for integration tests and found none.\n\n\
-         Checked, in order:\n  \
-         1. ${TEST_REDIS_URL_VAR} — not set\n  \
-         2. {DEFAULT_REDIS_URL} — nothing answered PING\n\n\
-         Fix one of:\n  \
-         - Start Redis from docker-compose.yml:\n      \
-         {COMPOSE_UP_CMD}\n      \
-         cargo test\n  \
-         - Point tests at a Redis you already have running:\n      \
-         export {TEST_REDIS_URL_VAR}=redis://<host>:<port>\n      \
-         cargo test"
-    );
-}
-
-async fn ping_redis(url: &str) -> redis::RedisResult<()> {
-    let probe = async {
-        let client = RedisClient::open(url)?;
-        let mut con = client.get_async_connection().await?;
-        redis::cmd("PING").query_async::<_, String>(&mut con).await
-    };
-    match tokio::time::timeout(DOCKER_PROBE_TIMEOUT, probe).await {
-        Ok(result) => result.map(|_| ()),
-        Err(_) => Err(redis::RedisError::from((
-            redis::ErrorKind::IoError,
-            "timed out connecting to Redis",
-        ))),
-    }
-}
-
-/// Whether a Docker daemon is actually reachable (not just that the CLI/socket
-/// path is configured) — pings it with a short timeout so a misconfigured or
-/// hung `DOCKER_HOST` doesn't stall every test run.
-async fn docker_available() -> bool {
-    let probe = async {
-        let client = docker_client_instance().await.ok()?;
-        client.ping().await.ok()
-    };
-    matches!(
-        tokio::time::timeout(DOCKER_PROBE_TIMEOUT, probe).await,
-        Ok(Some(_))
-    )
 }


### PR DESCRIPTION
Reverts Synapse-bridgez/synapse-core#810