### PR TITLE
Fix /ws auth bypass and three migration schema defects

### DIFF
--- a/migrations/20260722000000_settlements_status_default.down.sql
+++ b/migrations/20260722000000_settlements_status_default.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settlements ALTER COLUMN status SET DEFAULT 'pending';

--- a/migrations/20260722000000_settlements_status_default.sql
+++ b/migrations/20260722000000_settlements_status_default.sql
@@ -1,0 +1,7 @@
+-- The settlements.status column defaulted to 'pending', but
+-- 20260502000000_settlement_dispute.sql later added a CHECK constraint whose
+-- allowed set ('completed','pending_review','disputed','adjusted','voided')
+-- does not include 'pending'. Any insert relying on the column default would
+-- violate settlements_status_check. Align the default with the intended
+-- initial state, 'pending_review'.
+ALTER TABLE settlements ALTER COLUMN status SET DEFAULT 'pending_review';

--- a/migrations/20260722000001_timestamptz_monitor_cursors_and_quotas.down.sql
+++ b/migrations/20260722000001_timestamptz_monitor_cursors_and_quotas.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE account_monitor_cursors
+    ALTER COLUMN updated_at TYPE TIMESTAMP USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE api_quotas
+    ALTER COLUMN created_at TYPE TIMESTAMP USING created_at AT TIME ZONE 'UTC',
+    ALTER COLUMN updated_at TYPE TIMESTAMP USING updated_at AT TIME ZONE 'UTC';

--- a/migrations/20260722000001_timestamptz_monitor_cursors_and_quotas.sql
+++ b/migrations/20260722000001_timestamptz_monitor_cursors_and_quotas.sql
@@ -1,0 +1,12 @@
+-- account_monitor_cursors.updated_at and api_quotas.created_at/updated_at were
+-- declared as timezone-naive TIMESTAMP, inconsistent with every other
+-- timestamp column in the schema (TIMESTAMPTZ). NOW() is TIMESTAMPTZ and gets
+-- implicitly cast to the session's TimeZone on write; since all deployments
+-- run with TimeZone=UTC, the stored wall-clock values are already UTC, so
+-- this is a type/label fix rather than a data shift.
+ALTER TABLE account_monitor_cursors
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE api_quotas
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';

