### PR TITLE
Tighten release and CI update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     pull-request-branch-name:
       separator: "/"
     rebase-strategy: "auto"
+    cooldown:
+      default-days: 3
     allow:
       - dependency-type: "direct"
       - dependency-type: "indirect"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,6 +55,8 @@ env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: sccache
   SCCACHE_CACHE_SIZE: 1G
+  LOAD_TEST_P95_THRESHOLD_MS: "500"
+  LOAD_TEST_ERROR_RATE_THRESHOLD_PERCENT: "5"
   # Regex used by cargo-llvm-cov to exclude generated/test files from coverage
   # reports. Pagination test helpers in tests/ are excluded here so that only
   # production pagination code (src/) counts toward the threshold.

--- a/tests/load/VALIDATION_README.md
+++ b/tests/load/VALIDATION_README.md
@@ -181,6 +181,8 @@ The validation tests parse k6 JSON output in the following format:
 
 ## Integration with CI/CD
 
+As of August 28, 2026, the preferred CI contract is to keep explicit pass/fail thresholds in workflow environment variables so regressions are reviewable at the workflow layer, not hidden only inside load-test fixtures.
+
 ### GitHub Actions Example
 
 ```yaml

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -20,6 +20,10 @@ pub struct ReleaseArgs {
     /// Remote to push the tag to.
     #[arg(long, default_value = "origin")]
     pub remote: String,
+
+    /// Skip pushing release artifacts after the local build completes.
+    #[arg(long)]
+    pub skip_push: bool,
 }
 
 pub fn run(args: ReleaseArgs) -> anyhow::Result<()> {
@@ -36,7 +40,7 @@ pub fn run(args: ReleaseArgs) -> anyhow::Result<()> {
     println!("\n-- Building release binary --");
     run_cmd("cargo", &["build", "--release"])?;
 
-    if !args.skip_tag {
+    if !args.skip_tag && !args.skip_push {
         create_and_push_tag(version, &args.remote)?;
     }
 


### PR DESCRIPTION
## Summary
- add explicit load regression threshold env vars to CI
- slow dependency automation churn and add a release skip-push toggle

Closes #1133
Closes #1134
Closes #1135
Closes #1136