### PR TITLE
Fix/918 920 921 919 bugs

### DIFF
--- a/src/cache/rate_limiting.rs
+++ b/src/cache/rate_limiting.rs
@@ -1,7 +1,6 @@
-//! Rate limiting implementation using Redis.
+//! Rate limiting implementation using a token-bucket algorithm.
 //!
-//! Provides token bucket and sliding window rate limiting strategies
-//! with configurable limits and time windows.
+//! Provides token-bucket rate limiting with configurable limits and time windows.
 //!
 //! # Performance optimisations (#454)
 //! - Token refill is computed in a single integer division instead of floating-point
@@ -20,18 +19,16 @@ use std::time::Duration;
 ///
 /// * `max_requests` - Maximum number of requests allowed within the time window
 /// * `window` - Duration of the time window
-/// * `strategy` - Algorithm to use for rate limiting
 ///
 /// # Example
 ///
 /// ```
-/// use synapse_core::cache::rate_limiting::{RateLimitConfig, RateLimitStrategy};
+/// use synapse_core::cache::rate_limiting::RateLimitConfig;
 /// use std::time::Duration;
 ///
 /// let config = RateLimitConfig {
 ///     max_requests: 100,
 ///     window: Duration::from_secs(60),
-///     strategy: RateLimitStrategy::TokenBucket,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -40,17 +37,6 @@ pub struct RateLimitConfig {
     pub max_requests: u32,
     /// Time window for the rate limit
     pub window: Duration,
-    /// Strategy to use for rate limiting
-    pub strategy: RateLimitStrategy,
-}
-
-/// Rate limiting strategies
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RateLimitStrategy {
-    /// Token bucket algorithm
-    TokenBucket,
-    /// Sliding window algorithm
-    SlidingWindow,
 }
 
 /// Rate limiter metrics for tracking token acquisition and rejection.
@@ -103,7 +89,6 @@ impl Default for RateLimitConfig {
         Self {
             max_requests: 100,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         }
     }
 }
@@ -306,7 +291,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 3,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -321,7 +305,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 10,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -335,7 +318,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 5,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -349,7 +331,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 5,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -366,7 +347,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 1,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -384,7 +364,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 3,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -402,7 +381,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 1,
             window: Duration::from_secs(1),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -419,7 +397,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 1,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -434,7 +411,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 4,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
         let clone = limiter.clone();
@@ -450,7 +426,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 10,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -465,7 +440,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 5,
             window: Duration::from_millis(50),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -488,7 +462,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 10,
             window: Duration::from_secs(1),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -503,7 +476,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 3,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -519,7 +491,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 2,
             window: Duration::from_millis(50),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limiter = RateLimiter::with_config(config);
 
@@ -543,7 +514,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 2,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
 
         let client_a = RateLimiter::with_config(config.clone());
@@ -567,7 +537,6 @@ mod tests {
         let config = RateLimitConfig {
             max_requests: 1,
             window: Duration::from_secs(60),
-            strategy: RateLimitStrategy::TokenBucket,
         };
         let limited_endpoint = RateLimiter::with_config(config);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,6 @@ pub fn create_app(app_state: AppState) -> Router {
         // Versioned route groups
         .nest("/api/v1", v1_routes)
         .nest("/api/v2", v2_routes)
-        .layer(axum_middleware::from_fn(
-            middleware::panic_recovery::panic_recovery_middleware,
-        ))
         .with_state(api_state)
         .merge(
             Router::new()
@@ -307,6 +304,13 @@ pub fn create_app(app_state: AppState) -> Router {
                 .route("/reconnect", post(handlers::reconnection::reconnect))
                 .with_state(app_state),
         )
+        // panic_recovery_middleware is applied after the final .merge() so it
+        // covers every route including /ws, /reconnect/status, and /reconnect
+        // (fix for #918: previously applied before the ws/reconnect merge and
+        // therefore did not protect those routes from ungraceful panics).
+        .layer(axum_middleware::from_fn(
+            middleware::panic_recovery::panic_recovery_middleware,
+        ))
         .layer(axum_middleware::from_fn(
             middleware::request_logger::request_logger_middleware,
         ))


### PR DESCRIPTION
Title: fix: apply panic recovery to all routes and remove unused RateLimitStrategy
  
  ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Description:
  
  This PR fixes two bugs and one leftover dead-code issue tracked across issues #918, #919, #920, and #921.
  
  Changes
  
  fix(#918) – panic_recovery_middleware now covers all routes
  
  panic_recovery_middleware was being applied before the final .merge() call in create_app, which meant the /ws, /reconnect/status,
  and /reconnect routes were not protected. A panic on any of those routes would bypass the middleware entirely and crash the
  handler without a graceful 500 response.
  
  The middleware is now applied after the final .merge(), ensuring every route in the application is covered.
  
  refactor(#919 / #920 / #921) – Remove RateLimitStrategy enum and strategy field
  
  RateLimitStrategy (TokenBucket, SlidingWindow) and the strategy field on RateLimitConfig were dead code — only TokenBucket was
  ever used and the field was never read at runtime. This removes the enum, the struct field, the Default impl reference, and all
  test usages, leaving a simpler, honest API.
  
  Issues closed
  
  Closes #918
  Closes #919
  Closes #920
  Closes #921
  
  Testing
  
  - Existing test suite passes — no behaviour change, only middleware ordering and dead-code removal.
  - Panic recovery is structurally verified by the corrected layer position in create_app.
