### PR TITLE
test: add real log capture assertions for sanitization tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ tokio-tungstenite = "0.20"
 assert_cmd = "2"
 assert_fs = "1"
 wiremock = "0.5"
+tracing-test = { version = "0.2", features = ["no-env-filter"] }
 
 [[bench]]
 name = "critical_paths"

--- a/tests/README_REQUEST_LOGGER.md
+++ b/tests/README_REQUEST_LOGGER.md
@@ -45,15 +45,21 @@ Tests request body logging when enabled:
 
 ### 7. `test_request_logging_sanitization`
 Tests sanitization of sensitive data in logs:
-- Tests with sensitive fields (stellar_account, password, token)
-- Verifies request is processed (actual sanitization tested in utils)
-- Ensures sensitive data doesn't break request processing
+- Enables body logging (`LOG_REQUEST_BODY=true`)
+- Sends a payload containing `stellar_account`, `password`, and `token` fields
+- Captures the actual log output via `#[traced_test]`
+- Asserts that the `****` masking marker appears in the logged body
+- Asserts that plain-text sensitive values (`super_secret_password`, `secret_token_12345`, full account string) are absent from logs
+- Asserts that non-sensitive fields (e.g. `amount`) are still logged in plain text
 
 ### 8. `test_request_logging_nested_sensitive_data`
-Tests sanitization of nested sensitive data:
-- Tests deeply nested JSON structures
-- Verifies nested sensitive fields are handled
-- Confirms complex payloads are processed correctly
+Tests sanitization of nested sensitive data in logs:
+- Enables body logging (`LOG_REQUEST_BODY=true`)
+- Sends a deeply nested payload with `stellar_account` and `api_key` buried inside sub-objects
+- Captures the actual log output via `#[traced_test]`
+- Asserts that the `****` masking marker appears in the logged body
+- Asserts that plain-text sensitive values (`secret_api_key_12345`, full account string) are absent from logs
+- Asserts that non-sensitive fields at any nesting depth (e.g. `amount`, `name`) are still logged in plain text
 
 ### 9. `test_request_logging_large_body`
 Tests handling of oversized request bodies:
@@ -114,6 +120,7 @@ The tests use:
 - `tower`: Service trait and testing helpers
 - `serde_json`: JSON serialization for test payloads
 - `tokio`: Async runtime
+- `tracing-test` (`no-env-filter` feature): Captures tracing log output in integration tests and injects `logs_contain`/`logs_assert` helpers for asserting on logged content
 
 ## Environment Variables
 
@@ -217,12 +224,11 @@ INFO Outgoing response request_id=abc-123 method=POST uri=/test status=200 laten
 ## Future Enhancements
 
 Potential improvements:
-1. Add structured log capture for testing actual log output
-2. Test correlation with distributed tracing systems
-3. Add performance benchmarks
-4. Test with streaming request bodies
-5. Add tests for custom header propagation
-6. Test integration with observability platforms
+1. Test correlation with distributed tracing systems
+2. Add performance benchmarks
+3. Test with streaming request bodies
+4. Add tests for custom header propagation
+5. Test integration with observability platforms
 
 ## Troubleshooting
 
@@ -256,4 +262,4 @@ Potential improvements:
 
 ---
 
-**Test Coverage**: 13 comprehensive test cases covering all logging scenarios, error handling, and security features.
+**Test Coverage**: 13 comprehensive test cases covering all logging scenarios, error handling, and security features. Tests #7 and #8 capture actual log output (via `tracing-test`) and assert that sensitive fields are masked and never appear in plain text, providing real regression coverage for the sanitization behavior described in the Security Considerations section.

--- a/tests/request_logger_test.rs
+++ b/tests/request_logger_test.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use serde_json::json;
 use tower::ServiceExt;
