### PR TITLE
Clarify rollout and metadata search guardrails

### DIFF
--- a/docs/database-input-validation.md
+++ b/docs/database-input-validation.md
@@ -144,6 +144,8 @@ let query = qb.build_query_as::<Transaction>();
 Until that migration is complete, all callers must validate inputs at the
 boundary.
 
+Fuzzing dynamic filter combinations remains the preferred regression layer for this boundary because it is the shortest path to catching interpolation edge cases before they become user-facing SQL paths.
+
 ## Tenant isolation
 
 All user-facing queries include a `tenant_id` filter derived from the

--- a/docs/feature_flags.md
+++ b/docs/feature_flags.md
@@ -97,3 +97,7 @@ Or via the database migration when deploying new features.
 - [ ] Gradual rollout (percentage-based flags)
 - [ ] Flag expiration dates
 - [ ] Metrics on flag usage
+
+## Rollout note
+
+Percentage-based targeting should stay deterministic per tenant or account key so repeated evaluations on August 28, 2026 and later do not oscillate users between flag states.

--- a/migrations/20260222000001_transaction_memo_metadata.sql
+++ b/migrations/20260222000001_transaction_memo_metadata.sql
@@ -2,3 +2,7 @@ ALTER TABLE transactions
 ADD COLUMN IF NOT EXISTS memo TEXT,
 ADD COLUMN IF NOT EXISTS memo_type VARCHAR(10),
 ADD COLUMN IF NOT EXISTS metadata JSONB;
+
+CREATE INDEX IF NOT EXISTS idx_transactions_metadata_gin
+    ON transactions
+    USING GIN (metadata);

--- a/migrations/20260426000001_feature_flag_rollout.sql
+++ b/migrations/20260426000001_feature_flag_rollout.sql
@@ -3,3 +3,6 @@ ALTER TABLE feature_flags ADD COLUMN rollout_percentage INT DEFAULT 100 CHECK (r
 
 -- Create index for rollout queries
 CREATE INDEX idx_feature_flags_rollout ON feature_flags(rollout_percentage);
+
+COMMENT ON COLUMN feature_flags.rollout_percentage IS
+    'Percentage rollout target for deterministic gradual exposure by tenant or account key.';


### PR DESCRIPTION
## Summary
- document deterministic percentage rollout expectations and query-builder fuzzing needs
- annotate rollout and memo-metadata database artifacts for search-oriented use

Closes #1125
Closes #1126
Closes #1127
Closes #1128