### PR TITLE
Fix/payments pool and errors

### DIFF
--- a/src/payments/connection_pool.rs
+++ b/src/payments/connection_pool.rs
@@ -1,30 +1,33 @@
-//! Secure connection pool for the Payments / settlement module.
+//! Connection metadata pool for the Payments / settlement module.
 //!
-//! Provides a bounded, validated connection pool for the database connections
-//! used by settlement logic.  The pool enforces hard resource caps, validates
-//! endpoint configuration at construction time, and evicts stale connections
-//! lazily to prevent unbounded resource hold.
+//! Provides metadata tracking and lifecycle management for connections to the database
+//! used by settlement logic. The pool enforces hard resource caps, validates endpoint
+//! configuration at construction time, and evicts stale connections lazily.
 //!
-//! # Security guarantees
+//! **Note:** This implementation currently manages only connection *metadata*
+//! (IDs, endpoint labels, idle tracking) and does not establish or execute queries
+//! against actual database connections. Real sqlx connection pooling integration
+//! is not yet implemented.
+//!
+//! # Security guarantees (metadata layer)
 //!
 //! - The database URL is validated for scheme (`postgres://` / `postgresql://`)
-//!   and maximum length before any connection is created, preventing injection
-//!   and SSRF vectors.
+//!   and maximum length, preventing injection and SSRF vectors.
 //! - Pool size is hard-capped at [`PaymentsPoolConfig::max_size`]; acquisition
-//!   attempts beyond this limit return [`PaymentsPoolError::Exhausted`] rather
-//!   than blocking or allocating unboundedly.
-//! - Stale idle connections are evicted lazily on the next pool operation.
+//!   attempts beyond this limit return [`PaymentsPoolError::Exhausted`].
+//! - Stale idle connections are tracked and evicted lazily on the next pool operation.
 //! - Poisoned mutexes are recovered non-fatally so a panicking thread cannot
-//!   permanently disable the payments layer.
+//!   permanently disable the pool.
 //!
-//! # Usage
+//! # Usage (metadata tracking only)
 //!
 //! ```text
 //! use synapse_core::payments::connection_pool::{PaymentsConnectionPool, PaymentsPoolConfig};
 //!
 //! let pool = PaymentsConnectionPool::new()?;
 //! let conn = pool.acquire()?;
-//! // … execute settlement query …
+//! // conn tracks metadata (id, endpoint, idle time) only
+//! // TODO: No actual database query execution is currently possible
 //! pool.release(conn);
 //! ```
 

--- a/src/payments/connection_pool.rs
+++ b/src/payments/connection_pool.rs
@@ -245,13 +245,19 @@ impl PaymentsConnectionPool {
     }
 
     /// Number of idle connections currently available in the pool.
+    ///
+    /// Recovers gracefully from poisoned mutexes, consistent with acquire/release.
     pub fn idle_count(&self) -> usize {
-        self.state.lock().map(|s| s.available.len()).unwrap_or(0)
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.available.len()
     }
 
     /// Total connections managed by the pool (idle + currently in use).
+    ///
+    /// Recovers gracefully from poisoned mutexes, consistent with acquire/release.
     pub fn total_count(&self) -> usize {
-        self.state.lock().map(|s| s.total).unwrap_or(0)
+        let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.total
     }
 
     fn evict_stale_locked(&self, state: &mut PoolState) {

--- a/src/payments/error.rs
+++ b/src/payments/error.rs
@@ -41,7 +41,10 @@ pub enum PaymentError {
     NotFound(String),
 
     /// An underlying database operation failed.
-    #[error("Database error: {0}")]
+    /// The wrapped string is server-side log context only; the client receives
+    /// a generic message to prevent information leakage. Raw error details must
+    /// be logged by the caller before constructing this variant.
+    #[error("Database error")]
     Database(String),
 }
 
@@ -55,7 +58,8 @@ impl From<PaymentError> for AppError {
             PaymentError::InvalidTransition(msg) => AppError::InvalidStatusTransition(msg),
             PaymentError::AlreadyExists(msg) => AppError::SettlementAlreadyExists(msg),
             PaymentError::NotFound(msg) => AppError::NotFound(msg),
-            PaymentError::Database(msg) => AppError::DatabaseError(msg),
+            // Only pass "Database error" generic message to AppError, never the wrapped string
+            PaymentError::Database(_) => AppError::DatabaseError("Database error".to_string()),
         }
     }
 }
@@ -202,11 +206,10 @@ mod tests {
     }
 
     #[test]
-    fn database_error_message_not_empty() {
+    fn database_error_message_is_generic() {
         let err = PaymentError::Database("connection timeout".into());
         let msg = err.to_string();
-        assert!(!msg.is_empty());
-        assert!(msg.contains("Database error"));
+        assert_eq!(msg, "Database error");
     }
 
     // --- Error Propagation and Conversion Tests ---
@@ -323,11 +326,18 @@ mod tests {
     #[test]
     fn error_messages_do_not_leak_sensitive_details() {
         // Error messages should be user-facing, not expose internal details
-        let db_err = PaymentError::Database("password=secret123".into());
+        let raw_db_error = "connection refused: password=admin123 user=root table=payments_transactions";
+        let db_err = PaymentError::Database(raw_db_error.into());
         let msg = db_err.to_string();
-        // Message should not contain raw database error with credentials
-        // (In this test we verify the message is generated without leaking)
-        assert!(!msg.is_empty());
+
+        // Verify only generic error message is displayed
+        assert_eq!(msg, "Database error");
+        // Verify no credentials/table names are leaked in the Display output
+        assert!(!msg.contains("password"));
+        assert!(!msg.contains("admin123"));
+        assert!(!msg.contains("user=root"));
+        assert!(!msg.contains("payments_transactions"));
+        assert!(!msg.contains("connection refused"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

   Fixes three security and consistency issues in the payments module:

   ## Changes

   ### #989 — PaymentsConnectionPool documentation clarification
   - Updated module docs to accurately reflect that the pool currently manages only connection *metadata* (IDs, endpoints, idle tracking), not
   actual database connections
   - Removed misleading usage example that implied real SQL query execution
   - Added note that real sqlx connection pooling integration is not yet implemented

   ### #990 — Consistent poisoned mutex recovery
   - Fixed \`idle_count()\` and \`total_count()\` to recover gracefully from poisoned mutexes using \`.unwrap_or_else(|e| e.into_inner())\`
   - Now consistent with how \`acquire()\` and \`release()\` handle poisoned state
   - Prevents misleading \"pool is empty\" reports when mutex is poisoned

   ### #991 — Database error message sanitization
   - Changed \`PaymentError::Database\` to display only generic \"Database error\" message to clients
   - Prevents leaking raw database error details (table/column names, query fragments, credentials) to HTTP responses
   - Raw error details must be logged server-side by the caller
   - Updated test to verify no sensitive details leak in client-facing messages

   Closes #989, Closes #990, Closes #991