### PR TITLE
fix(cli): close parenthesis in tx search summary

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1490,7 +1490,7 @@ pub async fn handle_tx_search(
                         );
                     }
                     println!(
-                        "\n✓ {} results (total: {}",
+                        "\n✓ {} results (total: {})",
                         response.results.len(),
                         response.total
                     );


### PR DESCRIPTION
## Summary
`tx search` (table format) used `"\n✓ {} results (total: {}"` without the closing `)`, so output looked like `✓ 5 results (total: 12`.

Fixes #1002

## Test plan
- [ ] Format string is `"\n✓ {} results (total: {})"`
- [ ] Matches other summary lines in `src/cli.rs`