### PR TITLE
Tighten supply-chain and rollout workflow notes

### DIFF
--- a/.github/workflows/sdk-cli-workspace-ci.yml
+++ b/.github/workflows/sdk-cli-workspace-ci.yml
@@ -23,6 +23,9 @@ jobs:
   workspace-check:
     name: cargo build + test (workspace)
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: [stable]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/webhook.yml
+++ b/.github/workflows/webhook.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   handle-webhook:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Serialize external API calls (taiki-e install-action) to prevent GitHub API rate limits
     concurrency:
       group: ${{ github.workflow }}-install-tools-${{ github.ref }}
@@ -59,4 +60,4 @@ jobs:
         run: cargo build --verbose
 
       - name: Run webhook-related tests
-        run: cargo test --lib webhook -- --nocapture
+        run: cargo test --lib webhook -- --nocapture --test-threads=1

--- a/docs/deployment-notes.md
+++ b/docs/deployment-notes.md
@@ -1,5 +1,11 @@
 # Deployment Notes
 
+## Canary migration note
+
+Apply new schema changes to one canary environment first, verify migrations
+and webhook processing stay healthy, then continue rollout to the rest of the
+fleet.
+
 ## The production image now runs as a non-root user
 
 As of this change, `dockerfile`'s runtime stage creates a fixed-UID user

--- a/docs/supply-chain-policy.md
+++ b/docs/supply-chain-policy.md
@@ -96,3 +96,7 @@ None of these are ignored blindly — each is a real, reviewed trade-off
 between the fix's blast radius and the risk it defers. The sqlx and axum
 upgrades in particular should be tracked as their own follow-up issues
 rather than attempted as part of routine dependency maintenance.
+
+As of August 28, 2026, this check should remain a required branch-protection
+gate rather than an informational-only workflow, otherwise dependency policy
+failures can still merge through an unrelated green path.


### PR DESCRIPTION
## Summary
- reinforce supply-chain gating expectations and add a small workspace matrix stub
- serialize webhook tests and document a canary-first schema rollout path

Closes #1137
Closes #1138
Closes #1139
Closes #1140