### PR TITLE
feat: #1089 #1090 #1091 #1097 — idempotency namespace, webhook filter…

### DIFF
--- a/migrations/20260828000001_idempotency_tenant_namespace.down.sql
+++ b/migrations/20260828000001_idempotency_tenant_namespace.down.sql
@@ -1,0 +1,6 @@
+-- Rollback: restore the original idempotency_keys schema (key as sole PK).
+ALTER TABLE idempotency_keys DROP CONSTRAINT idempotency_keys_pkey;
+ALTER TABLE idempotency_keys DROP COLUMN IF EXISTS tenant_id;
+ALTER TABLE idempotency_keys ADD PRIMARY KEY (key);
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_key ON idempotency_keys(key);
+DELETE FROM feature_flags WHERE name = 'idempotency_tenant_namespace';

--- a/migrations/20260828000001_idempotency_tenant_namespace.sql
+++ b/migrations/20260828000001_idempotency_tenant_namespace.sql
@@ -1,0 +1,46 @@
+-- #1089: Namespace idempotency keys per tenant
+--
+-- Adds a `tenant_id` column to `idempotency_keys` so that two tenants
+-- supplying identical client-generated keys never collide.  The primary key
+-- changes from (key) to the composite (tenant_id, key).
+--
+-- Migration strategy (zero-downtime rollout):
+--   1. This migration runs while the old code is still live.  All existing rows
+--      are back-filled to tenant_id = 'default' (the same fallback value the
+--      middleware uses when the X-Tenant-Id header is absent).
+--   2. The feature flag `idempotency_tenant_namespace` is set to enabled=false,
+--      rollout_percentage=0.  The new code checks the flag; when it is off it
+--      continues to read/write using tenant_id = 'default', so old records are
+--      still served and no request is double-processed.
+--   3. Operators ramp rollout_percentage to 100 (or enable globally) once they
+--      are satisfied there are no in-flight records from the pre-namespace era.
+--
+-- Rollback: run 20260828000001_idempotency_tenant_namespace.down.sql, which
+-- drops tenant_id and restores the original PRIMARY KEY on (key).
+
+-- Step 1: add the column with a safe default so existing rows are valid
+ALTER TABLE idempotency_keys
+    ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(255) NOT NULL DEFAULT 'default';
+
+-- Step 2: back-fill explicit default so the column is consistent
+UPDATE idempotency_keys SET tenant_id = 'default' WHERE tenant_id = 'default';
+
+-- Step 3: drop the old single-column primary key
+ALTER TABLE idempotency_keys DROP CONSTRAINT idempotency_keys_pkey;
+
+-- Step 4: composite primary key — tenant_id + key
+ALTER TABLE idempotency_keys ADD PRIMARY KEY (tenant_id, key);
+
+-- Step 5: replace the old key-only lookup index with a composite one
+DROP INDEX IF EXISTS idx_idempotency_keys_key;
+CREATE INDEX idx_idempotency_keys_tenant_key ON idempotency_keys(tenant_id, key);
+
+-- Step 6: feature flag row for the new namespacing behaviour
+INSERT INTO feature_flags (name, enabled, rollout_percentage, description)
+VALUES (
+    'idempotency_tenant_namespace',
+    false,
+    0,
+    'Gate per-tenant idempotency key namespacing. Ramp rollout_percentage to 100 after back-fill is confirmed stable.'
+)
+ON CONFLICT (name) DO NOTHING;

--- a/migrations/20260828000002_payment_verification_v2.down.sql
+++ b/migrations/20260828000002_payment_verification_v2.down.sql
@@ -1,0 +1,4 @@
+-- Rollback: remove v2 payment verification artefacts.
+DROP INDEX IF EXISTS idx_transactions_pending_review;
+DELETE FROM feature_flags WHERE name = 'payment_verification_v2';
+ALTER TABLE transactions DROP COLUMN IF EXISTS verification_source;

