### PR TITLE
fix: Vault token renewal and DB timeout config error handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -229,16 +229,13 @@ impl Config {
             db_timeouts: DbTimeoutConfig {
                 read_query_secs: env::var("DB_TIMEOUT_READ_SECS")
                     .unwrap_or_else(|_| "5".to_string())
-                    .parse()
-                    .unwrap_or(5),
+                    .parse()?,
                 write_query_secs: env::var("DB_TIMEOUT_WRITE_SECS")
                     .unwrap_or_else(|_| "10".to_string())
-                    .parse()
-                    .unwrap_or(10),
+                    .parse()?,
                 admin_query_secs: env::var("DB_TIMEOUT_ADMIN_SECS")
                     .unwrap_or_else(|_| "60".to_string())
-                    .parse()
-                    .unwrap_or(60),
+                    .parse()?,
             },
             otlp_endpoint: env::var("OTLP_ENDPOINT").ok(),
             cors_allowed_origins: env::var("CORS_ALLOWED_ORIGINS")

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -8,6 +8,7 @@ use tokio::sync::RwLock;
 use vaultrs::auth::approle;
 use vaultrs::client::{Client, VaultClient, VaultClientSettingsBuilder};
 use vaultrs::kv2;
+use vaultrs::token;
 
 use crate::auth::AuthRateLimiter;
 
@@ -183,13 +184,46 @@ impl SecretsManager {
 
     /// Spawn a background task that refreshes secrets from Vault every 5 minutes.
     /// Rotated secrets remain valid for a grace period so in-flight requests are not rejected.
-    pub fn start_refresh_task(self, store: SecretsStore) {
+    pub fn start_refresh_task(mut self, store: SecretsStore) {
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(REFRESH_INTERVAL);
             interval.tick().await; // skip the immediate first tick
             loop {
                 interval.tick().await;
                 tracing::info!("secrets_rotation: refreshing secrets from Vault");
+
+                // Renew token before each refresh to prevent expiration
+                if let Err(e) = token::renew_self(&self.client, None).await {
+                    tracing::warn!("secrets_rotation: failed to renew Vault token: {e}");
+                    // Attempt to re-authenticate if token renewal fails
+                    let role_id = match env::var("VAULT_ROLE_ID") {
+                        Ok(id) => id,
+                        Err(_) => {
+                            tracing::error!("secrets_rotation: VAULT_ROLE_ID not set, cannot re-authenticate");
+                            continue;
+                        }
+                    };
+                    let secret_id = match env::var("VAULT_SECRET_ID") {
+                        Ok(id) => id,
+                        Err(_) => {
+                            tracing::error!("secrets_rotation: VAULT_SECRET_ID not set, cannot re-authenticate");
+                            continue;
+                        }
+                    };
+                    let auth_mount = env::var("VAULT_AUTH_MOUNT")
+                        .unwrap_or_else(|_| "auth/approle".to_string());
+
+                    match approle::login(&self.client, &auth_mount, &role_id, &secret_id).await {
+                        Ok(auth) => {
+                            self.client.set_token(&auth.client_token);
+                            tracing::info!("secrets_rotation: successfully re-authenticated to Vault");
+                        }
+                        Err(e) => {
+                            tracing::error!("secrets_rotation: failed to re-authenticate to Vault: {e}");
+                            continue;
+                        }
+                    }
+                }
 
                 match self.get_anchor_secret().await {
                     Ok(new_secret) => {


### PR DESCRIPTION
## Summary

Fixes two critical configuration and security issues:
- **#996**: Vault AppRole token was never renewed, causing silent secret rotation failures after token TTL expiration
- **#995**: DB timeout config fields silently swallowed parse errors instead of failing fast like all other numeric fields

## Changes

### #995 — DB timeout config error handling
- Changed `DB_TIMEOUT_READ_SECS`, `DB_TIMEOUT_WRITE_SECS`, and `DB_TIMEOUT_ADMIN_SECS` from `.parse().unwrap_or(N)` to `.parse()?`
- Now fails loudly at startup on invalid values (typos, units like "30s", etc.)
- Matches error-handling convention used by every other numeric field in Config::load()

### #996 — Vault token renewal
- Added `token::renew_self()` call before each 5-minute secret refresh
- Implements fallback re-authentication via AppRole login if renewal fails
- Prevents silent permanent failure of secret rotation after token expiry
- Logs renewal failures and re-authentication attempts for observability

## Test plan

- Build check: cargo build
- Config parsing: invalid DB_TIMEOUT_* values now fail at startup (previously silent)
- Token renewal: verify no additional Vault auth errors in logs during normal operation

Closes #996, Closes #995