### PR TITLE
Fix replica failover, partition archival, and audit retention memory bugs

### DIFF
--- a/src/db/audit.rs
+++ b/src/db/audit.rs
@@ -183,11 +183,19 @@ pub struct RetentionResult {
     pub deleted: u64,
 }
 
+/// Number of rows fetched/deleted per batch in [`run_retention`]. Keeps memory
+/// use bounded regardless of how large the backlog of expired rows grows.
+const RETENTION_BATCH_SIZE: i64 = 1000;
+
 /// Export audit logs older than `cutoff` (excluding protected entity IDs) to a
 /// gzip-compressed NDJSON file, then delete them from the database.
 ///
 /// Rows whose `entity_id` belongs to a transaction with status `'disputed'` are
 /// never deleted (they are still exported to the archive).
+///
+/// Rows are paged through in bounded batches (keyset pagination on
+/// `(timestamp, id)`) and streamed to the archive/delete per batch, so memory
+/// use stays bounded even when the backlog of expired rows is very large.
 ///
 /// Returns `Ok(None)` when there is nothing to do (no rows older than cutoff).
 pub async fn run_retention(
@@ -195,101 +203,142 @@ pub async fn run_retention(
     cutoff: DateTime<Utc>,
     archive_dir: &str,
 ) -> Result<Option<RetentionResult>, Box<dyn std::error::Error + Send + Sync>> {
-    // 1. Fetch all rows older than the cutoff.
-    let rows = sqlx::query(
-        r#"
-        SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
-        FROM audit_logs
-        WHERE timestamp < $1
-        ORDER BY timestamp ASC
-        "#,
-    )
-    .bind(cutoff)
-    .fetch_all(pool)
-    .await?;
-
-    if rows.is_empty() {
-        return Ok(None);
-    }
-
-    // 2. Identify entity_ids that belong to disputed transactions — these must
-    //    never be deleted.
-    let entity_ids: Vec<Uuid> = rows
-        .iter()
-        .map(|r| r.try_get::<Uuid, _>("entity_id"))
-        .collect::<Result<_, _>>()?;
-
-    let disputed: Vec<Uuid> = sqlx::query_scalar(
-        r#"
-        SELECT id FROM transactions
-        WHERE id = ANY($1)
-          AND status = 'disputed'
-        "#,
-    )
-    .bind(&entity_ids)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default(); // if transactions table has no disputed column yet, skip
-
-    let disputed_set: std::collections::HashSet<Uuid> = disputed.into_iter().collect();
-
-    // 3. Serialize all rows (including protected ones) to NDJSON and compress.
     let timestamp_str = Utc::now().format("%Y%m%dT%H%M%SZ");
     let archive_path = format!("{}/audit_logs_{}.ndjson.gz", archive_dir, timestamp_str);
 
-    let file = std::fs::File::create(&archive_path)?;
-    let mut gz = GzEncoder::new(file, Compression::default());
+    let mut gz: Option<GzEncoder<std::fs::File>> = None;
+    let mut exported: usize = 0;
+    let mut deleted: u64 = 0;
+    let mut cursor: Option<(DateTime<Utc>, Uuid)> = None;
 
-    for row in &rows {
-        let id: Uuid = row.try_get("id")?;
-        let entity_id: Uuid = row.try_get("entity_id")?;
-        let entity_type: String = row.try_get("entity_type")?;
-        let action: String = row.try_get("action")?;
-        let old_val: Option<JsonValue> = row.try_get("old_val")?;
-        let new_val: Option<JsonValue> = row.try_get("new_val")?;
-        let actor: String = row.try_get("actor")?;
-        let timestamp: DateTime<Utc> = row.try_get("timestamp")?;
+    loop {
+        let rows = match cursor {
+            None => {
+                sqlx::query(
+                    r#"
+                    SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
+                    FROM audit_logs
+                    WHERE timestamp < $1
+                    ORDER BY timestamp ASC, id ASC
+                    LIMIT $2
+                    "#,
+                )
+                .bind(cutoff)
+                .bind(RETENTION_BATCH_SIZE)
+                .fetch_all(pool)
+                .await?
+            }
+            Some((last_ts, last_id)) => {
+                sqlx::query(
+                    r#"
+                    SELECT id, entity_id, entity_type, action, old_val, new_val, actor, timestamp
+                    FROM audit_logs
+                    WHERE timestamp < $1
+                      AND (timestamp, id) > ($2, $3)
+                    ORDER BY timestamp ASC, id ASC
+                    LIMIT $4
+                    "#,
+                )
+                .bind(cutoff)
+                .bind(last_ts)
+                .bind(last_id)
+                .bind(RETENTION_BATCH_SIZE)
+                .fetch_all(pool)
+                .await?
+            }
+        };
 
-        let record = json!({
-            "id": id,
-            "entity_id": entity_id,
-            "entity_type": entity_type,
-            "action": action,
-            "old_val": old_val,
-            "new_val": new_val,
-            "actor": actor,
-            "timestamp": timestamp.to_rfc3339(),
-        });
+        if rows.is_empty() {
+            break;
+        }
+        let batch_len = rows.len();
 
-        writeln!(gz, "{}", record)?;
+        // Identify entity_ids in this batch that belong to disputed
+        // transactions — these must never be deleted.
+        let entity_ids: Vec<Uuid> = rows
+            .iter()
+            .map(|r| r.try_get::<Uuid, _>("entity_id"))
+            .collect::<Result<_, _>>()?;
+
+        let disputed: Vec<Uuid> = sqlx::query_scalar(
+            r#"
+            SELECT id FROM transactions
+            WHERE id = ANY($1)
+              AND status = 'disputed'
+            "#,
+        )
+        .bind(&entity_ids)
+        .fetch_all(pool)
+        .await
+        .unwrap_or_default(); // if transactions table has no disputed column yet, skip
+
+        let disputed_set: std::collections::HashSet<Uuid> = disputed.into_iter().collect();
+
+        let gz_writer = match gz.as_mut() {
+            Some(w) => w,
+            None => {
+                let file = std::fs::File::create(&archive_path)?;
+                gz.insert(GzEncoder::new(file, Compression::default()))
+            }
+        };
+
+        let mut deletable_ids: Vec<Uuid> = Vec::with_capacity(batch_len);
+        let mut last_key: Option<(DateTime<Utc>, Uuid)> = None;
+
+        for row in &rows {
+            let id: Uuid = row.try_get("id")?;
+            let entity_id: Uuid = row.try_get("entity_id")?;
+            let entity_type: String = row.try_get("entity_type")?;
+            let action: String = row.try_get("action")?;
+            let old_val: Option<JsonValue> = row.try_get("old_val")?;
+            let new_val: Option<JsonValue> = row.try_get("new_val")?;
+            let actor: String = row.try_get("actor")?;
+            let timestamp: DateTime<Utc> = row.try_get("timestamp")?;
+
+            let record = json!({
+                "id": id,
+                "entity_id": entity_id,
+                "entity_type": entity_type,
+                "action": action,
+                "old_val": old_val,
+                "new_val": new_val,
+                "actor": actor,
+                "timestamp": timestamp.to_rfc3339(),
+            });
+
+            writeln!(gz_writer, "{}", record)?;
+
+            if !disputed_set.contains(&entity_id) {
+                deletable_ids.push(id);
+            }
+            last_key = Some((timestamp, id));
+        }
+
+        exported += batch_len;
+
+        if !deletable_ids.is_empty() {
+            let result = sqlx::query("DELETE FROM audit_logs WHERE id = ANY($1)")
+                .bind(&deletable_ids)
+                .execute(pool)
+                .await?;
+            deleted += result.rows_affected();
+        }
+
+        cursor = last_key;
+
+        if batch_len < RETENTION_BATCH_SIZE as usize {
+            break;
+        }
     }
 
-    gz.finish()?;
-    let exported = rows.len();
+    if exported == 0 {
+        return Ok(None);
+    }
 
-    // 4. Delete only the non-protected rows.
-    let deletable_ids: Vec<Uuid> = rows
-        .iter()
-        .filter_map(|r| {
-            let id: Uuid = r.try_get("id").ok()?;
-            let entity_id: Uuid = r.try_get("entity_id").ok()?;
-            if disputed_set.contains(&entity_id) {
-                None
-            } else {
-                Some(id)
-            }
-        })
-        .collect();
-
-    let deleted = if deletable_ids.is_empty() {
-        0
-    } else {
-        let result = sqlx::query("DELETE FROM audit_logs WHERE id = ANY($1)")
-            .bind(&deletable_ids)
-            .execute(pool)
-            .await?;
-        result.rows_affected()
-    };
+    if let Some(mut gz_writer) = gz {
+        gz_writer.flush()?;
+        gz_writer.finish()?;
+    }
 
     Ok(Some(RetentionResult {
         exported,

--- a/src/db/cron.rs
+++ b/src/db/cron.rs
@@ -73,12 +73,15 @@ pub async fn detach_and_archive_old_partitions(
         if let Some((y, m)) = parse_partition_name(&child) {
             let part_date = Utc.with_ymd_and_hms(y, m, 1, 0, 0, 0).single().unwrap();
             if part_date < cutoff {
-                // detach
+                // Detach and move to the archive schema atomically: if the
+                // schema move fails, the detach must roll back too, otherwise
+                // the partition is orphaned (detached but never archived).
+                let mut tx = pool.begin().await?;
                 let detach_sql = format!("ALTER TABLE transactions DETACH PARTITION \"{child}\"");
-                sqlx::query(&detach_sql).execute(pool).await?;
-                // move to archive schema
+                sqlx::query(&detach_sql).execute(&mut *tx).await?;
                 let set_schema = format!("ALTER TABLE \"{child}\" SET SCHEMA archive");
-                sqlx::query(&set_schema).execute(pool).await?;
+                sqlx::query(&set_schema).execute(&mut *tx).await?;
+                tx.commit().await?;
             }
         }
     }

--- a/src/db/partition.rs
+++ b/src/db/partition.rs
@@ -39,11 +39,19 @@ impl PartitionManager {
         });
     }
 
-    /// Run partition maintenance (create new partitions, detach old ones)
+    /// Run partition maintenance: create the upcoming partition, then detach
+    /// and archive partitions past the retention window.
+    ///
+    /// Creation still goes through the `create_monthly_partition()` SQL
+    /// function, but retention uses [`crate::db::cron::detach_and_archive_old_partitions`]
+    /// instead of the SQL-only `detach_old_partitions()` so that old
+    /// partitions are actually moved into the `archive` schema rather than
+    /// left as loose, unmanaged tables in `public`.
     async fn maintain_partitions(&self) -> Result<(), sqlx::Error> {
-        sqlx::query("SELECT maintain_partitions()")
+        sqlx::query("SELECT create_monthly_partition()")
             .execute(&self.pool)
             .await?;
+        crate::db::cron::detach_and_archive_old_partitions(&self.pool, 12).await?;
         Ok(())
     }
 

--- a/src/db/pool_manager.rs
+++ b/src/db/pool_manager.rs
@@ -68,7 +68,55 @@ impl PoolManager {
     pub async fn get_write_pool(&self) -> &PgPool {
         &self.primary
     }
+
+    /// Spawn a background task that periodically probes the replica (and
+    /// primary) with a cheap query and writes the result to `failover_state`.
+    ///
+    /// Without this, `failover_state` is only ever set once at construction
+    /// time and `read_pool()` would keep routing to the replica forever,
+    /// even after it becomes unreachable.
+    pub fn start_health_checks(&self) {
+        if self.replica.is_none() {
+            return;
+        }
+
+        let replica = self.replica.clone();
+        let primary = self.primary.clone();
+        let failover_state = Arc::clone(&self.failover_state);
+
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(HEALTH_CHECK_INTERVAL);
+            loop {
+                ticker.tick().await;
+
+                let replica_healthy = match &replica {
+                    Some(pool) => sqlx::query("SELECT 1").execute(pool).await.is_ok(),
+                    None => false,
+                };
+                let primary_healthy = sqlx::query("SELECT 1").execute(&primary).await.is_ok();
+
+                let mut state = failover_state.write().await;
+                if state.replica_healthy != replica_healthy {
+                    tracing::warn!(
+                        replica_healthy,
+                        "Replica health changed; updating failover state"
+                    );
+                }
+                if state.primary_healthy != primary_healthy {
+                    tracing::warn!(
+                        primary_healthy,
+                        "Primary health changed; updating failover state"
+                    );
+                }
+                state.replica_healthy = replica_healthy;
+                state.primary_healthy = primary_healthy;
+            }
+        });
+    }
 }
+
+/// How often the background health-check task probes primary/replica.
+const HEALTH_CHECK_INTERVAL: Duration = Duration::from_secs(10);
 
 fn build_pool(
     url: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ async fn serve(
 
     if pool_manager.replica().is_some() {
         tracing::info!("Database replica configured - read queries will be routed to replica");
+        pool_manager.start_health_checks();
     } else {
         tracing::info!("No replica configured - all queries will use primary database");
     }


### PR DESCRIPTION
## Summary
- **#936** — `PoolManager` now spawns a periodic health-check task (`start_health_checks`) that probes primary/replica and writes results to `failover_state` via `.write()`. Previously `failover_state` was set once at construction and never updated, so `read_pool()` would route to a dead replica forever.
- **#935** — `PartitionManager::maintain_partitions` now calls `db::cron::detach_and_archive_old_partitions` instead of the SQL-only `detach_old_partitions()` (via `maintain_partitions()`), so the production scheduler actually archives old partitions into the `archive` schema instead of leaving them as orphaned tables in `public`.
- **#934** — `detach_and_archive_old_partitions` now wraps the `DETACH PARTITION` + `SET SCHEMA archive` pair in a single `sqlx::Transaction`, so a failure partway through can no longer leave a partition detached but never archived.
- **#933** — `audit::run_retention` now pages through expired `audit_logs` rows in bounded batches (keyset pagination on `(timestamp, id)`, `LIMIT 1000`) instead of `fetch_all`, streaming each batch to the gzip archive and deleting per batch, bounding memory use regardless of backlog size.

Closes #936 
closes #935 
closes #934 
closes #933 

## Test plan
- [x] `cargo check -p synapse-core --lib --bins` compiles cleanly with no new warnings on the touched files (verified against a temporarily-isolated workspace member set due to a pre-existing, unrelated `cli/synapse-cli` manifest issue on `main`)
- [ ] Tests intentionally skipped per task instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)