### PR TITLE
Fix tenant RLS leak, bulk-update TOCTOU race, missing query timeouts, and duplicate-query bug

### DIFF
--- a/migrations/20260501000000_tenant_rls.sql
+++ b/migrations/20260501000000_tenant_rls.sql
@@ -10,7 +10,12 @@ ALTER TABLE transactions FORCE ROW LEVEL SECURITY;
 -- Tenants see only their own rows; NULL tenant_id rows are visible to admins only
 CREATE POLICY tenant_isolation ON transactions
     USING (
-        tenant_id IS NULL                                          -- legacy / admin rows
+        (tenant_id IS NULL AND current_setting('app.is_admin', true) = 'true')  -- legacy / admin rows, admin-only
+        OR tenant_id::text = current_setting('app.tenant_id', true)  -- tenant match
+        OR current_setting('app.is_admin', true) = 'true'         -- admin bypass
+    )
+    WITH CHECK (
+        (tenant_id IS NULL AND current_setting('app.is_admin', true) = 'true')  -- only admins may write NULL-tenant rows
         OR tenant_id::text = current_setting('app.tenant_id', true)  -- tenant match
         OR current_setting('app.is_admin', true) = 'true'         -- admin bypass
     );

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -911,78 +911,87 @@ pub async fn update_settlement_status(
     new_total: Option<&sqlx::types::BigDecimal>,
     actor: &str,
 ) -> Result<Settlement> {
-    let mut db_tx = pool.begin().await?;
+    with_timeout(
+        QueryTier::Write,
+        "update_settlement_status [SELECT ... FOR UPDATE + UPDATE settlements]",
+        async {
+            let mut db_tx = pool.begin().await?;
 
-    let current =
-        sqlx::query_as::<_, Settlement>("SELECT * FROM settlements WHERE id = $1 FOR UPDATE")
+            let current = sqlx::query_as::<_, Settlement>(
+                "SELECT * FROM settlements WHERE id = $1 FOR UPDATE",
+            )
             .bind(id)
             .fetch_optional(&mut *db_tx)
             .await?
             .ok_or(sqlx::Error::RowNotFound)?;
 
-    // Validate transition against the locked row (not the pre-lock read).
-    // This catches concurrent modifications: if the status changed or no-op transition is detected,
-    // mark as stale by returning RowNotFound (which will be converted to StaleTransition in service layer).
-    if current.status != expected_from_status || current.status == new_status {
-        db_tx.rollback().await?;
-        return Err(sqlx::Error::RowNotFound);
-    }
+            // Validate transition against the locked row (not the pre-lock read).
+            // This catches concurrent modifications: if the status changed or no-op transition is detected,
+            // mark as stale by returning RowNotFound (which will be converted to StaleTransition in service layer).
+            if current.status != expected_from_status || current.status == new_status {
+                db_tx.rollback().await?;
+                return Err(sqlx::Error::RowNotFound);
+            }
 
-    // Preserve original amount on first adjustment
-    let original_total = if current.original_total_amount.is_none() && new_total.is_some() {
-        Some(current.total_amount.clone())
-    } else {
-        current.original_total_amount.clone()
-    };
+            // Preserve original amount on first adjustment
+            let original_total = if current.original_total_amount.is_none() && new_total.is_some()
+            {
+                Some(current.total_amount.clone())
+            } else {
+                current.original_total_amount.clone()
+            };
 
-    let updated = sqlx::query_as::<_, Settlement>(
-        r#"
-        UPDATE settlements SET
-            status = $1,
-            dispute_reason = COALESCE($2, dispute_reason),
-            total_amount = COALESCE($3, total_amount),
-            original_total_amount = COALESCE($4, original_total_amount),
-            reviewed_by = $5,
-            reviewed_at = NOW(),
-            updated_at = NOW()
-        WHERE id = $6 AND status = $7
-        RETURNING *
-        "#,
+            let updated = sqlx::query_as::<_, Settlement>(
+                r#"
+                UPDATE settlements SET
+                    status = $1,
+                    dispute_reason = COALESCE($2, dispute_reason),
+                    total_amount = COALESCE($3, total_amount),
+                    original_total_amount = COALESCE($4, original_total_amount),
+                    reviewed_by = $5,
+                    reviewed_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = $6 AND status = $7
+                RETURNING *
+                "#,
+            )
+            .bind(new_status)
+            .bind(reason)
+            .bind(new_total)
+            .bind(original_total)
+            .bind(actor)
+            .bind(id)
+            .bind(expected_from_status)
+            .fetch_optional(&mut *db_tx)
+            .await?
+            .ok_or(sqlx::Error::RowNotFound)?;
+
+            // If voided, release transactions back to unsettled
+            if new_status == "voided" {
+                sqlx::query(
+                    "UPDATE transactions SET settlement_id = NULL, updated_at = NOW() WHERE settlement_id = $1",
+                )
+                .bind(id)
+                .execute(&mut *db_tx)
+                .await?;
+            }
+
+            crate::db::audit::AuditLog::log(
+                &mut db_tx,
+                id,
+                crate::db::audit::ENTITY_SETTLEMENT,
+                "status_update",
+                Some(serde_json::json!({ "status": current.status })),
+                Some(serde_json::json!({ "status": new_status, "reason": reason })),
+                actor,
+            )
+            .await?;
+
+            db_tx.commit().await?;
+            Ok(updated)
+        },
     )
-    .bind(new_status)
-    .bind(reason)
-    .bind(new_total)
-    .bind(original_total)
-    .bind(actor)
-    .bind(id)
-    .bind(expected_from_status)
-    .fetch_optional(&mut *db_tx)
-    .await?
-    .ok_or(sqlx::Error::RowNotFound)?;
-
-    // If voided, release transactions back to unsettled
-    if new_status == "voided" {
-        sqlx::query(
-            "UPDATE transactions SET settlement_id = NULL, updated_at = NOW() WHERE settlement_id = $1",
-        )
-        .bind(id)
-        .execute(&mut *db_tx)
-        .await?;
-    }
-
-    crate::db::audit::AuditLog::log(
-        &mut db_tx,
-        id,
-        crate::db::audit::ENTITY_SETTLEMENT,
-        "status_update",
-        Some(serde_json::json!({ "status": current.status })),
-        Some(serde_json::json!({ "status": new_status, "reason": reason })),
-        actor,
-    )
-    .await?;
-
-    db_tx.commit().await?;
-    Ok(updated)
+    .await
 }
 
 pub async fn get_unique_assets_to_settle(pool: &PgPool) -> Result<Vec<String>> {
@@ -1489,86 +1498,96 @@ pub async fn bulk_update_transaction_status(
 ) -> Result<BulkUpdateResult> {
     use crate::validation::state_machine::validate_status_transition;
 
-    // Fetch current statuses for all requested IDs in one query
-    let rows = sqlx::query("SELECT id, status FROM transactions WHERE id = ANY($1)")
-        .bind(transaction_ids)
-        .fetch_all(pool)
-        .await?;
+    with_timeout(
+        QueryTier::Write,
+        "bulk_update_transaction_status [SELECT ... FOR UPDATE + UPDATE transactions]",
+        async {
+            let mut db_tx = pool.begin().await?;
 
-    let current: std::collections::HashMap<Uuid, String> = rows
-        .into_iter()
-        .map(|r| (r.get::<Uuid, _>("id"), r.get::<String, _>("status")))
-        .collect();
+            // Lock the target rows for the lifetime of the transaction so a concurrent
+            // update can't change their status between validation and the UPDATE below —
+            // same locked-row pattern as update_settlement_status.
+            let rows = sqlx::query("SELECT id, status FROM transactions WHERE id = ANY($1) FOR UPDATE")
+                .bind(transaction_ids)
+                .fetch_all(&mut *db_tx)
+                .await?;
 
-    let mut valid_ids: Vec<Uuid> = Vec::new();
-    let mut old_statuses: std::collections::HashMap<Uuid, String> =
-        std::collections::HashMap::new();
-    let mut errors: Vec<BulkUpdateError> = Vec::new();
+            let current: std::collections::HashMap<Uuid, String> = rows
+                .into_iter()
+                .map(|r| (r.get::<Uuid, _>("id"), r.get::<String, _>("status")))
+                .collect();
 
-    for &id in transaction_ids {
-        match current.get(&id) {
-            None => errors.push(BulkUpdateError {
-                transaction_id: id,
-                error: "transaction not found".to_string(),
-            }),
-            Some(from) => match validate_status_transition(from, new_status) {
-                Ok(_) => {
-                    old_statuses.insert(id, from.clone());
-                    valid_ids.push(id);
+            let mut valid_ids: Vec<Uuid> = Vec::new();
+            let mut old_statuses: std::collections::HashMap<Uuid, String> =
+                std::collections::HashMap::new();
+            let mut errors: Vec<BulkUpdateError> = Vec::new();
+
+            for &id in transaction_ids {
+                match current.get(&id) {
+                    None => errors.push(BulkUpdateError {
+                        transaction_id: id,
+                        error: "transaction not found".to_string(),
+                    }),
+                    Some(from) => match validate_status_transition(from, new_status) {
+                        Ok(_) => {
+                            old_statuses.insert(id, from.clone());
+                            valid_ids.push(id);
+                        }
+                        Err(e) => errors.push(BulkUpdateError {
+                            transaction_id: id,
+                            error: e.to_string(),
+                        }),
+                    },
                 }
-                Err(e) => errors.push(BulkUpdateError {
-                    transaction_id: id,
-                    error: e.to_string(),
-                }),
-            },
-        }
-    }
+            }
 
-    if valid_ids.is_empty() {
-        return Ok(BulkUpdateResult {
-            updated: 0,
-            failed: errors.len(),
-            errors,
-        });
-    }
+            if valid_ids.is_empty() {
+                db_tx.rollback().await?;
+                return Ok(BulkUpdateResult {
+                    updated: 0,
+                    failed: errors.len(),
+                    errors,
+                });
+            }
 
-    let mut db_tx = pool.begin().await?;
+            sqlx::query("UPDATE transactions SET status = $1, updated_at = NOW() WHERE id = ANY($2)")
+                .bind(new_status)
+                .bind(&valid_ids)
+                .execute(&mut *db_tx)
+                .await?;
 
-    sqlx::query("UPDATE transactions SET status = $1, updated_at = NOW() WHERE id = ANY($2)")
-        .bind(new_status)
-        .bind(&valid_ids)
-        .execute(&mut *db_tx)
-        .await?;
+            for &id in &valid_ids {
+                let old_status = old_statuses
+                    .get(&id)
+                    .map(|s| s.as_str())
+                    .unwrap_or("unknown");
+                let mut new_val = serde_json::json!({ "status": new_status });
+                if let Some(r) = reason {
+                    new_val["reason"] = serde_json::json!(r);
+                }
+                AuditLog::log(
+                    &mut db_tx,
+                    id,
+                    ENTITY_TRANSACTION,
+                    "status_update",
+                    Some(serde_json::json!({ "status": old_status })),
+                    Some(new_val),
+                    actor,
+                )
+                .await?;
+            }
 
-    for &id in &valid_ids {
-        let old_status = old_statuses
-            .get(&id)
-            .map(|s| s.as_str())
-            .unwrap_or("unknown");
-        let mut new_val = serde_json::json!({ "status": new_status });
-        if let Some(r) = reason {
-            new_val["reason"] = serde_json::json!(r);
-        }
-        AuditLog::log(
-            &mut db_tx,
-            id,
-            ENTITY_TRANSACTION,
-            "status_update",
-            Some(serde_json::json!({ "status": old_status })),
-            Some(new_val),
-            actor,
-        )
-        .await?;
-    }
+            db_tx.commit().await?;
 
-    db_tx.commit().await?;
-
-    let updated = valid_ids.len();
-    Ok(BulkUpdateResult {
-        updated,
-        failed: errors.len(),
-        errors,
-    })
+            let updated = valid_ids.len();
+            Ok(BulkUpdateResult {
+                updated,
+                failed: errors.len(),
+                errors,
+            })
+        },
+    )
+    .await
 }
 
 // --- Aggregate Queries (Cacheable) ---
@@ -1595,98 +1614,118 @@ pub struct AssetStats {
 }
 
 pub async fn get_status_counts(pool: &PgPool) -> Result<Vec<StatusCount>> {
-    let rows = sqlx::query(
-        r#"
-        SELECT status, COUNT(*) as count
-        FROM transactions
-        GROUP BY status
-        ORDER BY status
-        "#,
-    )
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(|row| StatusCount {
-            status: row.get("status"),
-            count: row.get("count"),
-        })
-        .collect())
-}
-
-pub async fn get_daily_totals(pool: &PgPool, days: i32) -> Result<Vec<DailyTotal>> {
-    let end = Utc::now();
-    let start = end - chrono::Duration::days(days.into());
-    let sql = r#"
-        SELECT 
-            DATE(created_at)::text as date,
-            SUM(amount) as total_amount,
-            COUNT(*) as tx_count
-        FROM transactions
-        WHERE created_at >= $1
-          AND created_at < $2
-        GROUP BY DATE(created_at)
-        ORDER BY DATE(created_at) DESC
-        "#;
-
-    if cfg!(debug_assertions) {
-        let explain_rows = sqlx::query(&format!("EXPLAIN ANALYZE {}", sql))
-            .bind(start)
-            .bind(end)
+    with_timeout(
+        QueryTier::Read,
+        "SELECT status, COUNT(*) FROM transactions GROUP BY status",
+        async {
+            let rows = sqlx::query(
+                r#"
+                SELECT status, COUNT(*) as count
+                FROM transactions
+                GROUP BY status
+                ORDER BY status
+                "#,
+            )
             .fetch_all(pool)
             .await?;
 
-        let explain_plan = explain_rows
-            .into_iter()
-            .map(|row| row.get::<String, _>(0))
-            .collect::<Vec<_>>()
-            .join("\n");
+            Ok(rows
+                .into_iter()
+                .map(|row| StatusCount {
+                    status: row.get("status"),
+                    count: row.get("count"),
+                })
+                .collect())
+        },
+    )
+    .await
+}
 
-        tracing::debug!("get_daily_totals EXPLAIN ANALYZE:\n{}", explain_plan);
-    }
+pub async fn get_daily_totals(pool: &PgPool, days: i32) -> Result<Vec<DailyTotal>> {
+    with_timeout(
+        QueryTier::Read,
+        "SELECT DATE(created_at), SUM/COUNT(amount) FROM transactions GROUP BY DATE(created_at)",
+        async {
+            let end = Utc::now();
+            let start = end - chrono::Duration::days(days.into());
+            let sql = r#"
+                SELECT
+                    DATE(created_at)::text as date,
+                    SUM(amount) as total_amount,
+                    COUNT(*) as tx_count
+                FROM transactions
+                WHERE created_at >= $1
+                  AND created_at < $2
+                GROUP BY DATE(created_at)
+                ORDER BY DATE(created_at) DESC
+                "#;
 
-    let rows = sqlx::query(sql)
-        .bind(start)
-        .bind(end)
-        .fetch_all(pool)
-        .await?;
+            // EXPLAIN ANALYZE actually executes the query, so running it unconditionally
+            // in every debug build would double the DB work on every call. Require an
+            // explicit opt-in env var so it only runs when a developer asks for it.
+            if cfg!(debug_assertions) && std::env::var("DB_EXPLAIN_ANALYZE").is_ok() {
+                let explain_rows = sqlx::query(&format!("EXPLAIN ANALYZE {}", sql))
+                    .bind(start)
+                    .bind(end)
+                    .fetch_all(pool)
+                    .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|row| DailyTotal {
-            date: row.get("date"),
-            total_amount: row.get("total_amount"),
-            tx_count: row.get("tx_count"),
-        })
-        .collect())
+                let explain_plan = explain_rows
+                    .into_iter()
+                    .map(|row| row.get::<String, _>(0))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                tracing::debug!("get_daily_totals EXPLAIN ANALYZE:\n{}", explain_plan);
+            }
+
+            let rows = sqlx::query(sql).bind(start).bind(end).fetch_all(pool).await?;
+
+            Ok(rows
+                .into_iter()
+                .map(|row| DailyTotal {
+                    date: row.get("date"),
+                    total_amount: row.get("total_amount"),
+                    tx_count: row.get("tx_count"),
+                })
+                .collect())
+        },
+    )
+    .await
 }
 
 pub async fn get_asset_stats(pool: &PgPool) -> Result<Vec<AssetStats>> {
-    let rows = sqlx::query(
-        r#"
-        SELECT
-            asset_code,
-            SUM(amount) as total_amount,
-            COUNT(*) as tx_count,
-            AVG(amount) as avg_amount
-        FROM transactions
-        GROUP BY asset_code
-        ORDER BY total_amount DESC
-        "#,
-    )
-    .fetch_all(pool)
-    .await?;
+    with_timeout(
+        QueryTier::Read,
+        "SELECT asset_code, SUM/COUNT/AVG(amount) FROM transactions GROUP BY asset_code",
+        async {
+            let rows = sqlx::query(
+                r#"
+                SELECT
+                    asset_code,
+                    SUM(amount) as total_amount,
+                    COUNT(*) as tx_count,
+                    AVG(amount) as avg_amount
+                FROM transactions
+                GROUP BY asset_code
+                ORDER BY total_amount DESC
+                "#,
+            )
+            .fetch_all(pool)
+            .await?;
 
-    Ok(rows
-        .into_iter()
-        .map(|row| AssetStats {
-            asset_code: row.get("asset_code"),
-            total_amount: row.get("total_amount"),
-            tx_count: row.get("tx_count"),
-            avg_amount: row.get("avg_amount"),
-        })
-        .collect())
+            Ok(rows
+                .into_iter()
+                .map(|row| AssetStats {
+                    asset_code: row.get("asset_code"),
+                    total_amount: row.get("total_amount"),
+                    tx_count: row.get("tx_count"),
+                    avg_amount: row.get("avg_amount"),
+                })
+                .collect())
+        },
+    )
+    .await
 }
 
 // --- Idempotency Fallback Queries ---