+use tracing_test::traced_test;
 
 // Helper function to create a test app with request logger middleware
 fn create_test_app() -> Router {
@@ -214,13 +215,14 @@ async fn test_request_logging_with_body() {
 }
 
 #[tokio::test]
+#[traced_test]
 async fn test_request_logging_sanitization() {
-    // Set environment variable to enable body logging
+    // Enable body logging so the middleware logs (and sanitizes) the request body.
     std::env::set_var("LOG_REQUEST_BODY", "true");
 
     let app = create_test_app();
 
-    // Payload with sensitive data
+    // Payload with sensitive data whose plain-text values must never appear in logs.
     let payload = json!({
         "stellar_account": "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
         "password": "super_secret_password",
@@ -244,22 +246,47 @@ async fn test_request_logging_sanitization() {
     assert_eq!(response.status(), StatusCode::OK);
     assert!(response.headers().contains_key("x-request-id"));
 
-    // Note: The actual sanitization happens in the logs, which we can't directly test here
-    // But we verify the request is processed successfully with sensitive data
-    // The sanitize_json function is tested separately in src/utils/sanitize.rs
+    // The log body must contain the masking marker for every sensitive field.
+    assert!(
+        logs_contain("****"),
+        "Expected at least one masked field in logs"
+    );
+
+    // Sensitive field values must not appear in plain text.
+    assert!(
+        !logs_contain("super_secret_password"),
+        "Plain-text password must not appear in logs"
+    );
+    assert!(
+        !logs_contain("secret_token_12345"),
+        "Plain-text token must not appear in logs"
+    );
+    // stellar_account value is long enough to be partially shown, but the full
+    // 36-char account string should never be logged verbatim.
+    assert!(
+        !logs_contain("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"),
+        "Full stellar_account value must not appear in logs"
+    );
+
+    // Non-sensitive fields must still be logged clearly.
+    assert!(
+        logs_contain("100.50"),
+        "Non-sensitive 'amount' field should be visible in logs"
+    );
 
     // Clean up
     std::env::remove_var("LOG_REQUEST_BODY");
 }
 
 #[tokio::test]
+#[traced_test]
 async fn test_request_logging_nested_sensitive_data() {
-    // Set environment variable to enable body logging
+    // Enable body logging so the middleware logs (and sanitizes) the request body.
     std::env::set_var("LOG_REQUEST_BODY", "true");
 
     let app = create_test_app();
 
-    // Payload with nested sensitive data
+    // Payload with sensitive data buried inside nested objects.
     let payload = json!({
         "transaction": {
             "stellar_account": "GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
@@ -285,6 +312,32 @@ async fn test_request_logging_nested_sensitive_data() {
 
     assert_eq!(response.status(), StatusCode::OK);
     assert!(response.headers().contains_key("x-request-id"));
+
+    // The log body must contain the masking marker, proving sanitization ran.
+    assert!(
+        logs_contain("****"),
+        "Expected at least one masked field in logs"
+    );
+
+    // Nested sensitive values must not appear in plain text.
+    assert!(
+        !logs_contain("secret_api_key_12345"),
+        "Plain-text api_key must not appear in logs"
+    );
+    assert!(
+        !logs_contain("GABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"),
+        "Full stellar_account value must not appear in logs"
+    );
+
+    // Non-sensitive fields at any depth must still be logged.
+    assert!(
+        logs_contain("100.50"),
+        "Non-sensitive 'amount' field should be visible in logs"
+    );
+    assert!(
+        logs_contain("John Doe"),
+        "Non-sensitive 'name' field should be visible in logs"
+    );
 
     // Clean up
     std::env::remove_var("LOG_REQUEST_BODY");


### PR DESCRIPTION
fix: add real log-capture assertions to sanitization tests
  
  Problem
  
  test_request_logging_sanitization and
  test_request_logging_nested_sensitive_data only asserted HTTP 200 +
  x-request-id. The test file itself admitted this with an inline comment:
  
  // Note: The actual sanitization happens in the logs, which we can't directly
  test here
  
  A regression that stopped masking password, token, or stellar_account in logs
  would pass this suite undetected, despite the README claiming "comprehensive...
  security features" coverage.
  
  Changes
  
  - Cargo.toml — add tracing-test = { version = "0.2", features =
  ["no-env-filter"] } as a dev-dependency. no-env-filter is required because
  integration tests in tests/ compile as a separate crate and would otherwise
  have their log events suppressed.
  - tests/request_logger_test.rs — rewrite both sanitization tests with
  #[traced_test] and real assertions:
    - logs_contain("****") — masking ran
    - !logs_contain("super_secret_password") /
  !logs_contain("secret_token_12345") / !logs_contain("GABCDEF...") — sensitive
  values are absent from logs
    - logs_contain("100.50") / logs_contain("John Doe") — non-sensitive fields
  are still visible
  
  - tests/README_REQUEST_LOGGER.md — accurate descriptions for tests #7 and #8;
  tracing-test added to dependencies; completed "Future Enhancements" item
  removed; closing summary updated to describe what is actually covered.
  
  Testing
  
  The two rewritten tests will now fail if sanitize_json stops masking any of the
  asserted fields, giving the regression coverage the README previously claimed
  but did not deliver.

closes #907

