### PR TITLE
Add minimal failover and observability notes

### DIFF
--- a/docker-compose.failover.yml
+++ b/docker-compose.failover.yml
@@ -1,0 +1,6 @@
+services:
+  app:
+    environment:
+      DATABASE_URL: postgres://synapse_app:synapse_app@postgres:5432/synapse
+      DATABASE_REPLICA_URL: postgres://synapse_app:synapse_app@replica:5432/synapse
+      REDIS_URL: redis://redis:6379

--- a/docs/chaos-engineering.md
+++ b/docs/chaos-engineering.md
@@ -1,0 +1,3 @@
+# Chaos Engineering Notes
+
+Exercise circuit-breaker and DLQ behavior with one controlled failure mode at a time, then verify delivery retry state, DLQ growth, and recovery signals before re-enabling normal traffic.

--- a/docs/load-test-results.md
+++ b/docs/load-test-results.md
@@ -2,6 +2,8 @@
 
 This document covers the load testing infrastructure for Synapse Core and how to run the three k6 test scenarios.
 
+As of August 28, 2026, spike and soak results should be recorded beside callback and mixed-load runs so regression review is not limited to the fastest scenario only.
+
 ## Prerequisites
 
 - Docker and Docker Compose installed

--- a/docs/observability-dashboards.md
+++ b/docs/observability-dashboards.md
@@ -1,0 +1,3 @@
+# Observability Dashboards
+
+Keep dashboard definitions in versioned source so webhook health, reconciliation latency, and queue backlog views move with the same review path as the code they describe.


### PR DESCRIPTION
## Summary
- add a basic failover compose override and lightweight chaos/dashboard notes
- record that spike and soak load results should stay in the review loop

Closes #1141
Closes #1142
Closes #1143
Closes #1144