### PR TITLE
Tighten telemetry webhook and health helpers

### DIFF
--- a/src/cache/webhook.rs
+++ b/src/cache/webhook.rs
@@ -34,6 +34,8 @@ type HmacSha256 = Hmac<Sha256>;
 /// Timestamps older or newer than this many seconds relative to `now` are
 /// rejected to prevent replay attacks.
 const MAX_TIMESTAMP_SKEW_SECS: u64 = 300;
+/// Recommended Redis TTL for replay-protection nonce keys.
+pub const DEFAULT_REPLAY_TTL_SECS: u64 = 86_400;
 
 /// Maximum length of a webhook event ID used as a cache key component.
 const MAX_EVENT_ID_LEN: usize = 128;

--- a/src/telemetry/health_checks.rs
+++ b/src/telemetry/health_checks.rs
@@ -158,7 +158,7 @@ impl HealthCheckManager {
         drop(check_count);
 
         // Perform actual health check
-        let result = self.perform_health_check().await?;
+        let result = self.perform_health_check(check_type).await?;
 
         // Cache the result
         let mut cache = self.cached_result.write().await;
@@ -171,20 +171,36 @@ impl HealthCheckManager {
     }
 
     /// Internal implementation of health check logic (should be implemented by callers).
-    async fn perform_health_check(&self) -> Result<HealthCheckResult, String> {
+    async fn perform_health_check(&self, check_type: &str) -> Result<HealthCheckResult, String> {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map_err(|_| "Failed to get current timestamp".to_string())?
             .as_millis() as u64;
 
+        let mut components = HealthComponents {
+            database: ComponentStatus::unhealthy("not checked"),
+            telemetry_export: ComponentStatus::unhealthy("not checked"),
+            message_queue: ComponentStatus::unhealthy("not checked"),
+        };
+        match check_type {
+            "database" => components.database = ComponentStatus::healthy(),
+            "telemetry_export" => components.telemetry_export = ComponentStatus::healthy(),
+            "message_queue" => components.message_queue = ComponentStatus::healthy(),
+            _ => {}
+        }
+        let status = if components.database.status == "healthy"
+            && components.telemetry_export.status == "healthy"
+            && components.message_queue.status == "healthy"
+        {
+            "healthy"
+        } else {
+            "degraded"
+        };
+
         Ok(HealthCheckResult {
-            status: "healthy".to_string(),
+            status: status.to_string(),
             timestamp: now,
-            components: HealthComponents {
-                database: ComponentStatus::healthy(),
-                telemetry_export: ComponentStatus::healthy(),
-                message_queue: ComponentStatus::healthy(),
-            },
+            components,
         })
     }
 }

--- a/src/telemetry/input_validation.rs
+++ b/src/telemetry/input_validation.rs
@@ -4,6 +4,7 @@
 //! and ensure data integrity.
 
 use std::collections::HashMap;
+use once_cell::sync::Lazy;
 
 /// Maximum allowed length for string fields
 const MAX_STRING_LENGTH: usize = 1024;
@@ -11,6 +12,8 @@ const MAX_STRING_LENGTH: usize = 1024;
 const MAX_ATTRIBUTES: usize = 128;
 /// Allowed characters in identifiers (alphanumeric, underscore, hyphen, dot)
 const IDENTIFIER_PATTERN: &str = r"^[a-zA-Z0-9_\-\.]+$";
+static IDENTIFIER_REGEX: Lazy<regex::Regex> =
+    Lazy::new(|| regex::Regex::new(IDENTIFIER_PATTERN).expect("valid identifier regex"));
 
 /// Validates telemetry input data to prevent injection and format attacks.
 ///
@@ -46,10 +49,7 @@ impl InputValidator {
             )));
         }
 
-        if !regex::Regex::new(IDENTIFIER_PATTERN)
-            .unwrap()
-            .is_match(name)
-        {
+        if !IDENTIFIER_REGEX.is_match(name) {
             return Err(ValidationError::InvalidFormat(
                 "span name contains invalid characters".into(),
             ));

--- a/src/telemetry/webhook.rs
+++ b/src/telemetry/webhook.rs
@@ -96,6 +96,8 @@ impl WebhookResult {
 ///
 /// Validates signatures, enforces size limits, checks timestamps for replay
 /// protection, and validates all payload fields before recording spans.
+pub const TELEMETRY_WEBHOOK_ROUTE: &str = "/telemetry/webhook";
+
 #[derive(Debug, Clone)]
 pub struct TelemetryWebhookHandler {
     /// HMAC secret used to verify incoming webhook signatures.


### PR DESCRIPTION
## Summary
- add explicit telemetry webhook routing and replay TTL constants
- stop returning blanket healthy component output and cache span-name regex compilation

Closes #976
Closes #977
Closes #978
Closes #979