--- a/scripts/build_transaction_search_indexes_concurrently.sql
+++ b/scripts/build_transaction_search_indexes_concurrently.sql
@@ -1,0 +1,28 @@
+-- Out-of-band index build for the live, high-volume `transactions` table.
+--
+-- migrations/20260222000000_transaction_search_indexes.sql and
+-- migrations/20260427000000_optimized_search_indexes.sql create these same
+-- indexes with plain `CREATE INDEX IF NOT EXISTS`, which takes a SHARE lock
+-- and blocks concurrent INSERT/UPDATE/DELETE on `transactions` for the
+-- duration of the build. `CREATE INDEX CONCURRENTLY` avoids that lock, but
+-- cannot run inside a transaction block, and sqlx (0.7) wraps every
+-- migration file in one with no opt-out — so it cannot be expressed as a
+-- migration at all.
+--
+-- On any environment where `transactions` already carries production
+-- traffic, run this script FIRST via psql (autocommit, one statement per
+-- connection-transaction), e.g.:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/build_transaction_search_indexes_concurrently.sql
+-- Once these indexes exist, the migrations' `IF NOT EXISTS` clauses make
+-- their own CREATE INDEX statements no-ops. On a fresh/empty database the
+-- migrations alone are sufficient and this script is unnecessary.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_asset_code ON transactions(asset_code);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_created_status ON transactions(created_at DESC, status);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_amount ON transactions(amount);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_created_id ON transactions(created_at DESC, id DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_search ON transactions(status, asset_code, created_at DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_status_asset_created ON transactions (status, asset_code, created_at DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_pending ON transactions (created_at DESC) WHERE status = 'pending';
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_metadata_gin ON transactions USING GIN (metadata jsonb_path_ops) WHERE metadata IS NOT NULL;

--- a/src/handlers/ws.rs
+++ b/src/handlers/ws.rs
@@ -92,8 +92,36 @@ pub async fn ws_handler(
         .map(|ci| ci.0.to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let _ = token; // validated above
+    if !authenticate_ws_token(&state, &token).await {
+        tracing::warn!(client_addr = %client_addr, "WebSocket authentication failed: token not recognized");
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
     ws.on_upgrade(move |socket| handle_socket(socket, state, client_addr))
+}
+
+/// Checks the token against real credentials: the current/previous admin API
+/// keys (rotation-aware, constant-time comparison) and active tenant API keys.
+/// `validate_ws_token` only checks the token's shape; this is what actually
+/// authenticates the caller.
+async fn authenticate_ws_token(state: &AppState, token: &str) -> bool {
+    if let Some(store) = &state.secrets_store {
+        let valid_keys = store.valid_admin_keys().await;
+        if valid_keys
+            .iter()
+            .any(|k| crate::middleware::auth::constant_time_eq(k.as_bytes(), token.as_bytes()))
+        {
+            return true;
+        }
+    }
+
+    match crate::db::queries::lookup_api_key(&state.db, token).await {
+        Ok(valid) => valid,
+        Err(e) => {
+            tracing::error!("WebSocket token lookup failed: {}", e);
+            false
+        }
+    }
 }
 
 // ── Per-connection handler ───────────────────────────────────────────────────

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -100,7 +100,7 @@ pub async fn admin_auth(req: Request<Body>, next: Next<Body>) -> Result<Response
 }
 
 /// Constant-time byte slice equality check to prevent timing attacks.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     use subtle::ConstantTimeEq;
     if a.len() != b.len() {
         return false;


### PR DESCRIPTION
## Summary
- Closes #944: `/ws` accepted any non-empty token because `validate_ws_token` only checked shape (length/non-empty/no-NUL) and the route sat outside the admin auth middleware. `ws_handler` now checks the token against real credentials — current/previous admin API keys via `SecretsStore` (constant-time comparison, same as `admin_auth`) and active tenant API keys via `lookup_api_key` (same as `api_key_auth`) — and rejects with 401 if neither matches.
- Closes #943: the two migrations building search indexes on the live `transactions` table used plain `CREATE INDEX IF NOT EXISTS`, which blocks concurrent writes for the build duration. Added `scripts/build_transaction_search_indexes_concurrently.sql` as the documented out-of-band path (sqlx 0.7 wraps every migration in a transaction with no opt-out, so `CREATE INDEX CONCURRENTLY` cannot be expressed as a migration file at all). Once run, the migrations' `IF NOT EXISTS` clauses become no-ops.
- Closes #942: `settlements.status` defaulted to `'pending'`, but the later `settlements_status_check` CHECK constraint's allowed set doesn't include it — any insert relying on the default would fail. Added a migration setting the default to `'pending_review'`, matching the CHECK constraint's documented intent.
- Closes #941: `account_monitor_cursors.updated_at` and `api_quotas.created_at`/`updated_at` used timezone-naive `TIMESTAMP`, inconsistent with `TIMESTAMPTZ` everywhere else in the schema. Added a migration converting both to `TIMESTAMPTZ` (data preserved via `AT TIME ZONE 'UTC'`, since all deployments run with `TimeZone=UTC`).

All fixes for already-applied migrations are additive (new forward migrations), not edits to historical migration files, to avoid breaking sqlx's checksum verification in any environment that has already run them.

## Test plan
- [ ] Run `sqlx migrate run` against a Postgres instance to confirm the new migrations apply cleanly (up and down)
- [ ] Confirm `/ws` rejects a well-formed but unrecognized token with 401, and accepts a valid tenant/admin API key
- [ ] Run `scripts/build_transaction_search_indexes_concurrently.sql` against a populated `transactions` table and confirm no write-blocking lock is taken

