### PR TITLE
fix(cliff): use GitHub URLs for commit-hash links

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -23,7 +23,7 @@ body = """
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
 {{ commit.message | upper_first }}\
 {% if commit.breaking %} [**BREAKING**]{% endif %} \
-([`{{ commit.id | truncate(length=7, end="") }}`]({{ commit.id }}))\
+([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/Synapse-bridgez/synapse-core/commit/{{ commit.id }}))\
 {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
## Summary
`cliff.toml`'s changelog body used `]({{ commit.id }})` as the href, so every commit-hash link in generated changelogs was a bare SHA instead of a GitHub URL.

This prefixes the href with `https://github.com/Synapse-bridgez/synapse-core/commit/`, matching the existing issue/link parsers in the same file.

Fixes #1011

## Test plan
- [ ] `git cliff` (or project changelog regen) produces clickable `…/commit/<sha>` links
- [ ] Short SHA display text is unchanged