@@ -1705,11 +1744,18 @@ pub struct IdempotencyKey {
 }
 
 pub async fn check_idempotency_key(pool: &PgPool, key: &str) -> Result<Option<IdempotencyKey>> {
-    sqlx::query_as::<_, IdempotencyKey>(
-        "SELECT key, status, response, created_at, expires_at FROM idempotency_keys WHERE key = $1 AND expires_at > NOW()",
+    with_timeout(
+        QueryTier::Read,
+        "SELECT ... FROM idempotency_keys WHERE key = $1 AND expires_at > NOW()",
+        async {
+            sqlx::query_as::<_, IdempotencyKey>(
+                "SELECT key, status, response, created_at, expires_at FROM idempotency_keys WHERE key = $1 AND expires_at > NOW()",
+            )
+            .bind(key)
+            .fetch_optional(pool)
+            .await
+        },
     )
-    .bind(key)
-    .fetch_optional(pool)
     .await
 }
 
@@ -1720,20 +1766,27 @@ pub async fn insert_idempotency_key(
     response: Option<&serde_json::Value>,
     expires_at: DateTime<Utc>,
 ) -> Result<()> {
-    sqlx::query(
-        r#"
-        INSERT INTO idempotency_keys (key, status, response, expires_at)
-        VALUES ($1, $2, $3, $4)
-        ON CONFLICT (key) DO NOTHING
-        "#,
+    with_timeout(
+        QueryTier::Write,
+        "INSERT INTO idempotency_keys ... ON CONFLICT (key) DO NOTHING",
+        async {
+            sqlx::query(
+                r#"
+                INSERT INTO idempotency_keys (key, status, response, expires_at)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (key) DO NOTHING
+                "#,
+            )
+            .bind(key)
+            .bind(status)
+            .bind(response)
+            .bind(expires_at)
+            .execute(pool)
+            .await?;
+            Ok(())
+        },
     )
-    .bind(key)
-    .bind(status)
-    .bind(response)
-    .bind(expires_at)
-    .execute(pool)
-    .await?;
-    Ok(())
+    .await
 }
 
 pub async fn update_idempotency_key_response(
@@ -1741,19 +1794,35 @@ pub async fn update_idempotency_key_response(
     key: &str,
     response: &serde_json::Value,
 ) -> Result<()> {
-    sqlx::query("UPDATE idempotency_keys SET response = $2, status = 'completed' WHERE key = $1")
-        .bind(key)
-        .bind(response)
-        .execute(pool)
-        .await?;
-    Ok(())
+    with_timeout(
+        QueryTier::Write,
+        "UPDATE idempotency_keys SET response = $2, status = 'completed' WHERE key = $1",
+        async {
+            sqlx::query(
+                "UPDATE idempotency_keys SET response = $2, status = 'completed' WHERE key = $1",
+            )
+            .bind(key)
+            .bind(response)
+            .execute(pool)
+            .await?;
+            Ok(())
+        },
+    )
+    .await
 }
 
 pub async fn cleanup_expired_idempotency_keys(pool: &PgPool) -> Result<u64> {
-    let result = sqlx::query("DELETE FROM idempotency_keys WHERE expires_at <= NOW()")
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected())
+    with_timeout(
+        QueryTier::Write,
+        "DELETE FROM idempotency_keys WHERE expires_at <= NOW()",
+        async {
+            let result = sqlx::query("DELETE FROM idempotency_keys WHERE expires_at <= NOW()")
+                .execute(pool)
+                .await?;
+            Ok(result.rows_affected())
+        },
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **#932** — `tenant_isolation` RLS policy on `transactions` unconditionally allowed `tenant_id IS NULL` rows to be read/written by *any* tenant session instead of admins only. Gated the NULL branch behind `app.is_admin` and added an explicit `WITH CHECK` so non-admins can no longer read or insert NULL-tenant rows.
- **#931** — `bulk_update_transaction_status` validated each transition against a stale, unlocked `SELECT` snapshot and then blindly bulk-`UPDATE`d, allowing a concurrent status change to be silently clobbered. Moved the read inside the update transaction with `SELECT ... FOR UPDATE`, matching the locked-row pattern already used by `update_settlement_status`.
- **#930** — Several query functions (`bulk_update_transaction_status`, `update_settlement_status`, `get_status_counts`, `get_asset_stats`, and the idempotency-key helpers) ran without `with_timeout`/`QueryTier`, contradicting the module's documented "all queries must be wrapped" invariant and leaving them able to hang indefinitely instead of failing fast. Wrapped them all with the appropriate tier.
- **#929** — `get_daily_totals` ran its aggregate query twice in every debug build (`EXPLAIN ANALYZE` executes the query, then the real query ran again). Now requires an explicit `DB_EXPLAIN_ANALYZE` env var opt-in in addition to `cfg!(debug_assertions)`.

Closes #932 
closes #931 
closes #930 
closes #929 

## Test plan
Per task instructions, tests were skipped for this change.