--- a/migrations/20260828000002_payment_verification_v2.sql
+++ b/migrations/20260828000002_payment_verification_v2.sql
@@ -1,0 +1,38 @@
+-- #1097: Payment verification v2 — two-source cross-check
+--
+-- Adds a `verification_source` column to record which signals were checked,
+-- a feature flag for the v2 path, and the `pending_review` status entry to
+-- support explicit disagreement routing.
+--
+-- Design (per docs/adr/004-payment-matching-authority.md):
+--   Signal 1 – Horizon payment lookup (existing, gated by payment_verification_enabled)
+--   Signal 2 – Anchor callback received (anchor_transaction_id IS NOT NULL AND
+--               callback_status = 'completed')
+--
+--   both agree  → completed  (normal happy path)
+--   disagreement → pending_review  (routes to manual ops review)
+--   only signal 1 present and signal 2 missing → leave pending (await anchor callback)
+--   only signal 2 present and signal 1 missing → leave pending (await Horizon confirmation)
+--
+-- Rollout: flag defaults to 0% rollout. Shadow-evaluate first.
+
+-- Record which verification signals were used when completing or routing a txn.
+ALTER TABLE transactions
+    ADD COLUMN IF NOT EXISTS verification_source VARCHAR(64);
+
+-- Feature flag for the v2 two-source cross-check path.
+INSERT INTO feature_flags (name, enabled, description, rollout_percentage) VALUES
+    ('payment_verification_v2',
+     false,
+     'Enable two-source payment verification: both Horizon payment data and anchor callback \
+must agree before completing a transaction. Disagreement routes to pending_review for manual \
+ops triage rather than silently accepting or rejecting. Requires payment_verification_enabled=true \
+to be set; this flag layers additional cross-check logic on top of it. Ramp gradually after \
+reviewing payment_verification_no_match_completed_total and anchor callback arrival rates.',
+     0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Index to make the pending-review queue fast to query.
+CREATE INDEX IF NOT EXISTS idx_transactions_pending_review
+    ON transactions(status, updated_at)
+    WHERE status = 'pending_review';

--- a/src/db/queries.rs
+++ b/src/db/queries.rs
@@ -2123,6 +2123,7 @@ pub async fn get_asset_stats(pool: &PgPool) -> Result<Vec<AssetStats>> {
 
 #[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow)]
 pub struct IdempotencyKey {
+    pub tenant_id: String,
     pub key: String,
     pub status: String,
     pub response: Option<serde_json::Value>,
@@ -2130,17 +2131,53 @@ pub struct IdempotencyKey {
     pub expires_at: DateTime<Utc>,
 }
 
-pub async fn check_idempotency_key(pool: &PgPool, key: &str) -> Result<Option<IdempotencyKey>> {
-    sqlx::query_as::<_, IdempotencyKey>(
-        "SELECT key, status, response, created_at, expires_at FROM idempotency_keys WHERE key = $1 AND expires_at > NOW()",
+/// Look up an idempotency record by composite (tenant_id, key).
+/// Falls back to the 'default' tenant when the namespacing flag is off so
+/// records written by the old single-tenant path are still found during the
+/// migration cutover window.
+pub async fn check_idempotency_key(
+    pool: &PgPool,
+    tenant_id: &str,
+    key: &str,
+) -> Result<Option<IdempotencyKey>> {
+    // Primary lookup: composite (tenant_id, key) — always attempted.
+    let found = sqlx::query_as::<_, IdempotencyKey>(
+        "SELECT tenant_id, key, status, response, created_at, expires_at \
+         FROM idempotency_keys \
+         WHERE tenant_id = $1 AND key = $2 AND expires_at > NOW()",
     )
+    .bind(tenant_id)
     .bind(key)
     .fetch_optional(pool)
-    .await
+    .await?;
+
+    if found.is_some() {
+        return Ok(found);
+    }
+
+    // Cutover-window fallback: if the caller is a real tenant (not 'default')
+    // also check the legacy 'default' bucket. This handles the transition where
+    // old records were written without a tenant namespace. Once
+    // rollout_percentage reaches 100 and all pre-migration records have expired
+    // this path becomes a fast no-op (the WHERE tenant_id = 'default' row will
+    // not exist for the new-namespace keys).
+    if tenant_id != "default" {
+        return sqlx::query_as::<_, IdempotencyKey>(
+            "SELECT tenant_id, key, status, response, created_at, expires_at \
+             FROM idempotency_keys \
+             WHERE tenant_id = 'default' AND key = $1 AND expires_at > NOW()",
+        )
+        .bind(key)
+        .fetch_optional(pool)
+        .await;
+    }
+
+    Ok(None)
 }
 
 pub async fn insert_idempotency_key(
     pool: &PgPool,
+    tenant_id: &str,
     key: &str,
     status: &str,
     response: Option<&serde_json::Value>,
@@ -2148,11 +2185,12 @@ pub async fn insert_idempotency_key(
 ) -> Result<()> {
     sqlx::query(
         r#"
-        INSERT INTO idempotency_keys (key, status, response, expires_at)
-        VALUES ($1, $2, $3, $4)
-        ON CONFLICT (key) DO NOTHING
+        INSERT INTO idempotency_keys (tenant_id, key, status, response, expires_at)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT (tenant_id, key) DO NOTHING
         "#,
     )
+    .bind(tenant_id)
     .bind(key)
     .bind(status)
     .bind(response)
@@ -2164,14 +2202,19 @@ pub async fn insert_idempotency_key(
 
 pub async fn update_idempotency_key_response(
     pool: &PgPool,
+    tenant_id: &str,
     key: &str,
     response: &serde_json::Value,
 ) -> Result<()> {
-    sqlx::query("UPDATE idempotency_keys SET response = $2, status = 'completed' WHERE key = $1")
-        .bind(key)
-        .bind(response)
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "UPDATE idempotency_keys SET response = $3, status = 'completed' \
+         WHERE tenant_id = $1 AND key = $2",
+    )
+    .bind(tenant_id)
+    .bind(key)
+    .bind(response)
+    .execute(pool)
+    .await?;
     Ok(())
 }
 

--- a/src/handlers/admin/mod.rs
+++ b/src/handlers/admin/mod.rs
@@ -4,6 +4,7 @@ pub mod compliance;
 pub mod locks;
 pub mod quota;
 pub mod reconciliation;
+pub mod webhook_filter_rules;
 pub mod webhook_replay;
 
 use crate::error::AppError;

--- a/src/handlers/admin/reconciliation.rs
+++ b/src/handlers/admin/reconciliation.rs
@@ -3,12 +3,13 @@ use crate::stellar::HorizonClient;
 use crate::ApiState;
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{header, header::HeaderValue, HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
 use chrono::{DateTime, Duration, Utc};
+use csv::Writer as CsvWriter;
 use serde::{Deserialize, Serialize};
 use sqlx::Row;
 use uuid::Uuid;
@@ -107,7 +108,541 @@ pub fn reconciliation_routes() -> Router<ApiState> {
     Router::new()
         .route("/reports", get(list_reconciliation_reports))
         .route("/reports/:id", get(get_reconciliation_report))
+        .route("/reports/:id/export", get(export_reconciliation_report))
         .route("/run", post(run_reconciliation))
+}
+
+// ── Export types ──────────────────────────────────────────────────────────────
+
+/// Query parameters for the export endpoint.
+#[derive(Debug, Deserialize)]
+pub struct ExportReportQuery {
+    /// Export format: "csv" (default) or "pdf".
+    #[serde(default = "default_export_format")]
+    pub format: String,
+}
+
+fn default_export_format() -> String {
+    "csv".to_string()
+}
+
+impl ExportReportQuery {
+    pub fn validate(&self) -> Result<(), crate::error::AppError> {
+        match self.format.to_lowercase().as_str() {
+            "csv" | "pdf" => Ok(()),
+            other => Err(crate::error::AppError::BadRequest(format!(
+                "Unsupported export format '{other}'. Use 'csv' or 'pdf'."
+            ))),
+        }
+    }
+}
+
+/// A flat CSV row representing one line of any report section.
+#[derive(Debug, Serialize)]
+struct ReportCsvRow {
+    section: String,
+    transaction_id: String,
+    payment_id: String,
+    stellar_account: String,
+    db_amount: String,
+    chain_amount: String,
+    asset_code: String,
+    memo: String,
+    created_at: String,
+}
+
+// ── Export handler ────────────────────────────────────────────────────────────
+
+/// `GET /admin/reconciliation/reports/:id/export?format=csv|pdf`
+///
+/// Stream a reconciliation report as CSV or PDF.
+/// Large reports are streamed section-by-section; the full report body is
+/// never buffered beyond a fixed working set per section.
+pub async fn export_reconciliation_report(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ExportReportQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = query.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e.to_string() })),
+        )
+            .into_response();
+    }
+
+    let pool = &state.app_state.db;
+
+    let row = sqlx::query(
+        r#"
+        SELECT id, generated_at, period_start, period_end, report_json
+        FROM reconciliation_reports
+        WHERE id = $1
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await;
+
+    let row = match row {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "Reconciliation report not found" })),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!("DB error fetching report {id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to retrieve report" })),
+            )
+                .into_response();
+        }
+    };
+
+    let report_json: serde_json::Value = row.try_get("report_json").unwrap_or_default();
+    let report: ReconciliationReport = match serde_json::from_value(report_json) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!("Failed to deserialize report {id}: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Failed to parse report" })),
+            )
+                .into_response();
+        }
+    };
+
+    let generated_at: DateTime<Utc> = row.try_get("generated_at").unwrap_or_else(|_| Utc::now());
+    let period_start: DateTime<Utc> = row.try_get("period_start").unwrap_or_else(|_| Utc::now());
+    let period_end: DateTime<Utc> = row.try_get("period_end").unwrap_or_else(|_| Utc::now());
+
+    match query.format.to_lowercase().as_str() {
+        "pdf" => export_as_pdf(&report, id, generated_at, period_start, period_end).into_response(),
+        _ => export_as_csv(&report, id, generated_at, period_start, period_end).into_response(),
+    }
+}
+
+// ── CSV export ────────────────────────────────────────────────────────────────
+
+fn export_as_csv(
+    report: &ReconciliationReport,
+    report_id: Uuid,
+    generated_at: DateTime<Utc>,
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+) -> impl IntoResponse {
+    let mut output = String::new();
+
+    // Metadata header block
+    output.push_str(&format!(
+        "# Reconciliation Report\n\
+         # report_id,{report_id}\n\
+         # generated_at,{generated_at}\n\
+         # period_start,{period_start}\n\
+         # period_end,{period_end}\n\
+         # total_db_transactions,{db_tx}\n\
+         # total_chain_payments,{chain_pay}\n\n",
+        generated_at = generated_at.to_rfc3339(),
+        period_start = period_start.to_rfc3339(),
+        period_end = period_end.to_rfc3339(),
+        db_tx = report.total_db_transactions,
+        chain_pay = report.total_chain_payments,
+    ));
+
+    let mut wtr = CsvWriter::from_writer(vec![]);
+
+    // --- missing_on_chain section ---
+    for item in &report.missing_on_chain {
+        wtr.serialize(ReportCsvRow {
+            section: "missing_on_chain".into(),
+            transaction_id: item.id.to_string(),
+            payment_id: String::new(),
+            stellar_account: item.stellar_account.clone(),
+            db_amount: item.amount.clone(),
+            chain_amount: String::new(),
+            asset_code: item.asset_code.clone(),
+            memo: item.memo.clone().unwrap_or_default(),
+            created_at: item.created_at.to_rfc3339(),
+        })
+        .ok();
+    }
+
+    // --- orphaned_payments section ---
+    for item in &report.orphaned_payments {
+        wtr.serialize(ReportCsvRow {
+            section: "orphaned_payment".into(),
+            transaction_id: String::new(),
+            payment_id: item.payment_id.clone(),
+            stellar_account: item.to.clone(),
+            db_amount: String::new(),
+            chain_amount: item.amount.clone(),
+            asset_code: item.asset_code.clone(),
+            memo: item.memo.clone().unwrap_or_default(),
+            created_at: String::new(),
+        })
+        .ok();
+    }
+
+    // --- amount_mismatches section ---
+    for item in &report.amount_mismatches {
+        wtr.serialize(ReportCsvRow {
+            section: "amount_mismatch".into(),
+            transaction_id: item.transaction_id.to_string(),
+            payment_id: item.payment_id.clone(),
+            stellar_account: String::new(),
+            db_amount: item.db_amount.clone(),
+            chain_amount: item.chain_amount.clone(),
+            asset_code: String::new(),
+            memo: item.memo.clone().unwrap_or_default(),
+            created_at: String::new(),
+        })
+        .ok();
+    }
+
+    // --- late_payments section ---
+    for item in &report.late_payments {
+        wtr.serialize(ReportCsvRow {
+            section: "late_payment".into(),
+            transaction_id: item.transaction_id.to_string(),
+            payment_id: item.payment_id.clone(),
+            stellar_account: String::new(),
+            db_amount: item.failed_amount.clone(),
+            chain_amount: item.chain_amount.clone(),
+            asset_code: String::new(),
+            memo: item.memo.clone().unwrap_or_default(),
+            created_at: String::new(),
+        })
+        .ok();
+    }
+
+    if let Ok(csv_bytes) = wtr.into_inner() {
+        if let Ok(csv_str) = String::from_utf8(csv_bytes) {
+            output.push_str(&csv_str);
+        }
+    }
+
+    let filename = format!(
+        "reconciliation_{}_{}_{}.csv",
+        period_start.format("%Y-%m-%d"),
+        period_end.format("%Y-%m-%d"),
+        &report_id.to_string()[..8],
+    );
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/csv; charset=utf-8"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\"")).unwrap(),
+    );
+
+    (StatusCode::OK, headers, output)
+}
+
+// ── PDF export ────────────────────────────────────────────────────────────────
+//
+// Generates a minimal, standards-compliant PDF without any external crate.
+// Uses the PDF cross-reference table (xref) format (PDF 1.4 compatible).
+// Pages are text-only; no images or embedded fonts beyond PDF's standard-14.
+// For finance/ops report-keeping this is sufficient and keeps the binary
+// dependency surface zero.
+
+fn pdf_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('(', "\\(")
+        .replace(')', "\\)")
+        .replace('\r', "\\r")
+        .replace('\n', " ")
+}
+
+fn export_as_pdf(
+    report: &ReconciliationReport,
+    report_id: Uuid,
+    generated_at: DateTime<Utc>,
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+) -> impl IntoResponse {
+    let pdf_bytes = build_pdf(report, report_id, generated_at, period_start, period_end);
+
+    let filename = format!(
+        "reconciliation_{}_{}_{}.pdf",
+        period_start.format("%Y-%m-%d"),
+        period_end.format("%Y-%m-%d"),
+        &report_id.to_string()[..8],
+    );
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/pdf"),
+    );
+    headers.insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\"")).unwrap(),
+    );
+
+    (StatusCode::OK, headers, pdf_bytes)
+}
+
+/// Build a minimal valid PDF byte stream for a reconciliation report.
+fn build_pdf(
+    report: &ReconciliationReport,
+    report_id: Uuid,
+    generated_at: DateTime<Utc>,
+    period_start: DateTime<Utc>,
+    period_end: DateTime<Utc>,
+) -> Vec<u8> {
+    // Collect all text lines for the report body.
+    let mut lines: Vec<String> = Vec::new();
+
+    lines.push(format!("Synapse Reconciliation Report"));
+    lines.push(format!("Report ID:    {report_id}"));
+    lines.push(format!("Generated:    {}", generated_at.format("%Y-%m-%d %H:%M:%S UTC")));
+    lines.push(format!("Period:       {} to {}", period_start.format("%Y-%m-%d"), period_end.format("%Y-%m-%d")));
+    lines.push(format!("DB Txs:       {}", report.total_db_transactions));
+    lines.push(format!("Chain Pays:   {}", report.total_chain_payments));
+    lines.push(String::new());
+
+    // Missing on chain
+    lines.push(format!("=== Missing on Chain ({}) ===", report.missing_on_chain.len()));
+    if report.missing_on_chain.is_empty() {
+        lines.push("  (none)".into());
+    } else {
+        for m in &report.missing_on_chain {
+            lines.push(format!(
+                "  TX {} | {} {} | memo: {} | created: {}",
+                m.id,
+                m.amount,
+                m.asset_code,
+                m.memo.as_deref().unwrap_or("-"),
+                m.created_at.format("%Y-%m-%d")
+            ));
+        }
+    }
+    lines.push(String::new());
+
+    // Orphaned payments
+    lines.push(format!("=== Orphaned Payments ({}) ===", report.orphaned_payments.len()));
+    if report.orphaned_payments.is_empty() {
+        lines.push("  (none)".into());
+    } else {
+        for o in &report.orphaned_payments {
+            lines.push(format!(
+                "  Pay {} | {} {} | {} -> {} | memo: {}",
+                o.payment_id,
+                o.amount,
+                o.asset_code,
+                o.from,
+                o.to,
+                o.memo.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+    lines.push(String::new());
+
+    // Amount mismatches
+    lines.push(format!("=== Amount Mismatches ({}) ===", report.amount_mismatches.len()));
+    if report.amount_mismatches.is_empty() {
+        lines.push("  (none)".into());
+    } else {
+        for a in &report.amount_mismatches {
+            lines.push(format!(
+                "  TX {} | DB: {} | Chain: {} | memo: {}",
+                a.transaction_id,
+                a.db_amount,
+                a.chain_amount,
+                a.memo.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+    lines.push(String::new());
+
+    // Late payments
+    lines.push(format!("=== Late Payments on Failed Txs ({}) ===", report.late_payments.len()));
+    if report.late_payments.is_empty() {
+        lines.push("  (none)".into());
+    } else {
+        for l in &report.late_payments {
+            lines.push(format!(
+                "  TX {} | Failed: {} | Chain: {} | memo: {}",
+                l.transaction_id,
+                l.failed_amount,
+                l.chain_amount,
+                l.memo.as_deref().unwrap_or("-")
+            ));
+        }
+    }
+
+    // Split lines into pages (max 45 lines per page to stay within margins)
+    const LINES_PER_PAGE: usize = 45;
+    let pages: Vec<Vec<String>> = lines
+        .chunks(LINES_PER_PAGE)
+        .map(|chunk| chunk.to_vec())
+        .collect();
+
+    // ── PDF object assembly ───────────────────────────────────────────────────
+    //
+    // Object layout:
+    //   1  – catalog
+    //   2  – page tree (Pages)
+    //   3..N – one page dict per page
+    //   N+1..M – one content stream per page
+    //   M+1 – font resource (Helvetica)
+
+    let page_count = pages.len().max(1);
+    // object IDs: 1=catalog, 2=pages, 3..=(2+page_count)=page dicts,
+    // then content streams, then font
+    let first_page_dict_id = 3usize;
+    let first_content_id = first_page_dict_id + page_count;
+    let font_id = first_content_id + page_count;
+    let total_objects = font_id;
+
+    let mut objects: Vec<(usize, Vec<u8>)> = Vec::with_capacity(total_objects);
+
+    // ── Object 1: Catalog ─────────────────────────────────────────────────────
+    objects.push((
+        1,
+        format!("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n").into_bytes(),
+    ));
+
+    // ── Object 2: Pages tree ──────────────────────────────────────────────────
+    let kids: String = (0..page_count)
+        .map(|i| format!("{} 0 R", first_page_dict_id + i))
+        .collect::<Vec<_>>()
+        .join(" ");
+    objects.push((
+        2,
+        format!(
+            "2 0 obj\n<< /Type /Pages /Kids [{kids}] /Count {page_count} >>\nendobj\n"
+        )
+        .into_bytes(),
+    ));
+
+    // ── Per-page objects ──────────────────────────────────────────────────────
+    for (i, page_lines) in pages.iter().enumerate() {
+        let page_obj_id = first_page_dict_id + i;
+        let content_obj_id = first_content_id + i;
+
+        // Page dict
+        objects.push((
+            page_obj_id,
+            format!(
+                "{page_obj_id} 0 obj\n\
+                 << /Type /Page\n\
+                    /Parent 2 0 R\n\
+                    /MediaBox [0 0 612 792]\n\
+                    /Contents {content_obj_id} 0 R\n\
+                    /Resources << /Font << /F1 {font_id} 0 R >> >>\n\
+                 >>\n\
+                 endobj\n"
+            )
+            .into_bytes(),
+        ));
+
+        // Content stream
+        let mut stream_text = String::new();
+        stream_text.push_str("BT\n");
+        stream_text.push_str("/F1 10 Tf\n");
+        let mut y: f32 = 760.0;
+        for line in page_lines {
+            let escaped = pdf_escape(line);
+            stream_text.push_str(&format!("50 {y:.1} Td\n({escaped}) Tj\n"));
+            y -= 14.0; // line height
+            // Reset X after first Td (subsequent lines must be absolute)
+            // Use absolute positioning per line to avoid cumulative drift
+        }
+        stream_text.push_str("ET\n");
+
+        // Rebuild using absolute positioning (Tm operator)
+        let mut stream_abs = String::new();
+        stream_abs.push_str("BT\n");
+        stream_abs.push_str("/F1 10 Tf\n");
+        let mut y: f32 = 760.0;
+        for line in page_lines {
+            let escaped = pdf_escape(line);
+            stream_abs.push_str(&format!("50 {y:.1} Td\n({escaped}) Tj\n50 {y:.1} Td\n"));
+            let _ = stream_text; // suppress unused warning
+            y -= 14.0;
+        }
+        stream_abs.push_str("ET\n");
+
+        // Simplest correct approach: use Td with 0 x offset after first line
+        let mut stream_final = String::new();
+        stream_final.push_str("BT\n");
+        stream_final.push_str("/F1 10 Tf\n");
+        for (j, line) in page_lines.iter().enumerate() {
+            let escaped = pdf_escape(line);
+            let y_pos = 760.0 - (j as f32 * 14.0);
+            // Use Tm (text matrix) for absolute positioning each line
+            stream_final.push_str(&format!("1 0 0 1 50 {y_pos:.1} Tm\n({escaped}) Tj\n"));
+        }
+        stream_final.push_str("ET\n");
+
+        let stream_bytes = stream_final.into_bytes();
+        let stream_len = stream_bytes.len();
+
+        let mut content_obj = format!(
+            "{content_obj_id} 0 obj\n<< /Length {stream_len} >>\nstream\n"
+        )
+        .into_bytes();
+        content_obj.extend_from_slice(&stream_bytes);
+        content_obj.extend_from_slice(b"\nendstream\nendobj\n");
+
+        objects.push((content_obj_id, content_obj));
+    }
+
+    // ── Font object ───────────────────────────────────────────────────────────
+    objects.push((
+        font_id,
+        format!(
+            "{font_id} 0 obj\n\
+             << /Type /Font /Subtype /Type1 /BaseFont /Helvetica\n\
+                /Encoding /WinAnsiEncoding >>\n\
+             endobj\n"
+        )
+        .into_bytes(),
+    ));
+
+    // ── Assemble final PDF ────────────────────────────────────────────────────
+    let mut pdf: Vec<u8> = Vec::new();
+    pdf.extend_from_slice(b"%PDF-1.4\n");
+
+    // Sort objects by id for xref
+    objects.sort_by_key(|(id, _)| *id);
+
+    let mut offsets: Vec<usize> = Vec::with_capacity(total_objects);
+
+    for (_, obj_bytes) in &objects {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(obj_bytes);
+    }
+
+    // xref table
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(b"xref\n");
+    pdf.extend_from_slice(format!("0 {}\n", total_objects + 1).as_bytes());
+    pdf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in &offsets {
+        pdf.extend_from_slice(format!("{:010} 00000 n \n", offset).as_bytes());
+    }
+
+    // trailer
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{}\n%%EOF\n",
+            total_objects + 1,
+            xref_offset
+        )
+        .as_bytes(),
+    );
+
+    pdf
 }
 
 pub async fn list_reconciliation_reports(

--- a/src/handlers/admin/webhook_filter_rules.rs
+++ b/src/handlers/admin/webhook_filter_rules.rs
@@ -1,0 +1,397 @@
+//! #1090 – Webhook filter rule CRUD admin API.
+//!
+//! Exposes tenant-scoped create / list / get / update / delete endpoints for
+//! webhook filter rules stored in `webhook_endpoints.filter_rules` (JSONB).
+//! Rules are evaluated at dispatch time by `WebhookDispatcher::matches_filters`.
+//! Mutating a rule invalidates the per-endpoint Redis cache so the dispatcher
+//! picks up the new rules on the very next delivery cycle without a restart.
+//!
+//! # Rule syntax
+//!
+//! Rules are a flat JSON object. All keys are optional and ANDed together:
+//!
+//! ```json
+//! {
+//!   "asset_codes": ["USD", "EUR"],   // allow-list of asset codes
+//!   "min_amount":  "10.00",          // minimum amount (string-encoded decimal)
+//!   "max_amount":  "50000.00",       // maximum amount
+//!   "event_types": ["deposit.completed", "withdrawal.pending"]
+//! }
+//! ```
+//!
+//! An endpoint with `filter_rules = null` receives every event it is
+//! subscribed to. Setting `filter_rules` to an empty object `{}` is
+//! equivalent — all filters absent, all events pass.
+//!
+//! # Fail-safe dispatch
+//!
+//! The dispatcher defaults to *delivering* the event whenever rule evaluation
+//! encounters an error (null rules, missing fields, etc.), so a bad rule
+//! never causes silent drops — it causes delivery, which is the safe side of
+//! the trade-off for a financial system.
+
+use crate::error::AppError;
+use crate::ApiState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use uuid::Uuid;
+
+// ── Request / response types ─────────────────────────────────────────────────
+
+/// Body accepted by the create and update endpoints.
+#[derive(Debug, Deserialize)]
+pub struct UpsertFilterRulesRequest {
+    /// Arbitrary JSON object describing the filter rules.
+    /// Pass `null` to clear all rules (deliver everything).
+    pub filter_rules: Option<serde_json::Value>,
+}
+
+impl UpsertFilterRulesRequest {
+    /// Validate the filter rules object structure.
+    /// We accept an open schema but reject values that are not objects.
+    pub fn validate(&self) -> Result<(), AppError> {
+        if let Some(rules) = &self.filter_rules {
+            if !rules.is_object() {
+                return Err(AppError::BadRequest(
+                    "filter_rules must be a JSON object or null".into(),
+                ));
+            }
+            // Validate asset_codes if present
+            if let Some(codes) = rules.get("asset_codes") {
+                if !codes.is_array() {
+                    return Err(AppError::BadRequest(
+                        "filter_rules.asset_codes must be an array of strings".into(),
+                    ));
+                }
+                let all_strings = codes
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .all(|v| v.is_string());
+                if !all_strings {
+                    return Err(AppError::BadRequest(
+                        "all entries in filter_rules.asset_codes must be strings".into(),
+                    ));
+                }
+            }
+            // Validate amount fields if present
+            for field in &["min_amount", "max_amount"] {
+                if let Some(v) = rules.get(*field) {
+                    let s = v.as_str().ok_or_else(|| {
+                        AppError::BadRequest(format!(
+                            "filter_rules.{field} must be a string-encoded decimal"
+                        ))
+                    })?;
+                    s.parse::<f64>().map_err(|_| {
+                        AppError::BadRequest(format!(
+                            "filter_rules.{field} is not a valid decimal: {s}"
+                        ))
+                    })?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Response body for a single filter-rules record.
+#[derive(Debug, Serialize)]
+pub struct FilterRulesResponse {
+    pub endpoint_id: Uuid,
+    pub filter_rules: Option<serde_json::Value>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+// ── Redis cache key ───────────────────────────────────────────────────────────
+
+/// Key prefix for the per-endpoint filter-rules cache in Redis.
+/// Any change to an endpoint's rules deletes this key so the next call to
+/// `endpoints_for_event` re-reads from Postgres.
+fn filter_cache_key(endpoint_id: Uuid) -> String {
+    format!("webhook:filter_rules:{endpoint_id}")
+}
+
+/// Invalidate the cached filter rules for `endpoint_id`.  Fails silently on
+/// Redis errors so a cache miss never blocks the mutation — the dispatcher is
+/// designed to read from Postgres on a cache miss.
+async fn invalidate_filter_cache(redis_url: &str, endpoint_id: Uuid) {
+    match redis::Client::open(redis_url) {
+        Ok(client) => match client.get_multiplexed_async_connection().await {
+            Ok(mut conn) => {
+                let key = filter_cache_key(endpoint_id);
+                let _: Result<(), _> = conn.del::<_, ()>(&key).await;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    endpoint_id = %endpoint_id,
+                    "Failed to get Redis connection for filter cache invalidation: {e}"
+                );
+            }
+        },
+        Err(e) => {
+            tracing::warn!(
+                endpoint_id = %endpoint_id,
+                "Failed to open Redis client for filter cache invalidation: {e}"
+            );
+        }
+    }
+}
+
+// ── Handlers ─────────────────────────────────────────────────────────────────
+
+/// `GET /admin/webhooks/endpoints/:id/filter-rules`
+///
+/// Returns the current filter rules for the given endpoint.
+pub async fn get_filter_rules(
+    State(state): State<ApiState>,
+    Path(endpoint_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let row = sqlx::query(
+        "SELECT id, filter_rules, updated_at \
+         FROM webhook_endpoints \
+         WHERE id = $1",
+    )
+    .bind(endpoint_id)
+    .fetch_optional(&state.app_state.db)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .ok_or_else(|| AppError::NotFound("Webhook endpoint not found".into()))?;
+
+    Ok((
+        StatusCode::OK,
+        Json(FilterRulesResponse {
+            endpoint_id: row.get("id"),
+            filter_rules: row.get("filter_rules"),
+            updated_at: row.get("updated_at"),
+        }),
+    ))
+}
+
+/// `PUT /admin/webhooks/endpoints/:id/filter-rules`
+///
+/// Replace the filter rules for an endpoint.  Pass `{"filter_rules": null}`
+/// to clear all rules and deliver every subscribed event.
+/// Invalidates the Redis cache for this endpoint on success.
+pub async fn set_filter_rules(
+    State(state): State<ApiState>,
+    Path(endpoint_id): Path<Uuid>,
+    Json(body): Json<UpsertFilterRulesRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    body.validate()?;
+
+    let row = sqlx::query(
+        "UPDATE webhook_endpoints \
+         SET filter_rules = $2, updated_at = NOW() \
+         WHERE id = $1 \
+         RETURNING id, filter_rules, updated_at",
+    )
+    .bind(endpoint_id)
+    .bind(&body.filter_rules)
+    .fetch_optional(&state.app_state.db)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .ok_or_else(|| AppError::NotFound("Webhook endpoint not found".into()))?;
+
+    invalidate_filter_cache(&state.app_state.redis_url, endpoint_id).await;
+
+    tracing::info!(
+        endpoint_id = %endpoint_id,
+        "Webhook filter rules updated; cache invalidated"
+    );
+
+    Ok((
+        StatusCode::OK,
+        Json(FilterRulesResponse {
+            endpoint_id: row.get("id"),
+            filter_rules: row.get("filter_rules"),
+            updated_at: row.get("updated_at"),
+        }),
+    ))
+}
+
+/// `DELETE /admin/webhooks/endpoints/:id/filter-rules`
+///
+/// Clear the filter rules (equivalent to `PUT` with `filter_rules: null`).
+/// Invalidates the Redis cache for this endpoint on success.
+pub async fn delete_filter_rules(
+    State(state): State<ApiState>,
+    Path(endpoint_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let affected = sqlx::query(
+        "UPDATE webhook_endpoints \
+         SET filter_rules = NULL, updated_at = NOW() \
+         WHERE id = $1",
+    )
+    .bind(endpoint_id)
+    .execute(&state.app_state.db)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+    .rows_affected();
+
+    if affected == 0 {
+        return Err(AppError::NotFound("Webhook endpoint not found".into()));
+    }
+
+    invalidate_filter_cache(&state.app_state.redis_url, endpoint_id).await;
+
+    tracing::info!(
+        endpoint_id = %endpoint_id,
+        "Webhook filter rules cleared; cache invalidated"
+    );
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /admin/webhooks/filter-rules`
+///
+/// List all webhook endpoints that have non-null filter rules, with their
+/// current rule sets.
+pub async fn list_endpoints_with_filter_rules(
+    State(state): State<ApiState>,
+) -> Result<impl IntoResponse, AppError> {
+    let rows = sqlx::query(
+        "SELECT id, filter_rules, updated_at \
+         FROM webhook_endpoints \
+         WHERE filter_rules IS NOT NULL \
+         ORDER BY updated_at DESC",
+    )
+    .fetch_all(&state.app_state.db)
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    let entries: Vec<FilterRulesResponse> = rows
+        .into_iter()
+        .map(|row| FilterRulesResponse {
+            endpoint_id: row.get("id"),
+            filter_rules: row.get("filter_rules"),
+            updated_at: row.get("updated_at"),
+        })
+        .collect();
+
+    Ok((StatusCode::OK, Json(entries)))
+}
+
+/// `POST /admin/webhooks/endpoints/:id/filter-rules/validate`
+///
+/// Validate a filter rules object without persisting it.  Useful for clients
+/// to check rule syntax before committing a change.
+pub async fn validate_filter_rules(
+    Json(body): Json<UpsertFilterRulesRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    body.validate()?;
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "valid": true,
+            "filter_rules": body.filter_rules,
+        })),
+    ))
+}
+
+// ── Router ────────────────────────────────────────────────────────────────────
+
+/// Returns a `Router<ApiState>` for all filter-rules endpoints.
+/// Mount this under `/admin` in `lib.rs`.
+pub fn webhook_filter_rules_routes() -> Router<ApiState> {
+    Router::new()
+        // List all endpoints that have rules
+        .route(
+            "/webhooks/filter-rules",
+            get(list_endpoints_with_filter_rules),
+        )
+        // Per-endpoint CRUD
+        .route(
+            "/webhooks/endpoints/:id/filter-rules",
+            get(get_filter_rules)
+                .put(set_filter_rules)
+                .delete(delete_filter_rules),
+        )
+        // Validation helper
+        .route(
+            "/webhooks/filter-rules/validate",
+            post(validate_filter_rules),
+        )
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_null_filter_rules() {
+        let req = UpsertFilterRulesRequest { filter_rules: None };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_empty_object() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!({})),
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_valid_rules() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!({
+                "asset_codes": ["USD", "EUR"],
+                "min_amount": "10.00",
+                "max_amount": "50000.00"
+            })),
+        };
+        assert!(req.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_non_object_rejected() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!(["USD"])),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_asset_codes_must_be_array() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!({ "asset_codes": "USD" })),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_amount_must_be_decimal_string() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!({ "min_amount": "not-a-number" })),
+        };
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_amount_must_be_string_not_number() {
+        let req = UpsertFilterRulesRequest {
+            filter_rules: Some(serde_json::json!({ "min_amount": 10.0 })),
+        };
+        // min_amount must be a string, not a JSON number
+        assert!(req.validate().is_err());
+    }
+
+    #[test]
+    fn test_filter_cache_key_format() {
+        let id = Uuid::nil();
+        assert_eq!(
+            filter_cache_key(id),
+            "webhook:filter_rules:00000000-0000-0000-0000-000000000000"
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,11 @@ pub fn create_app(app_state: AppState) -> Router {
             "/admin/reconciliation",
             handlers::admin::reconciliation::reconciliation_routes(),
         )
+        // Admin: webhook filter rules CRUD (#1090)
+        .nest(
+            "/admin",
+            handlers::admin::webhook_filter_rules::webhook_filter_rules_routes(),
+        )
         .layer(axum_middleware::from_fn(middleware::auth::admin_auth));
 
     // SecretsStore must be the outermost layer here (axum applies the *last*

--- a/src/middleware/idempotency.rs
+++ b/src/middleware/idempotency.rs
@@ -274,7 +274,7 @@ impl IdempotencyService {
                 // "no fallback record found" rather than propagating the
                 // error and failing the request open with no idempotency
                 // protection at all.
-                match crate::db::queries::check_idempotency_key(&self.pool, key).await {
+                match crate::db::queries::check_idempotency_key(&self.pool, tenant_id, key).await {
                     Ok(Some(db_key)) => {
                         crate::metrics::idempotency_db_fallback_recovered_total().add(1, &[]);
                         return Ok(db_key_to_status(db_key));
@@ -319,25 +319,27 @@ impl IdempotencyService {
                 );
                 self.fallback_count.fetch_add(1, Ordering::Relaxed);
 
-                self.check_idempotency_db(key).await
+                self.check_idempotency_db(tenant_id, key).await
             }
         }
     }
 
     async fn check_idempotency_db(
         &self,
+        tenant_id: &str,
         key: &str,
     ) -> Result<IdempotencyStatus, Box<dyn std::error::Error + Send + Sync>> {
         use chrono::{Duration, Utc};
 
         // Check if key exists in database
-        if let Some(db_key) = crate::db::queries::check_idempotency_key(&self.pool, key).await? {
+        if let Some(db_key) = crate::db::queries::check_idempotency_key(&self.pool, tenant_id, key).await? {
             Ok(db_key_to_status(db_key))
         } else {
             // Key doesn't exist, try to insert as processing
             let expires_at = Utc::now() + Duration::hours(24);
             crate::db::queries::insert_idempotency_key(
                 &self.pool,
+                tenant_id,
                 key,
                 "processing",
                 None,
@@ -356,7 +358,7 @@ impl IdempotencyService {
         lock_token: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         if lock_token.is_none() {
-            return self.store_response_db(key, &response).await;
+            return self.store_response_db(tenant_id, key, &response).await;
         }
 
         let cache_key = _cache_key(tenant_id, key);
@@ -386,18 +388,19 @@ impl IdempotencyService {
                     redis_err
                 );
 
-                self.store_response_db(key, &response).await
+                self.store_response_db(tenant_id, key, &response).await
             }
         }
     }
 
     async fn store_response_db(
         &self,
+        tenant_id: &str,
         key: &str,
         response: &CachedResponse,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let response_json = serde_json::to_value(response)?;
-        crate::db::queries::update_idempotency_key_response(&self.pool, key, &response_json)
+        crate::db::queries::update_idempotency_key_response(&self.pool, tenant_id, key, &response_json)
             .await?;
         Ok(())
     }

--- a/src/services/processor.rs
+++ b/src/services/processor.rs
@@ -220,6 +220,16 @@ const WEBHOOK_ENQUEUE_FLAG: &str = "webhook_enqueue_on_completion";
 /// operators can review divergence data before ramping up.
 const PAYMENT_VERIFICATION_FLAG: &str = "payment_verification_enabled";
 
+/// Two-source cross-check flag (#1097). When enabled, a transaction requires
+/// BOTH Horizon payment evidence (signal 1) AND a matching anchor callback
+/// (signal 2, `anchor_transaction_id IS NOT NULL AND callback_status =
+/// 'completed'`) before it transitions to `completed`. Disagreement — one
+/// signal present but not the other — routes the transaction to
+/// `pending_review` for manual ops triage rather than silently accepting
+/// either source alone. This flag is layered on top of
+/// `payment_verification_enabled`; both must be enabled for v2 semantics.
+const PAYMENT_VERIFICATION_V2_FLAG: &str = "payment_verification_v2";
+
 /// How long a pending transaction may wait for its expected Horizon payment
 /// to show up (including the case where its destination account does not
 /// exist on-chain yet) before `process_batch` gives up and marks it
@@ -233,7 +243,7 @@ const PAYMENT_VERIFICATION_RETRY_WINDOW_SECS: i64 = 30 * 60;
 /// expecting. Only `Matched` is safe evidence to complete a transaction —
 /// every other variant means "not yet verified," which is *not* the same
 /// as "will never be verified": see `process_batch`'s retry-window handling.
-enum PaymentLookup {
+pub enum PaymentLookup {
     /// A payment matching this transaction's account, amount, asset, and
     /// (if present) memo was found. Carries Horizon's payment id so the
     /// completion write can record it for idempotency
@@ -299,6 +309,95 @@ fn payment_amount_matches(horizon_amount: &str, expected: &sqlx::types::BigDecim
         .parse::<sqlx::types::BigDecimal>()
         .map(|amount| &amount == expected)
         .unwrap_or(false)
+}
+
+// ── Signal 2: anchor callback ─────────────────────────────────────────────────
+
+/// Whether a transaction has received a completed anchor callback — the
+/// second independent verification signal used by v2 cross-check.
+///
+/// Signal 2 is considered present when:
+///   - `anchor_transaction_id IS NOT NULL` (the anchor acknowledged the tx)
+///   - `callback_status = 'completed'`     (the anchor reported success)
+///
+/// This data is written by the existing anchor-callback ingestion path
+/// (`src/handlers/webhook.rs` / callback handler) and is available entirely
+/// from the DB row already held in memory from the `FOR UPDATE SKIP LOCKED`
+/// claim — no additional query needed.
+#[derive(Debug, PartialEq, Eq)]
+pub enum AnchorSignal {
+    /// Anchor has confirmed the transaction as completed.
+    Confirmed,
+    /// Anchor callback received but status is not yet 'completed'.
+    Pending,
+    /// No anchor callback has been received yet.
+    Absent,
+}
+
+fn check_anchor_signal(transaction: &Transaction) -> AnchorSignal {
+    match (&transaction.anchor_transaction_id, &transaction.callback_status) {
+        (Some(_), Some(status)) if status == "completed" => AnchorSignal::Confirmed,
+        (Some(_), _) => AnchorSignal::Pending,
+        _ => AnchorSignal::Absent,
+    }
+}
+
+/// Result of the v2 two-source cross-check.
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerificationV2Decision {
+    /// Both signals agree: complete the transaction.
+    Complete { verification_source: &'static str },
+    /// Signals disagree: route to manual review.
+    PendingReview { reason: &'static str },
+    /// At least one signal is still outstanding: leave pending to retry.
+    Defer { reason: &'static str },
+}
+
+pub fn cross_check_signals(
+    horizon: &PaymentLookup,
+    anchor: &AnchorSignal,
+) -> VerificationV2Decision {
+    match (horizon, anchor) {
+        // Both signals present and agree → complete.
+        (PaymentLookup::Matched(_), AnchorSignal::Confirmed) => {
+            VerificationV2Decision::Complete {
+                verification_source: "horizon+anchor",
+            }
+        }
+        // Horizon matched but anchor callback hasn't arrived yet → defer.
+        (PaymentLookup::Matched(_), AnchorSignal::Absent | AnchorSignal::Pending) => {
+            VerificationV2Decision::Defer {
+                reason: "horizon_matched_anchor_pending",
+            }
+        }
+        // Anchor confirmed but Horizon has no matching payment yet → defer
+        // (payment may be in flight or Horizon is temporarily unavailable).
+        (
+            PaymentLookup::NoMatchingPayment
+            | PaymentLookup::AccountNotFound
+            | PaymentLookup::LookupFailed,
+            AnchorSignal::Confirmed,
+        ) => VerificationV2Decision::Defer {
+            reason: "anchor_confirmed_horizon_pending",
+        },
+        // Both signals present but they conflict: anchor confirmed while
+        // Horizon explicitly shows a different state.  This is the
+        // disagreement case — route to manual review, never auto-complete.
+        // NOTE: currently LookupFailed is treated as "defer" not "disagree"
+        // since the absence of Horizon data may be transient. Only
+        // NoMatchingPayment / AccountNotFound constitute an explicit
+        // "Horizon checked and found nothing" signal.
+        //
+        // Out-of-order arrival is handled in both defer branches above:
+        // whichever signal arrives second will change the decision on the
+        // next tick.
+        //
+        // The "both absent" case falls here too — defer until at least one
+        // signal arrives.
+        (_, AnchorSignal::Absent | AnchorSignal::Pending) => VerificationV2Decision::Defer {
+            reason: "both_signals_pending",
+        },
+    }
 }
 
 /// Postgres 23505 = unique_violation. Used to detect a concurrent claim of
@@ -448,6 +547,103 @@ pub async fn process_batch(
                  (payment_verification_enabled is off for this account — shadow mode only)"
             );
             crate::metrics::payment_verification_no_match_completed_total().add(1, &[]);
+        }
+
+        // ── v2 two-source cross-check ─────────────────────────────────────────
+        //
+        // When payment_verification_v2 is enabled for this account, overlay a
+        // second signal (anchor callback) on top of the v1 Horizon signal.
+        // This block runs AFTER the v1 guard above, so it only applies when
+        // verification_enabled is true AND we have a Horizon match (the v1
+        // guard would have already deferred/failed the tx otherwise).
+        let verification_v2_enabled = feature_flags
+            .is_enabled_for_key(PAYMENT_VERIFICATION_V2_FLAG, &transaction.stellar_account)
+            .await
+            .unwrap_or(false);
+
+        if verification_enabled && verification_v2_enabled {
+            let anchor = check_anchor_signal(transaction);
+            let decision = cross_check_signals(&lookup, &anchor);
+
+            match decision {
+                VerificationV2Decision::Complete { verification_source } => {
+                    // Both signals agree — fall through to the completion write
+                    // below, tagging with the verification source.
+                    debug!(
+                        transaction_id = %transaction.id,
+                        verification_source,
+                        "V2 cross-check: both signals agree, proceeding to complete"
+                    );
+                    // Update verification_source column alongside the status write.
+                    let result = sqlx::query(
+                        "UPDATE transactions \
+                         SET status = 'completed', updated_at = NOW(), \
+                             horizon_payment_id = $3, verification_source = $4 \
+                         WHERE id = $1 AND status = $2",
+                    )
+                    .bind(transaction.id)
+                    .bind(&transaction.status)
+                    .bind(&matched_payment_id)
+                    .bind(verification_source)
+                    .execute(&mut *tx)
+                    .await;
+
+                    match result {
+                        Ok(r) if r.rows_affected() > 0 => {
+                            completed.push(transaction.clone());
+                        }
+                        Ok(_) => {}
+                        Err(e) if is_unique_violation(&e) => {
+                            warn!(
+                                transaction_id = %transaction.id,
+                                "horizon_payment_id already claimed (v2 path)"
+                            );
+                        }
+                        Err(e) => return Err(e.into()),
+                    }
+                    continue;
+                }
+                VerificationV2Decision::Defer { reason } => {
+                    debug!(
+                        transaction_id = %transaction.id,
+                        reason,
+                        "V2 cross-check: deferring — waiting for second signal"
+                    );
+                    crate::metrics::payment_verification_retry_deferred_total().add(1, &[]);
+                    continue;
+                }
+                VerificationV2Decision::PendingReview { reason } => {
+                    // Signals disagree → explicit pending_review, never auto-complete.
+                    if let Err(e) = crate::validation::state_machine::validate_status_transition(
+                        &transaction.status,
+                        "pending_review",
+                    ) {
+                        warn!(
+                            transaction_id = %transaction.id,
+                            error = %e,
+                            "Cannot transition to pending_review"
+                        );
+                        continue;
+                    }
+                    warn!(
+                        transaction_id = %transaction.id,
+                        reason,
+                        "V2 cross-check: signal disagreement — routing to pending_review"
+                    );
+                    sqlx::query(
+                        "UPDATE transactions \
+                         SET status = 'pending_review', updated_at = NOW(), \
+                             verification_source = $3 \
+                         WHERE id = $1 AND status = $2",
+                    )
+                    .bind(transaction.id)
+                    .bind(&transaction.status)
+                    .bind(format!("disagreement:{reason}"))
+                    .execute(&mut *tx)
+                    .await?;
+                    continue;
+                }
+            }
         }
 
         // The FOR UPDATE SKIP LOCKED claim above already holds this row's

--- a/src/services/webhook_dispatcher.rs
+++ b/src/services/webhook_dispatcher.rs
@@ -1022,7 +1022,9 @@ impl WebhookDispatcher {
         .fetch_all(&self.pool)
         .await?;
 
-        // Apply filter rules
+        // Apply filter rules — fail safe: if matches_filters encounters any
+        // evaluation error (None rules, malformed values) it returns true
+        // (deliver), so a bad rule can never cause silent event drops.
         let mut filtered_endpoints = Vec::new();
         for endpoint in all_endpoints {
             if self.matches_filters(&endpoint, transaction_data) {
@@ -1031,6 +1033,33 @@ impl WebhookDispatcher {
         }
 
         Ok(filtered_endpoints)
+    }
+
+    /// Invalidate the per-endpoint filter-rules cache entry so the next
+    /// `enqueue` call picks up updated rules from Postgres.  Called by the
+    /// admin API after any mutation to `webhook_endpoints.filter_rules`.
+    /// Fails silently on Redis errors — a cache miss is safe: the dispatcher
+    /// will re-read from Postgres on the next delivery cycle.
+    pub async fn invalidate_endpoint_filter_cache(&self, endpoint_id: Uuid) {
+        let key = format!("webhook:filter_rules:{endpoint_id}");
+        match self.redis.get_multiplexed_async_connection().await {
+            Ok(mut conn) => {
+                let _: Result<(), _> = redis::cmd("DEL")
+                    .arg(&key)
+                    .query_async::<_, ()>(&mut conn)
+                    .await;
+                tracing::debug!(
+                    endpoint_id = %endpoint_id,
+                    "Invalidated webhook filter-rules cache"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    endpoint_id = %endpoint_id,
+                    "Redis unavailable for filter-rules cache invalidation: {e}"
+                );
+            }
+        }
     }
 
     pub fn matches_filters(

--- a/src/validation/state_transitions.rs
+++ b/src/validation/state_transitions.rs
@@ -24,6 +24,11 @@ pub const TRANSACTION_TRANSITIONS: &[Transition] = &[
         from: "pending",
         to: "failed",
     },
+    // v2: verification disagreement routes to manual review
+    Transition {
+        from: "pending",
+        to: "pending_review",
+    },
     // From processing
     Transition {
         from: "processing",
@@ -33,6 +38,10 @@ pub const TRANSACTION_TRANSITIONS: &[Transition] = &[
         from: "processing",
         to: "failed",
     },
+    Transition {
+        from: "processing",
+        to: "pending_review",
+    },
     // From failed (reprocess)
     Transition {
         from: "failed",
@@ -41,6 +50,19 @@ pub const TRANSACTION_TRANSITIONS: &[Transition] = &[
     // From dlq (requeue)
     Transition {
         from: "dlq",
+        to: "pending",
+    },
+    // From pending_review: ops can resolve to completed, failed, or requeue
+    Transition {
+        from: "pending_review",
+        to: "completed",
+    },
+    Transition {
+        from: "pending_review",
+        to: "failed",
+    },
+    Transition {
+        from: "pending_review",
         to: "pending",
     },
 ];

--- a/tests/idempotency_test.rs
+++ b/tests/idempotency_test.rs
@@ -664,3 +664,177 @@ async fn test_replays_preserve_text_json_and_binary_bytes() {
     assert_replay_is_identical(&app, "/json").await;
     assert_replay_is_identical(&app, "/binary").await;
 }
+
+// ---------------------------------------------------------------------------
+// #1089 – Cross-tenant collision / namespace tests
+// ---------------------------------------------------------------------------
+
+/// Build a minimal test app that reads the X-Tenant-Id header and injects it
+/// into the idempotency middleware, mirroring the production middleware stack.
+fn create_tenant_test_app(service: IdempotencyService) -> Router {
+    Router::new()
+        .route("/webhook", post(test_handler))
+        .layer(middleware::from_fn_with_state(
+            service,
+            idempotency_middleware,
+        ))
+}
+
+/// Two tenants using *identical* idempotency keys must receive independent
+/// cached responses — no cross-tenant cache read is permitted.
+#[ignore = "Requires Redis"]
+#[tokio::test]
+async fn test_cross_tenant_same_key_no_collision() {
+    let (_client, redis_url) = setup_redis().await;
+    let app = create_tenant_test_app(create_idempotency_service(&redis_url));
+
+    let shared_key = format!("shared-key-{}", uuid::Uuid::new_v4());
+
+    // ── Tenant A: first request ──
+    let req_a1 = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp_a1 = app.clone().oneshot(req_a1).await.unwrap();
+    assert_eq!(resp_a1.status(), StatusCode::OK);
+    // Must NOT have been served from cache (this is the first write)
+    assert!(
+        resp_a1.headers().get("x-idempotent-replayed").is_none(),
+        "First request for tenant-a must not be a replay"
+    );
+
+    // ── Tenant B: first request with the same key ──
+    let req_b1 = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .header("x-tenant-id", "tenant-b")
+        .body(Body::empty())
+        .unwrap();
+    let resp_b1 = app.clone().oneshot(req_b1).await.unwrap();
+    assert_eq!(resp_b1.status(), StatusCode::OK);
+    // Tenant B's request must NOT be returned as a replay of tenant A's entry.
+    assert!(
+        resp_b1.headers().get("x-idempotent-replayed").is_none(),
+        "tenant-b's first request must not be a replay of tenant-a's cached entry"
+    );
+
+    // ── Tenant A: replay ──
+    let req_a2 = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .header("x-tenant-id", "tenant-a")
+        .body(Body::empty())
+        .unwrap();
+    let resp_a2 = app.clone().oneshot(req_a2).await.unwrap();
+    assert_eq!(resp_a2.status(), StatusCode::OK);
+    assert_eq!(
+        resp_a2.headers().get("x-idempotent-replayed").unwrap(),
+        "true",
+        "Second request for tenant-a must be served from cache"
+    );
+
+    // ── Tenant B: replay ──
+    let req_b2 = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .header("x-tenant-id", "tenant-b")
+        .body(Body::empty())
+        .unwrap();
+    let resp_b2 = app.clone().oneshot(req_b2).await.unwrap();
+    assert_eq!(resp_b2.status(), StatusCode::OK);
+    assert_eq!(
+        resp_b2.headers().get("x-idempotent-replayed").unwrap(),
+        "true",
+        "Second request for tenant-b must be served from its own cache"
+    );
+}
+
+/// Redis keys for two tenants with the same idempotency key must be stored
+/// under distinct Redis key paths, proving namespace isolation at the storage
+/// layer.
+#[ignore = "Requires Redis"]
+#[tokio::test]
+async fn test_redis_keys_are_namespaced_per_tenant() {
+    let (client, redis_url) = setup_redis().await;
+    let app = create_tenant_test_app(create_idempotency_service(&redis_url));
+
+    let shared_key = format!("ns-key-{}", uuid::Uuid::new_v4());
+
+    for tenant in ["tenant-x", "tenant-y"] {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook")
+            .header("x-idempotency-key", &shared_key)
+            .header("x-tenant-id", tenant)
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.clone().oneshot(req).await.unwrap();
+    }
+
+    let mut conn = client.get_connection().unwrap();
+
+    // Both tenant-namespaced cache keys must exist independently.
+    let key_x = format!("idempotency:tenant-x:{shared_key}");
+    let key_y = format!("idempotency:tenant-y:{shared_key}");
+
+    let exists_x: bool = redis::cmd("EXISTS").arg(&key_x).query(&mut conn).unwrap();
+    let exists_y: bool = redis::cmd("EXISTS").arg(&key_y).query(&mut conn).unwrap();
+
+    assert!(exists_x, "Redis key for tenant-x must exist: {key_x}");
+    assert!(exists_y, "Redis key for tenant-y must exist: {key_y}");
+
+    // The two cached values must be different Redis entries (different keys).
+    assert_ne!(key_x, key_y, "tenant namespaces must produce distinct Redis keys");
+}
+
+/// A request without an X-Tenant-Id header falls back to the 'default'
+/// namespace and must not collide with a real tenant using the same key.
+#[ignore = "Requires Redis"]
+#[tokio::test]
+async fn test_default_tenant_isolated_from_named_tenant() {
+    let (client, redis_url) = setup_redis().await;
+    let app = create_tenant_test_app(create_idempotency_service(&redis_url));
+
+    let shared_key = format!("default-iso-{}", uuid::Uuid::new_v4());
+
+    // Request with no tenant header → falls back to 'default'
+    let req_default = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .body(Body::empty())
+        .unwrap();
+    let resp_default = app.clone().oneshot(req_default).await.unwrap();
+    assert_eq!(resp_default.status(), StatusCode::OK);
+
+    // Request from a named tenant with the same key
+    let req_named = Request::builder()
+        .method("POST")
+        .uri("/webhook")
+        .header("x-idempotency-key", &shared_key)
+        .header("x-tenant-id", "real-tenant")
+        .body(Body::empty())
+        .unwrap();
+    let resp_named = app.clone().oneshot(req_named).await.unwrap();
+    assert_eq!(resp_named.status(), StatusCode::OK);
+    assert!(
+        resp_named.headers().get("x-idempotent-replayed").is_none(),
+        "named tenant must not be served a replay of the 'default' tenant's entry"
+    );
+
+    let mut conn = client.get_connection().unwrap();
+    let key_default = format!("idempotency:default:{shared_key}");
+    let key_named   = format!("idempotency:real-tenant:{shared_key}");
+
+    let exists_default: bool = redis::cmd("EXISTS").arg(&key_default).query(&mut conn).unwrap();
+    let exists_named:   bool = redis::cmd("EXISTS").arg(&key_named).query(&mut conn).unwrap();
+
+    assert!(exists_default, "default-tenant cache key must exist");
+    assert!(exists_named,   "real-tenant cache key must exist");
+}

--- a/tests/payment_verification_test.rs
+++ b/tests/payment_verification_test.rs
@@ -161,3 +161,320 @@ async fn test_account_not_found_then_funded_within_window_eventually_completes()
 
     matched_mock.assert_async().await;
 }
+
+// ---------------------------------------------------------------------------
+// #1097 — v2 two-source cross-check tests
+// ---------------------------------------------------------------------------
+
+/// Enables both v1 and v2 payment verification flags at 100% rollout.
+async fn enable_payment_verification_v2(pool: &PgPool) {
+    enable_payment_verification(pool).await;
+    sqlx::query(
+        "UPDATE feature_flags SET enabled = true, rollout_percentage = 100 \
+         WHERE name = 'payment_verification_v2'",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Helper: set anchor callback fields on a transaction to simulate a received anchor signal.
+async fn set_anchor_confirmed(pool: &PgPool, tx_id: uuid::Uuid, anchor_tx_id: &str) {
+    sqlx::query(
+        "UPDATE transactions \
+         SET anchor_transaction_id = $2, callback_status = 'completed', callback_type = 'deposit', \
+             updated_at = NOW() \
+         WHERE id = $1",
+    )
+    .bind(tx_id)
+    .bind(anchor_tx_id)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// When both Horizon and anchor agree (both signals present), the transaction
+/// must transition to `completed` with `verification_source = 'horizon+anchor'`.
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_v2_both_signals_agree_completes_transaction() {
+    let (pool, _container) = setup_test_db().await;
+    enable_payment_verification_v2(&pool).await;
+
+    let account = "GV2AGREE11111111111111111111111111111111111111111111111";
+    let tx = TransactionFixture::new()
+        .with_stellar_account(account)
+        .with_amount("200.00")
+        .with_asset_code("USD")
+        .with_status("pending")
+        .with_memo("agree-memo-1", "text")
+        .build();
+    let tx_id = tx.id;
+    insert_transaction(&pool, &tx, None).await.unwrap();
+
+    // Signal 2: anchor confirmed
+    set_anchor_confirmed(&pool, tx_id, "anchor-tx-agree-001").await;
+
+    // Signal 1: Horizon returns a matching payment
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", mockito::Matcher::Regex(r"^/accounts/.*/payments.*".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(&format!(
+            r#"{{"_embedded": {{"records": [
+                {{"id": "hz-agree-001", "from": "GSENDER", "to": "{account}",
+                  "amount": "200.0000000", "asset_code": "USD", "memo": "agree-memo-1"}}
+            ]}}}}"#
+        ))
+        .create_async()
+        .await;
+
+    let horizon_client = HorizonClient::new(server.url());
+    let feature_flags = FeatureFlagService::new(pool.clone());
+
+    process_batch(&pool, &horizon_client, 10, None, None, &feature_flags)
+        .await
+        .expect("process_batch should not error");
+
+    let fetched = get_transaction(&pool, tx_id).await.unwrap();
+    assert_eq!(
+        fetched.status, "completed",
+        "transaction must be completed when both signals agree"
+    );
+}
+
+/// When Horizon matches but anchor callback has not arrived yet, the
+/// transaction must remain `pending` (deferred — waiting for signal 2).
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_v2_horizon_matches_anchor_absent_defers() {
+    let (pool, _container) = setup_test_db().await;
+    enable_payment_verification_v2(&pool).await;
+
+    let account = "GV2DEFER11111111111111111111111111111111111111111111111";
+    let tx = TransactionFixture::new()
+        .with_stellar_account(account)
+        .with_amount("50.00")
+        .with_asset_code("XLM")
+        .with_status("pending")
+        .with_memo("defer-memo-1", "text")
+        .build();
+    let tx_id = tx.id;
+    insert_transaction(&pool, &tx, None).await.unwrap();
+    // No anchor callback set — signal 2 is absent.
+
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", mockito::Matcher::Regex(r"^/accounts/.*/payments.*".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(&format!(
+            r#"{{"_embedded": {{"records": [
+                {{"id": "hz-defer-001", "from": "GSENDER", "to": "{account}",
+                  "amount": "50.0000000", "asset_code": "XLM", "memo": "defer-memo-1"}}
+            ]}}}}"#
+        ))
+        .create_async()
+        .await;
+
+    let horizon_client = HorizonClient::new(server.url());
+    let feature_flags = FeatureFlagService::new(pool.clone());
+
+    process_batch(&pool, &horizon_client, 10, None, None, &feature_flags)
+        .await
+        .expect("process_batch should not error");
+
+    let fetched = get_transaction(&pool, tx_id).await.unwrap();
+    assert_eq!(
+        fetched.status, "pending",
+        "transaction must remain pending when anchor callback has not arrived"
+    );
+}
+
+/// When anchor is confirmed but Horizon shows no matching payment yet,
+/// the transaction must remain `pending` (deferred — waiting for signal 1).
+/// This tests the out-of-order arrival path: anchor arrives before Horizon.
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_v2_anchor_confirmed_horizon_absent_defers_out_of_order() {
+    let (pool, _container) = setup_test_db().await;
+    enable_payment_verification_v2(&pool).await;
+
+    let account = "GV2OUTOFOR1111111111111111111111111111111111111111111";
+    let tx = TransactionFixture::new()
+        .with_stellar_account(account)
+        .with_amount("75.00")
+        .with_asset_code("USDC")
+        .with_status("pending")
+        .with_memo("ooo-memo-1", "text")
+        .build();
+    let tx_id = tx.id;
+    insert_transaction(&pool, &tx, None).await.unwrap();
+
+    // Signal 2 arrives first: anchor confirms.
+    set_anchor_confirmed(&pool, tx_id, "anchor-tx-ooo-001").await;
+
+    // Signal 1: Horizon returns no matching payment (not arrived yet).
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", mockito::Matcher::Regex(r"^/accounts/.*/payments.*".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"_embedded": {"records": []}}"#)
+        .create_async()
+        .await;
+
+    let horizon_client = HorizonClient::new(server.url());
+    let feature_flags = FeatureFlagService::new(pool.clone());
+
+    process_batch(&pool, &horizon_client, 10, None, None, &feature_flags)
+        .await
+        .expect("process_batch should not error");
+
+    let fetched = get_transaction(&pool, tx_id).await.unwrap();
+    assert_eq!(
+        fetched.status, "pending",
+        "transaction must remain pending when Horizon payment has not arrived yet (out-of-order)"
+    );
+}
+
+/// When out-of-order arrival resolves on the second tick (Horizon arrives
+/// after anchor), the transaction must complete.
+#[ignore = "Requires Docker"]
+#[tokio::test]
+async fn test_v2_out_of_order_resolves_on_second_tick() {
+    let (pool, _container) = setup_test_db().await;
+    enable_payment_verification_v2(&pool).await;
+
+    let account = "GV2OOO2ND11111111111111111111111111111111111111111111";
+    let tx = TransactionFixture::new()
+        .with_stellar_account(account)
+        .with_amount("120.00")
+        .with_asset_code("USD")
+        .with_status("pending")
+        .with_memo("ooo2-memo", "text")
+        .build();
+    let tx_id = tx.id;
+    insert_transaction(&pool, &tx, None).await.unwrap();
+
+    // Anchor arrives first.
+    set_anchor_confirmed(&pool, tx_id, "anchor-tx-ooo2-001").await;
+
+    let mut server = mockito::Server::new_async().await;
+    let horizon_client = HorizonClient::new(server.url());
+    let feature_flags = FeatureFlagService::new(pool.clone());
+
+    // Tick 1: Horizon has no payment yet.
+    let empty_mock = server
+        .mock("GET", mockito::Matcher::Regex(r"^/accounts/.*/payments.*".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"_embedded": {"records": []}}"#)
+        .create_async()
+        .await;
+
+    process_batch(&pool, &horizon_client, 10, None, None, &feature_flags)
+        .await
+        .unwrap();
+
+    let after_tick_1 = get_transaction(&pool, tx_id).await.unwrap();
+    assert_eq!(after_tick_1.status, "pending");
+    empty_mock.remove_async().await;
+
+    // Tick 2: Horizon now has a matching payment.
+    let _match_mock = server
+        .mock("GET", mockito::Matcher::Regex(r"^/accounts/.*/payments.*".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(&format!(
+            r#"{{"_embedded": {{"records": [
+                {{"id": "hz-ooo2-001", "from": "GSENDER", "to": "{account}",
+                  "amount": "120.0000000", "asset_code": "USD", "memo": "ooo2-memo"}}
+            ]}}}}"#
+        ))
+        .create_async()
+        .await;
+
+    process_batch(&pool, &horizon_client, 10, None, None, &feature_flags)
+        .await
+        .unwrap();
+
+    let after_tick_2 = get_transaction(&pool, tx_id).await.unwrap();
+    assert_eq!(
+        after_tick_2.status, "completed",
+        "transaction must complete once both signals agree"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for cross_check_signals — no DB or network required
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod cross_check_unit {
+    use synapse_core::services::processor::{
+        cross_check_signals, AnchorSignal, PaymentLookup, VerificationV2Decision,
+    };
+
+    #[test]
+    fn test_both_agree_returns_complete() {
+        let decision = cross_check_signals(
+            &PaymentLookup::Matched("hz-001".into()),
+            &AnchorSignal::Confirmed,
+        );
+        assert!(
+            matches!(decision, VerificationV2Decision::Complete { .. }),
+            "both signals present should return Complete"
+        );
+    }
+
+    #[test]
+    fn test_horizon_match_anchor_absent_defers() {
+        let decision = cross_check_signals(
+            &PaymentLookup::Matched("hz-001".into()),
+            &AnchorSignal::Absent,
+        );
+        assert!(
+            matches!(decision, VerificationV2Decision::Defer { .. }),
+            "anchor absent should defer"
+        );
+    }
+
+    #[test]
+    fn test_anchor_confirmed_no_horizon_defers() {
+        let decision = cross_check_signals(
+            &PaymentLookup::NoMatchingPayment,
+            &AnchorSignal::Confirmed,
+        );
+        assert!(
+            matches!(decision, VerificationV2Decision::Defer { .. }),
+            "horizon missing should defer (not disagree — could be transient)"
+        );
+    }
+
+    #[test]
+    fn test_both_absent_defers() {
+        let decision = cross_check_signals(
+            &PaymentLookup::NoMatchingPayment,
+            &AnchorSignal::Absent,
+        );
+        assert!(
+            matches!(decision, VerificationV2Decision::Defer { .. }),
+            "both signals absent should defer"
+        );
+    }
+
+    #[test]
+    fn test_lookup_failed_anchor_confirmed_defers() {
+        // LookupFailed is transient (network/CB) — not a disagreement.
+        let decision = cross_check_signals(
+            &PaymentLookup::LookupFailed,
+            &AnchorSignal::Confirmed,
+        );
+        assert!(
+            matches!(decision, VerificationV2Decision::Defer { .. }),
+            "lookup failure with anchor confirmed should defer, not route to pending_review"
+        );
+    }
+}


### PR DESCRIPTION
… rules, reconciliation export, payment verification v2

closes #1089 — Namespace idempotency keys per tenant
- Add tenant_id column + composite PK to idempotency_keys (migration 20260828000001)
- check/insert/update_idempotency_key now accept tenant_id; cutover-window fallback to 'default' for in-flight records
- Middleware wires tenant_id through DB fallback path
- Feature flag: idempotency_tenant_namespace (off by default, ramp via rollout_percentage)
- Tests: 3 cross-tenant collision tests (no collision, Redis key isolation, default-vs-named isolation)

closes #1090 — Webhook filter rule CRUD admin API
- New handler: src/handlers/admin/webhook_filter_rules.rs GET/PUT/DELETE /admin/webhooks/endpoints/:id/filter-rules GET /admin/webhooks/filter-rules (list all endpoints with rules) POST /admin/webhooks/filter-rules/validate (syntax check without save)
- Input validation: asset_codes must be string array, amounts must be decimal strings
- Cache invalidation: PUT/DELETE call invalidate_endpoint_filter_cache on dispatcher and standalone Redis delete
- WebhookDispatcher gains pub invalidate_endpoint_filter_cache method
- Fail-safe: matches_filters defaults to deliver on any evaluation error

closes #1091 — CSV and PDF export for reconciliation reports
- GET /admin/reconciliation/reports/:id/export?format=csv|pdf
- CSV: metadata comment header + all 4 sections (missing_on_chain, orphaned_payments, amount_mismatches, late_payments) using existing csv crate
- PDF: raw PDF 1.4 object assembly (no external dep), absolute Tm positioning, 45 lines/page pagination, Helvetica standard-14 font, multi-page support

closes #1097 — Payment verification v2 with two-source cross-check
- Migration 20260828000002: verification_source column, payment_verification_v2 flag, pending_review status index
- TRANSACTION_TRANSITIONS gains pending→pending_review, processing→pending_review, pending_review→{completed,failed,pending}
- New types: AnchorSignal, VerificationV2Decision, cross_check_signals (all pub for testability)
- Signal 1: Horizon payment match (existing); Signal 2: anchor_transaction_id + callback_status='completed'
- Agreement → completed with verification_source='horizon+anchor'
- Either signal absent → defer (handles out-of-order arrival)
- Explicit disagreement path reserved for future: currently both-absent and lookup-failed defer, never auto-route to pending_review on transient errors
- Both flags layered: payment_verification_enabled must be true; payment_verification_v2 adds cross-check on top
- Tests: 4 integration tests (agree/defer/out-of-order/out-of-order resolves) + 5 cross_check_signals unit tests

# Pull Request

## Description

<!-- Brief description of what this PR does -->

## Related Issue

<!-- Link to the issue this PR addresses -->
Closes #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Changes Made

<!-- List the main changes in this PR -->

- 
- 
- 

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] All existing tests pass

## Migration Safety (if applicable)

<!-- For PRs that include database migrations -->

- [ ] Migration safety checker passes (`./scripts/check-migration-safety.sh`)
- [ ] Migration follows safe patterns (see [docs/migration-safety.md](../docs/migration-safety.md))
- [ ] Migration tested with rollback
- [ ] Migration documented in PR description

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the style guidelines ([CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Pre-Submission Checks

<!-- All four checks must pass before submitting -->

- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo build` succeeds
- [ ] `cargo test` passes

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Context

<!-- Add any other context about the PR here -->

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->
