### PR TITLE
fix: resolve cache-stampede, env loading, and DATABASE_URL validation issues

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,13 +34,13 @@ impl AppEnv {
 }
 
 /// Load the profile-specific .env file (.env.development, .env.staging, .env.production)
-/// then fall back to the base .env. Profile file is loaded first so base .env can override.
+/// with precedence over the base .env. Profile-specific values override base .env values.
 fn load_env_profile(app_env: &AppEnv) {
     // Load base .env first (lowest priority)
     dotenv().ok();
-    // Load profile-specific file (higher priority — values set here override base .env)
+    // Load profile-specific file (higher priority — use _override to ensure it takes precedence)
     let profile_file = format!(".env.{}", app_env.as_str());
-    dotenvy::from_filename(&profile_file).ok();
+    dotenvy::from_filename_override(&profile_file).ok();
 }
 
 /// Apply profile defaults for any env vars not already set

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::secrets::SecretsManager;
-use anyhow::Result;
+use anyhow::{Result, Context};
 use dotenvy::dotenv;
 use ipnet::IpNet;
 use std::env;
@@ -194,7 +194,8 @@ impl Config {
             let db_template = env::var("DATABASE_URL_TEMPLATE").ok();
             let db_url = db_template
                 .map(|template| template.replace("{password}", &db_password))
-                .unwrap_or_else(|| env::var("DATABASE_URL").unwrap_or_default());
+                .or_else(|_| env::var("DATABASE_URL"))
+                .context("DATABASE_URL must be set (or DATABASE_URL_TEMPLATE when using Vault)")?;
 
             (db_url, anchor_secret)
         } else {

--- a/src/payments/pagination.rs
+++ b/src/payments/pagination.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, Mutex};
 use utoipa::ToSchema;
 
 /// Configuration for pagination caching.
@@ -82,6 +82,8 @@ impl CachedCount {
 pub struct PaginationManager {
     config: PaginationConfig,
     cached_counts: Arc<RwLock<std::collections::HashMap<String, CachedCount>>>,
+    // Per-key locks to prevent cache-stampede (single-flight pattern)
+    in_flight_locks: Arc<RwLock<std::collections::HashMap<String, Arc<Mutex<()>>>>>,
 }
 
 impl PaginationManager {
@@ -95,16 +97,40 @@ impl PaginationManager {
         Self {
             config,
             cached_counts: Arc::new(RwLock::new(std::collections::HashMap::new())),
+            in_flight_locks: Arc::new(RwLock::new(std::collections::HashMap::new())),
         }
     }
 
     /// Get or compute the total count for a query, with caching.
+    /// Uses a single-flight pattern to prevent cache-stampede when multiple
+    /// concurrent requests miss the cache for the same key.
     pub async fn get_cached_count(
         &self,
         cache_key: &str,
         compute_count: impl std::future::Future<Output = Result<u64, String>>,
     ) -> Result<u64, String> {
         // Check if we have a valid cached count
+        let cached = self.cached_counts.read().await;
+        if let Some(cached_count) = cached.get(cache_key) {
+            if !cached_count.is_expired(&self.config) {
+                return Ok(cached_count.count);
+            }
+        }
+        drop(cached);
+
+        // Get or create a per-key lock for single-flight coordination
+        let key_lock = {
+            let mut locks = self.in_flight_locks.write().await;
+            locks
+                .entry(cache_key.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+
+        // Acquire the per-key lock (only first requester proceeds, others wait)
+        let _guard = key_lock.lock().await;
+
+        // After acquiring lock, check cache again (another task may have computed it)
         let cached = self.cached_counts.read().await;
         if let Some(cached_count) = cached.get(cache_key) {
             if !cached_count.is_expired(&self.config) {
@@ -254,5 +280,47 @@ mod tests {
             .unwrap();
 
         assert_eq!(call_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_cache_stampede_prevention() {
+        // Verify that concurrent cache misses coalesce into a single computation
+        let manager = Arc::new(PaginationManager::new());
+        let call_count = Arc::new(tokio::sync::Mutex::new(0));
+
+        let mut handles = vec![];
+
+        // Spawn 5 concurrent requests that will all miss the cache
+        for _ in 0..5 {
+            let manager = manager.clone();
+            let call_count = call_count.clone();
+
+            let handle = tokio::spawn(async move {
+                let count = manager
+                    .get_cached_count("stampede_test", async {
+                        let mut count = call_count.lock().await;
+                        *count += 1;
+                        // Simulate expensive work
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        Ok::<u64, String>(42)
+                    })
+                    .await
+                    .unwrap();
+
+                count
+            });
+
+            handles.push(handle);
+        }
+
+        // Wait for all tasks to complete
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert_eq!(result, 42);
+        }
+
+        // Verify only one computation occurred (not 5)
+        let final_count = *call_count.lock().await;
+        assert_eq!(final_count, 1);
     }
 }


### PR DESCRIPTION
## Summary

This PR addresses three critical issues in the pagination and configuration subsystems:

1. **Cache-stampede prevention** — Concurrent cache misses no longer trigger multiple expensive COUNT queries
2. **Environment configuration precedence** — Profile-specific .env files now properly override base .env values  
3. **DATABASE_URL validation** — Vault-backed config now errors immediately with clear messages when DATABASE_URL is missing

## Changes

### #992 — Cache-stampede prevention
- Implement single-flight pattern using per-key async mutexes in `PaginationManager`
- Concurrent requesters for the same cache key now wait on a shared lock
- Only the first completes the expensive computation; others use cached result
- Add `test_cache_stampede_prevention()` to verify behavior

### #993 — Correct .env loading order
- Switch from `dotenvy::from_filename()` to `dotenvy::from_filename_override()` for profile files
- Ensures profile-specific values (rate limits, timeouts) properly take precedence over base .env
- Critical fix for production safety in fintech context

### #994 — Vault DATABASE_URL validation
- Replace `.unwrap_or_default()` with `.or_else().context()` pattern
- Align Vault path error handling with non-Vault path
- Clear error messages at config load time instead of cryptic pool-creation failures

Closes #992, Closes #993, Closes #994