### PR TITLE
fix(xtask): resolve DATABASE_URL before psql seed

### DIFF
--- a/xtask/src/commands/setup.rs
+++ b/xtask/src/commands/setup.rs
@@ -84,10 +84,19 @@ fn run_migrations() -> anyhow::Result<()> {
 fn seed_data() -> anyhow::Result<()> {
     println!("\n-- Seeding initial data --");
     // Feature flags seed — non-fatal if psql is unavailable or row already exists.
+    // `run_cmd` uses `Command` (no shell), so `${DATABASE_URL}` would be passed
+    // literally; resolve the env var in Rust first.
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) if !url.is_empty() => url,
+        _ => {
+            println!("  Warning: DATABASE_URL not set — seed step skipped.");
+            return Ok(());
+        }
+    };
     let result = run_cmd(
         "psql",
         &[
-            "${DATABASE_URL}",
+            database_url.as_str(),
             "-c",
             "INSERT INTO feature_flags (name, enabled) VALUES ('dev_seed', true) ON CONFLICT DO NOTHING;",
         ],


### PR DESCRIPTION
## Summary
`seed_data()` passed `"${DATABASE_URL}"` to `psql` via `Command`, which does not shell-expand env vars — so seeding always failed and was swallowed as a warning.

This reads `DATABASE_URL` with `std::env::var` and passes the resolved value (or skips with a clear warning when unset).

Fixes #1012

## Test plan
- [ ] `DATABASE_URL=… cargo xtask setup` (or equivalent) inserts `dev_seed` when Postgres is up
- [ ] Unset `DATABASE_URL` prints the skip warning instead of a psql connection error to a literal `${DATABASE_URL}`